### PR TITLE
alerting: Add fromAlerting to identify queries form alerting

### DIFF
--- a/pkg/datasource.go
+++ b/pkg/datasource.go
@@ -134,10 +134,8 @@ func (plugin *GrafanaAzureDXDatasource) QueryData(ctx context.Context, req *back
 	res := backend.NewQueryDataResponse()
 
 	var fromAlert bool
-	if req.Headers != nil {
-		if req.Headers["FromAlert"] == "true" {
-			fromAlert = true
-		}
+	if req.Headers != nil && req.Headers["FromAlert"] == "true" {
+		fromAlert = true
 	}
 
 	backend.Logger.Debug("Query", "datasource", req.PluginContext.DataSourceInstanceSettings.Name, "fromAlert", fromAlert)


### PR DESCRIPTION
depends on grafana/grafana#27599 (Edit: Now merged into master, should be in next 7.2 beta)

will be used so the macros will not be expanded in "optimized query" style for alerts

cc @mckn 

Creating as draft since it isn't used yet + the dependency is not merged yet. Once merged, for pre 7.2 versions of Grafana, this will always be false.