### PR TITLE
Improve database connection test

### DIFF
--- a/src/datasource.ts
+++ b/src/datasource.ts
@@ -101,6 +101,16 @@ export class KustoDBDatasource {
   }
 
   testDatasource() {
+    return this.testDatasourceConnection()
+      .then(() => this.testDatasourceAccess()
+        .catch(error => ({
+          status: 'error',
+          message: error.message + ' Connection to database could be established.',
+        }))
+      );
+  }
+
+  testDatasourceConnection() {
     const url = `${this.baseUrl}/v1/rest/mgmt`;
     const req = {
       csl: '.show databases',
@@ -130,6 +140,44 @@ export class KustoDBDatasource {
           message += error.data;
         } else {
           message += 'Cannot connect to the Azure Data Explorer REST API.';
+        }
+        return {
+          status: 'error',
+          message: message,
+        };
+      });
+  }
+
+  testDatasourceAccess() {
+    const url = `${this.baseUrl}/v1/rest/mgmt`;
+    const req = {
+      csl: '.show databases schema',
+    };
+    return this.doRequest(url, req)
+      .then(response => {
+        if (response.status === 200) {
+          return {
+            status: 'success',
+            message: 'Successfully queried the Azure Data Explorer database.',
+            title: 'Success',
+          };
+        }
+
+        return {
+          status: 'error',
+          message: 'Returned http status code ' + response.status,
+        };
+      })
+      .catch(error => {
+        let message = 'Azure Data Explorer: ';
+        message += error.statusText ? error.statusText + ': ' : '';
+
+        if (error.data && error.data.Message) {
+          message += error.data.Message;
+        } else if (error.data) {
+          message += error.data;
+        } else {
+          message += 'Cannot read database schema from Azure Data Explorer REST API.';
         }
         return {
           status: 'error',

--- a/src/datasource.ts
+++ b/src/datasource.ts
@@ -102,12 +102,13 @@ export class KustoDBDatasource {
 
   testDatasource() {
     return this.testDatasourceConnection()
-      .then(() => this.testDatasourceAccess()
-        .catch(error => ({
+      .then(() => this.testDatasourceAccess())
+      .catch(error => {
+        return {
           status: 'error',
-          message: error.message + ' Connection to database could be established.',
-        }))
-      );
+          message: error.message + ' Connection to database could not be established.',
+        };
+      });
   }
 
   testDatasourceConnection() {
@@ -169,13 +170,13 @@ export class KustoDBDatasource {
         };
       })
       .catch(error => {
-        let message = 'Azure Data Explorer: ';
+        let message = 'Azure Data Explorer: Cannot read database schema from REST API. ';
         message += error.statusText ? error.statusText + ': ' : '';
 
-        if (error.data && error.data.Message) {
-          message += error.data.Message;
+        if (error.data && error.data.error && error.data.error['@message']) {
+          message += error.data.error && error.data.error['@message'];
         } else if (error.data) {
-          message += error.data;
+          message += JSON.stringify(error.data);
         } else {
           message += 'Cannot read database schema from Azure Data Explorer REST API.';
         }


### PR DESCRIPTION
When using authorization via service principal which does not have
sufficient rights, it can happen that `.show databases` succeeds
and returns an empty list of rows:

```json
{
  "Tables": [
    {
      "TableName": "Table_0",
      "Columns": [
        {
          "ColumnName": "DatabaseName",
          "DataType": "String"
        },
        // ...
      ],
      "Rows": []
    }
  ]
}
```

However, `.show databases schema` returns a 403 error:

```
Forbidden: Caller is not authorized to perform this action
Principal 'aadapp=...' is not authorized to perform operation 'Access the Kusto service' on 'https://.../
```

This commit adds another Kusto call which runs exactly this query
when testing the database connection and gives appropriate feedback.

