### PR TITLE
Show Databases Fix for Kusto

### DIFF
--- a/pkg/azuredx/table.go
+++ b/pkg/azuredx/table.go
@@ -412,7 +412,7 @@ func extractValueForTable(v interface{}, typ string) (*datasource.RowValue, erro
 			return nil, fmt.Errorf("failed to marshal dynamic type into JSON string '%v': %v", v, err)
 		}
 		r.StringValue = string(b)
-	case kustoTypeString, kustoTypeGUID, kustoTypeTimespan, kustoTypeDatetime, "":
+	case kustoTypeString, kustoTypeGUID, kustoTypeTimespan, kustoTypeDatetime:
 		r.Kind = datasource.RowValue_TYPE_STRING
 		r.StringValue, ok = v.(string)
 		if !ok {

--- a/pkg/azuredx/table_test.go
+++ b/pkg/azuredx/table_test.go
@@ -166,6 +166,26 @@ func Test_extractValueForTable(t *testing.T) {
 			StringValue:  "00:00:00.0000001",
 		},
 		{
+			name:         "should handle empty string types (json float)",
+			args:         extractValueArgs{json.Number("3.14159265"), ""},
+			errorIs:      assert.NoError,
+			rowValKindIs: assert.Equal,
+			rowValKind:   datasource.RowValue_TYPE_DOUBLE,
+			rowValField:  "DoubleValue",
+			rowValIs:     assert.Equal,
+			DoubleValue:  3.14159265,
+		},
+		{
+			name:         "should handle empty string types (json int)",
+			args:         extractValueArgs{json.Number("314"), ""},
+			errorIs:      assert.NoError,
+			rowValKindIs: assert.Equal,
+			rowValKind:   datasource.RowValue_TYPE_INT64,
+			rowValField:  "Int64Val",
+			rowValIs:     assert.Equal,
+			Int64Val:     314,
+		},
+		{
 			name:         "null bool should be null", // all types should be except string, but only bool and string are tested
 			args:         extractValueArgs{nil, kustoTypeBool},
 			errorIs:      assert.NoError,
@@ -173,9 +193,11 @@ func Test_extractValueForTable(t *testing.T) {
 			rowValKind:   datasource.RowValue_TYPE_NULL,
 		},
 		{
-			name:    "null string should be error", // as per documentation, null strings are not supported by Kusto
-			args:    extractValueArgs{nil, kustoTypeString},
-			errorIs: assert.Error,
+			name:         "null string should be type null",
+			args:         extractValueArgs{nil, kustoTypeString},
+			errorIs:      assert.NoError,
+			rowValKindIs: assert.Equal,
+			rowValKind:   datasource.RowValue_TYPE_NULL,
 		},
 	}
 	for _, tt := range tests {


### PR DESCRIPTION
Show Databases returned different fields than other responses, plus some string fields that were null.

This potential fix does it's best to handle those responses.

It makes assumptions about datatypes returned. For example the column.DataType field seems to return a C# canonical datatype rather than a kusto data type. As a result, this version does it's best to translate them.