### PR TITLE
Small fixes

### DIFF
--- a/src/components/VisualQueryEditor.tsx
+++ b/src/components/VisualQueryEditor.tsx
@@ -21,7 +21,6 @@ import { isFieldExpression } from '../editor/guards';
 import { AdxDataSource } from '../datasource';
 import { AdxSchemaResolver } from '../schema/AdxSchemaResolver';
 import { QueryEditorResultFormat, selectResultFormat } from '../components/QueryEditorResultFormat';
-import { KustoExpressionParser } from '../KustoExpressionParser';
 import { TextArea, stylesFactory } from '@grafana/ui';
 import { SelectableValue } from '@grafana/data';
 import { AdxAutoComplete } from '../schema/AdxAutoComplete';
@@ -36,8 +35,6 @@ interface Props {
   datasource: AdxDataSource;
   templateVariableOptions: SelectableValue<string>;
 }
-
-const kustoExpressionParser = new KustoExpressionParser();
 
 export const VisualQueryEditor: React.FC<Props> = props => {
   const { query, database, datasource, schema } = props;
@@ -58,7 +55,7 @@ export const VisualQueryEditor: React.FC<Props> = props => {
 
     props.onChangeQuery({
       ...props.query,
-      query: kustoExpressionParser.query(
+      query: datasource.parseExpression(
         {
           ...props.query.expression,
           from,
@@ -116,7 +113,7 @@ export const VisualQueryEditor: React.FC<Props> = props => {
         resultFormat: resultFormat,
         database: database,
         expression: next,
-        query: kustoExpressionParser.query(next, tableSchema.value),
+        query: datasource.parseExpression(next, tableSchema.value),
       });
     },
     [props.onChangeQuery, props.query, tableSchema.value, resultFormat, database, table]
@@ -135,7 +132,7 @@ export const VisualQueryEditor: React.FC<Props> = props => {
         resultFormat: resultFormat,
         database: database,
         expression: next,
-        query: kustoExpressionParser.query(next, tableSchema.value),
+        query: datasource.parseExpression(next, tableSchema.value),
       });
     },
     [props.onChangeQuery, props.query, tableSchema.value, resultFormat, database, table]
@@ -154,7 +151,7 @@ export const VisualQueryEditor: React.FC<Props> = props => {
         resultFormat: resultFormat,
         database: database,
         expression: next,
-        query: kustoExpressionParser.query(next, tableSchema.value),
+        query: datasource.parseExpression(next, tableSchema.value),
       });
     },
     [props.onChangeQuery, props.query, tableSchema.value, resultFormat, database, table]

--- a/src/components/VisualQueryEditorSections.tsx
+++ b/src/components/VisualQueryEditorSections.tsx
@@ -63,6 +63,7 @@ export const KustoWhereEditorSection = buildFilterQueryEditorSection(filterSecti
       operator('in~')
         .supportTypes([QueryEditorPropertyType.String, QueryEditorPropertyType.Number])
         .withDescription('in (case-insensitive)')
+        .multipleValues(true)
         .add();
 
       operator('!in')

--- a/src/datasource.ts
+++ b/src/datasource.ts
@@ -13,12 +13,13 @@ import {
 import { map } from 'lodash';
 import { getBackendSrv, BackendSrv, getTemplateSrv, TemplateSrv, DataSourceWithBackend } from '@grafana/runtime';
 import { ResponseParser, DatabaseItem } from './response_parser';
-import { AdxDataSourceOptions, KustoQuery, AdxSchema, AdxColumnSchema, defaultQuery } from './types';
+import { AdxDataSourceOptions, KustoQuery, AdxSchema, AdxColumnSchema, defaultQuery, QueryExpression } from './types';
 import { getAnnotationsFromFrame } from './common/annotationsFromFrame';
 import interpolateKustoQuery from './query_builder';
 import { firstStringFieldToMetricFindValue } from 'common/responseHelpers';
 import { QueryEditorPropertyExpression } from 'editor/expressions';
 import { cache } from 'schema/cache';
+import { KustoExpressionParser } from 'KustoExpressionParser';
 
 export class AdxDataSource extends DataSourceWithBackend<KustoQuery, AdxDataSourceOptions> {
   private backendSrv: BackendSrv;
@@ -26,6 +27,7 @@ export class AdxDataSource extends DataSourceWithBackend<KustoQuery, AdxDataSour
   private baseUrl: string;
   private defaultOrFirstDatabase: string;
   private url?: string;
+  private expressionParser: KustoExpressionParser;
 
   constructor(instanceSettings: DataSourceInstanceSettings<AdxDataSourceOptions>) {
     super(instanceSettings);
@@ -35,6 +37,7 @@ export class AdxDataSource extends DataSourceWithBackend<KustoQuery, AdxDataSour
     this.baseUrl = '/azuredataexplorer';
     this.defaultOrFirstDatabase = instanceSettings.jsonData.defaultDatabase;
     this.url = instanceSettings.url;
+    this.expressionParser = new KustoExpressionParser(instanceSettings.jsonData.defaultTakeLimit ?? 10000);
   }
 
   /**
@@ -270,6 +273,10 @@ export class AdxDataSource extends DataSourceWithBackend<KustoQuery, AdxDataSour
       return "'" + val + "'";
     });
     return quotedValues.filter(v => v !== "''").join(',');
+  }
+
+  parseExpression(sections: QueryExpression | undefined, columns: AdxColumnSchema[] | undefined): string {
+    return this.expressionParser.query(sections, columns);
   }
 }
 

--- a/src/partials/config.html
+++ b/src/partials/config.html
@@ -108,7 +108,7 @@
       <span class="gf-form-label width-11">Default take limit</span>
       <input type="number" min="1" class="gf-form-input width-9" ng-model="ctrl.current.jsonData.defaultTakeLimit" spellcheck="false" placeholder="10000"></input>
       <info-popover mode="right-absolute">
-        The default row limit is 10 000. If you need a greater or lower default, enter the required value.
+        The default take limit is 10 000. If you need a greater or lower default, enter the required value.
       </info-popover>
     </div>
   </div>

--- a/src/partials/config.html
+++ b/src/partials/config.html
@@ -105,7 +105,7 @@
   </div>
   <div class="gf-form-inline">
     <div class="gf-form">
-      <span class="gf-form-label width-11">Default row limit</span>
+      <span class="gf-form-label width-11">Default take limit</span>
       <input type="number" min="1" class="gf-form-input width-9" ng-model="ctrl.current.jsonData.defaultTakeLimit" spellcheck="false" placeholder="10000"></input>
       <info-popover mode="right-absolute">
         The default row limit is 10 000. If you need a greater or lower default, enter the required value.

--- a/src/partials/config.html
+++ b/src/partials/config.html
@@ -103,6 +103,15 @@
       </info-popover>
     </div>
   </div>
+  <div class="gf-form-inline">
+    <div class="gf-form">
+      <span class="gf-form-label width-11">Default row limit</span>
+      <input type="number" min="1" class="gf-form-input width-9" ng-model="ctrl.current.jsonData.defaultTakeLimit" spellcheck="false" placeholder="10000"></input>
+      <info-popover mode="right-absolute">
+        The default row limit is 10 000. If you need a greater or lower default, enter the required value.
+      </info-popover>
+    </div>
+  </div>
 </div>
 
 <div class="gf-form-group" ng-if="ctrl.showMinVersionWarning()">

--- a/src/types.ts
+++ b/src/types.ts
@@ -49,6 +49,7 @@ export const defaultQuery: Pick<KustoQuery, 'query' | 'expression' | 'querySourc
 export interface AdxDataSourceOptions extends DataSourceJsonData {
   defaultDatabase: string;
   minimalCache: number;
+  defaultTakeLimit: number;
 }
 
 export interface AdxSchema {


### PR DESCRIPTION
This PR addresses the following:
- Where statement - ~in should have a multiselect as input type.
- Introduce a "max number of returned values" setting for the datasource. Currently it is fixed to 10 000 which seems to be too low in some scenarios.

Before moving on, I'd like feedback on moving the KustoExpressionParser to the datasource :)