### PR TITLE
Mention Grafana version dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@
 
 ## Installation
 
-This plugin requires Grafana 6.3.6 or newer.
+This plugin requires Grafana 7.1.0 or newer as of version 3.0.0. Plugin versions prior to 3.0.0 require Grafana 6.3.6.
 
 ## Grafana Cloud
 


### PR DESCRIPTION
Explicitly mention Grafana version requirements in the repository's README - intended to resolve #171 (or at least preempt similar confusion). 