### PR TITLE
DatasourceSettings: Adds default editor mode

### DIFF
--- a/src/components/QueryEditorToolbar.tsx
+++ b/src/components/QueryEditorToolbar.tsx
@@ -3,8 +3,7 @@ import { css } from 'emotion';
 import { Select, Button, stylesFactory, ConfirmModal } from '@grafana/ui';
 import { SelectableValue } from '@grafana/data';
 import { QueryEditorSection } from '../editor/components/QueryEditorSection';
-
-type EditorMode = 'raw' | 'visual';
+import { EditorMode } from 'types';
 
 interface Props {
   database: string;
@@ -42,7 +41,7 @@ export const QueryEditorToolbar: React.FC<Props> = props => {
           props.onChangeDatabase(selected.value);
         }}
       />
-      {props.editorMode === 'raw' && (
+      {props.editorMode === EditorMode.Raw && (
         <>
           <div className={styles.spacing} />
           <label className="gf-form-label">(Run Query: Shift+Enter, Trigger Suggestion: Ctrl+Space)</label>
@@ -52,7 +51,7 @@ export const QueryEditorToolbar: React.FC<Props> = props => {
         <div className="gf-form-label--grow" />
       </div>
       <Button variant="secondary" onClick={onToggleMode}>
-        {props.editorMode === 'visual' ? 'Edit KQL' : 'Switch to builder'}
+        {props.editorMode === EditorMode.Visual ? 'Edit KQL' : 'Switch to builder'}
       </Button>
       <div className={styles.spacing} />
       <Button variant={props.dirty ? 'primary' : 'secondary'} onClick={props.onRunQuery}>

--- a/src/config_ctrl.ts
+++ b/src/config_ctrl.ts
@@ -1,6 +1,7 @@
 import { AdxDataSource } from './datasource';
 import config from 'grafana/app/core/config';
 import { isVersionGtOrEq } from './version';
+import { EditorMode } from './types';
 
 export class KustoDBConfigCtrl {
   static templateUrl = 'partials/config.html';
@@ -11,6 +12,7 @@ export class KustoDBConfigCtrl {
   databases: any[];
   hasRequiredGrafanaVersion: boolean;
   loading = false;
+  editorModes: Array<{ value: string; label: string }>;
 
   /** @ngInject */
   constructor(private $scope) {
@@ -25,6 +27,14 @@ export class KustoDBConfigCtrl {
       this.current.url = 'api/datasources/proxy/' + this.current.id;
       this.datasource = new AdxDataSource(this.current);
       this.getDatabases();
+    }
+
+    this.editorModes = Object.keys(EditorMode)
+      .filter(key => isNaN(parseInt(key, 10)))
+      .map(key => ({ value: EditorMode[key], label: key }));
+
+    if (!this.current.jsonData?.defaultEditorMode) {
+      this.current.jsonData.defaultEditorMode = this.editorModes[0].value;
     }
   }
 

--- a/src/datasource.test.ts
+++ b/src/datasource.test.ts
@@ -3,6 +3,7 @@ import { dateTime } from '@grafana/data';
 import { TemplateSrv } from './test/template_srv';
 import _ from 'lodash';
 import { setBackendSrv, BackendSrv, BackendSrvRequest, setTemplateSrv } from '@grafana/runtime';
+import { EditorMode } from 'types';
 
 describe('AdxDataSource', () => {
   const ctx: any = {};
@@ -300,6 +301,34 @@ describe('AdxDataSource', () => {
         }
       );
       expect(result.data[0].target).toEqual('y');
+    });
+  });
+});
+
+describe('AdxDataSource', () => {
+  describe('when constructing with defaultEditorMode', () => {
+    it('then defaultEditorMode should be correct', () => {
+      const instanceSettings: any = {
+        jsonData: {
+          defaultEditorMode: EditorMode.Raw,
+        },
+      };
+
+      const datasource = new AdxDataSource(instanceSettings);
+
+      expect(datasource.getDefaultEditorMode()).toEqual(EditorMode.Raw);
+    });
+  });
+
+  describe('when constructing without defaultEditorMode', () => {
+    it('then defaultEditorMode should be Visual', () => {
+      const instanceSettings: any = {
+        jsonData: {},
+      };
+
+      const datasource = new AdxDataSource(instanceSettings);
+
+      expect(datasource.getDefaultEditorMode()).toEqual(EditorMode.Visual);
     });
   });
 });

--- a/src/datasource.ts
+++ b/src/datasource.ts
@@ -13,7 +13,15 @@ import {
 import { map } from 'lodash';
 import { getBackendSrv, BackendSrv, getTemplateSrv, TemplateSrv, DataSourceWithBackend } from '@grafana/runtime';
 import { ResponseParser, DatabaseItem } from './response_parser';
-import { AdxDataSourceOptions, KustoQuery, AdxSchema, AdxColumnSchema, defaultQuery, QueryExpression } from './types';
+import {
+  AdxDataSourceOptions,
+  KustoQuery,
+  AdxSchema,
+  AdxColumnSchema,
+  defaultQuery,
+  QueryExpression,
+  EditorMode,
+} from './types';
 import { getAnnotationsFromFrame } from './common/annotationsFromFrame';
 import interpolateKustoQuery from './query_builder';
 import { firstStringFieldToMetricFindValue } from 'common/responseHelpers';
@@ -28,6 +36,7 @@ export class AdxDataSource extends DataSourceWithBackend<KustoQuery, AdxDataSour
   private defaultOrFirstDatabase: string;
   private url?: string;
   private expressionParser: KustoExpressionParser;
+  private defaultEditorMode: EditorMode;
 
   constructor(instanceSettings: DataSourceInstanceSettings<AdxDataSourceOptions>) {
     super(instanceSettings);
@@ -38,6 +47,7 @@ export class AdxDataSource extends DataSourceWithBackend<KustoQuery, AdxDataSour
     this.defaultOrFirstDatabase = instanceSettings.jsonData.defaultDatabase;
     this.url = instanceSettings.url;
     this.expressionParser = new KustoExpressionParser(instanceSettings.jsonData.defaultTakeLimit ?? 10000);
+    this.defaultEditorMode = instanceSettings.jsonData.defaultEditorMode ?? EditorMode.Visual;
   }
 
   /**
@@ -277,6 +287,10 @@ export class AdxDataSource extends DataSourceWithBackend<KustoQuery, AdxDataSour
 
   parseExpression(sections: QueryExpression | undefined, columns: AdxColumnSchema[] | undefined): string {
     return this.expressionParser.query(sections, columns);
+  }
+
+  getDefaultEditorMode(): EditorMode {
+    return this.defaultEditorMode;
   }
 }
 

--- a/src/partials/config.html
+++ b/src/partials/config.html
@@ -115,7 +115,9 @@
   <div class="gf-form-inline">
     <div class="gf-form">
       <span class="gf-form-label width-11">Data concistency</span>
-      <select class="gf-form-input" ng-model="ctrl.current.jsonData.dataConsistency" ng-options="d.value as d.label for d in ctrl.dataConsistency"></select>
+      <div class="gf-form-select-wrapper gf-form-select-wrapper--caret-indent">
+        <select class="gf-form-input" ng-model="ctrl.current.jsonData.dataConsistency" ng-options="d.value as d.label for d in ctrl.dataConsistency"></select>
+      </div>
       <info-popover mode="right-normal">
         By default the data consistency is strong. If you want to query your data with an other cosistency, choose the desired value.
       </info-popover>

--- a/src/partials/config.html
+++ b/src/partials/config.html
@@ -112,6 +112,17 @@
       </info-popover>
     </div>
   </div>
+  <div class="gf-form-inline">
+    <div class="gf-form">
+      <span class="gf-form-label width-11">Default editor mode</span>
+      <div class="gf-form-select-wrapper gf-form-select-wrapper--caret-indent">
+        <select class="gf-form-input" ng-model="ctrl.current.jsonData.defaultEditorMode" ng-options="mode.value as mode.label for mode in ctrl.editorModes"></select>
+      </div>
+      <info-popover mode="right-normal">
+        The default editor mode is Visual. If you need to change the default editor mode choose the desired value.
+      </info-popover>
+    </div>
+  </div>
 </div>
 
 <div class="gf-form-group" ng-if="ctrl.showMinVersionWarning()">

--- a/src/types.ts
+++ b/src/types.ts
@@ -26,9 +26,14 @@ export interface KustoQuery extends DataQuery {
   pluginVersion: string;
 }
 
+export enum EditorMode {
+  Visual = 'visual',
+  Raw = 'raw',
+}
+
 export const defaultQuery: Pick<KustoQuery, 'query' | 'expression' | 'querySource' | 'pluginVersion'> = {
   query: '',
-  querySource: 'raw',
+  querySource: EditorMode.Raw,
   expression: {
     where: {
       type: QueryEditorExpressionType.And,
@@ -50,6 +55,7 @@ export interface AdxDataSourceOptions extends DataSourceJsonData {
   defaultDatabase: string;
   minimalCache: number;
   defaultTakeLimit: number;
+  defaultEditorMode: EditorMode;
 }
 
 export interface AdxSchema {


### PR DESCRIPTION
Adds a new setting to the data source config page:
![image](https://user-images.githubusercontent.com/562238/93216953-a7acca80-f768-11ea-9044-8e89471f05c9.png)

Introduced `EditorMode` enum and refactored some magic strings so please check they're ok :)