### PR TITLE
Changed default for metrics with only value, metric, timestamp

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,14 @@ If you do not have a [Grafana Cloud](https://grafana.com/cloud) account, you can
 
 Metrics are displayed using an "ALIAS BY" field displayed when in edit mode. The display uses the grafana templating system to address columns in the query, with one default.
 
- * `$metricname`: By default, when no alias is present, the template $metricname is used. 
+#### Defaults
+When specifying no alias, the following defaults will be taken into account
+1. When querying a simple timestamp, value, and metric, only the metric will be displayed. (`metric`)
+2. When querying a timestamp, metric, and multiple values, the metric name plus names of other columns will be displayed with periods.
+   - Examples
+     - `metric1.value1, metric2.value1, metric2.value2`
+     - `metric1.column1.value1, metric3.column2.value1`
+3. Use the `$full` alias to specify JSON like formattting of the alias. (`value2: {metric:metric1,column:column2}`)
 
 #### Examples of metric naming
 Given a table with the following columns:
@@ -42,11 +49,11 @@ Given a table with the following columns:
 
 | Query | Template | Results |
 |-------|----------|---------|
-| `data | project metric, value, timestamp` | $metric | cpu_usage,mem_percent_used|
-| `data | project metric, value, timestamp, location` | \$metric.$location | cpu_usage.server1, mem_percent_used.server2 |
-| `data | project name=metric, val=value, time=timestamp` | $name | cpu_usage,mem_percent_used |
-| `data | project timestamp, metric, value, state` | \$metric.$value | cpu_usage.value, cpu_usage.state, mem_percent_used.value, mem_percent_used.state |
-| `data | project timestamp, metric, value, state, server, importance` | [$importance]: \$metric.\$server.\$value | [low]: cpu_usage.server1.value, [med]: cpu_usage.server1.state, [high]: mem_percent_used.server2.value, [high]: mem_percent_used.server2.state
+| `data \| project metric, value, timestamp` | $metric | cpu_usage,mem_percent_used|
+| `data \| project metric, value, timestamp, location` | \$metric.$location | cpu_usage.server1, mem_percent_used.server2 |
+| `data \| project name=metric, val=value, time=timestamp` | $name | cpu_usage,mem_percent_used |
+| `data \| project timestamp, metric, value, state` | \$metric.$value | cpu_usage.value, cpu_usage.state, mem_percent_used.value, mem_percent_used.state |
+| `data \| project timestamp, metric, value, state, server, importance` | [$importance]: \$metric.\$server.\$value | [low]: cpu_usage.server1.value, [med]: cpu_usage.server1.state, [high]: mem_percent_used.server2.value, [high]: mem_percent_used.server2.state
 
 ### Docker
 

--- a/src/datasource.ts
+++ b/src/datasource.ts
@@ -72,19 +72,24 @@ export class KustoDBDatasource {
           // Table format does not use aliases yet. The user could
           // control the table format using aliases in the query itself
           // ex: data | project NewColumnName=ColumnName
-          if (query.resultFormat === "time_series") {
+          if (query.resultFormat === 'time_series') {
             let alias = query.alias;
             try {
               let key = Object.keys(r.target)[0];
               let meta = r.target[key];
-              let full = JSON.stringify(r.target).replace(/"/g,'').replace(/^\{(.*?)\}$/,'$1');
+              let full = JSON.stringify(r.target)
+                .replace(/"/g, '')
+                .replace(/^\{(.*?)\}$/, '$1');
               // Generating a default time series metric name requires both the metricname
               // and the value, but only if multiple values were requested.
               // By default, and for backwards compatibility, if there is only one metric
               // in the alias values, use that one.
               let defaultAlias = meta[Object.keys(meta)[0]];
-              if (typeof ret.valueCount !== "undefined" && ret.valueCount > 1) {
-                defaultAlias = Object.keys(meta).map(key => '$' + key).join('.') + '.$value';
+              if (typeof ret.valueCount !== 'undefined' && ret.valueCount > 1) {
+                defaultAlias =
+                  Object.keys(meta)
+                    .map(key => '$' + key)
+                    .join('.') + '.$value';
               }
               templateVars['value'] = { text: key, value: key };
               templateVars['full'] = { text: full, value: full };
@@ -96,7 +101,7 @@ export class KustoDBDatasource {
               }
               r.target = this.templateSrv.replace(alias, templateVars);
             } catch (ex) {
-              console.log("Error generating time series alias", ex);
+              console.log('Error generating time series alias', ex);
             }
           }
         });

--- a/src/response_parser.ts
+++ b/src/response_parser.ts
@@ -299,13 +299,20 @@ export class ResponseParser {
       return { data: data };
     }
 
+    let valueMap = {};
+
     for (const key in res.data.results) {
       const queryRes = res.data.results[key];
 
       if (queryRes.series) {
         for (const series of queryRes.series) {
+          let target = JSON.parse(series.name);
+          let val = Object.keys(target)[0];
+          // We are just counting the unique values in this response
+          // so that later we can use it to determine the best alias name
+          valueMap[val] = 0;
           data.push({
-            target: series.name,
+            target,
             datapoints: series.points,
             refId: queryRes.refId,
             meta: queryRes.meta,
@@ -323,6 +330,9 @@ export class ResponseParser {
       }
     }
 
-    return { data: data };
+    return {
+      data: data,
+      valueCount: Object.keys(valueMap).length,
+    };
   }
 }


### PR DESCRIPTION
Changing the default to be backwards compatible with the 1.3 version of the datasource to promote maximum backwards compatibility.