### PR TITLE
Possible templateable solution for #33

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,29 @@ If you do not have a [Grafana Cloud](https://grafana.com/cloud) account, you can
 - [Installing on Windows](http://docs.grafana.org/installation/windows/)
 - [Installing on Mac](http://docs.grafana.org/installation/mac/)
 
+### Metric Naming & Aliasing
+
+Metrics are displayed using an "ALIAS BY" field displayed when in edit mode. The display uses the grafana templating system to address columns in the query, with one default.
+
+ * `$metricname`: By default, when no alias is present, the template $metricname is used. 
+
+#### Examples of metric naming
+Given a table with the following columns:
+1. **timestamp**: The time of the reading
+2. **metric**: The name of the metric recorded 
+3. **value**: The value of the metric recorded
+4. **state**: Boolean representation of an alarm state (1=in alarm state, 0=normal)
+5. **server**: The server name
+6. **importance**: The importance of the reading to operations (low|med|high)
+
+| Query | Template | Results |
+|-------|----------|---------|
+| `data | project metric, value, timestamp` | $metric | cpu_usage,mem_percent_used|
+| `data | project metric, value, timestamp, location` | \$metric.$location | cpu_usage.server1, mem_percent_used.server2 |
+| `data | project name=metric, val=value, time=timestamp` | $name | cpu_usage,mem_percent_used |
+| `data | project timestamp, metric, value, state` | \$metric.$value | cpu_usage.value, cpu_usage.state, mem_percent_used.value, mem_percent_used.state |
+| `data | project timestamp, metric, value, state, server, importance` | [$importance]: \$metric.\$server.\$value | [low]: cpu_usage.server1.value, [med]: cpu_usage.server1.state, [high]: mem_percent_used.server2.value, [high]: mem_percent_used.server2.state
+
 ### Docker
 
 1. Fetch the latest version of grafana from Docker Hub:

--- a/pkg/azuredx/table.go
+++ b/pkg/azuredx/table.go
@@ -280,7 +280,14 @@ func (r *rowLabels) GetName(colName string) string {
 	if len(r.keyVals) == 0 {
 		return colName
 	}
-	return fmt.Sprintf("%v {%v}", colName, r.str)
+
+	//var names []string
+	//for _, val := range r.keyVals {
+	//	names = append(names, val)
+	//}
+
+	return fmt.Sprintf("{ \"%v\": {%v} }", colName, r.str)
+	//return strings.Join(names, "|")
 }
 
 func labelMaker(columns []Column, row Row, labelColumnIdxs []int) (*rowLabels, error) {
@@ -294,7 +301,7 @@ func labelMaker(columns []Column, row Row, labelColumnIdxs []int) (*rowLabels, e
 			return nil, fmt.Errorf("failed to get string value for column %v", row[labelIdx])
 		}
 		colName := columns[labelIdx].ColumnName
-		if _, err := labelsSB.WriteString(fmt.Sprintf("%v=%v", colName, val)); err != nil {
+		if _, err := labelsSB.WriteString(fmt.Sprintf("\"%v\":\"%v\"", colName, val)); err != nil {
 			return nil, err
 		}
 		if len(labelColumnIdxs) > 1 && idx != len(labelColumnIdxs)-1 {

--- a/src/partials/query.editor.html
+++ b/src/partials/query.editor.html
@@ -26,6 +26,15 @@
 
   <div class="gf-form-inline">
     <div class="gf-form">
+      <label class="gf-form-label query-keyword">ALIAS BY</label>
+      <input
+        type="text"
+        class="gf-form-input"
+        ng-model="ctrl.target.alias"
+        spellcheck="false"
+        placeholder="Naming pattern"
+        ng-blur="ctrl.refresh()"
+      /> 
       <label class="gf-form-label query-keyword width-7">Format As</label>
       <div class="gf-form-select-wrapper">
         <select class="gf-form-input gf-size-auto" ng-model="ctrl.target.resultFormat" ng-options="f.value as f.text for f in ctrl.resultFormats"


### PR DESCRIPTION
This test version/possibility adds the following:

The tables columns are templates that can be used in the "Alias By" text box.

For example:
data | project timestamp, metric, value

If you alias this as:
$metric

You will get the metric name and only the metric name (the default as of v1.3

If you use:
$value {metric=$metric}

You will get the v2.0 behavior.

If you query other colums, you can use them directly:
data | time, geohash, speed, make, model

With an alias by:
$make.$model[$value]
Will give you metric names like this:
Toyota.Corolla[geohash]