### PR TITLE
Query: adding datasource settings for query timeout.

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/grafana/azure-data-explorer-datasource
 go 1.14
 
 require (
+	github.com/davecgh/go-spew v1.1.1
 	github.com/google/go-cmp v0.4.0
 	github.com/google/uuid v1.1.1
 	github.com/grafana/grafana-plugin-sdk-go v0.75.0

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,6 @@ module github.com/grafana/azure-data-explorer-datasource
 go 1.14
 
 require (
-	github.com/davecgh/go-spew v1.1.1
 	github.com/google/go-cmp v0.4.0
 	github.com/google/uuid v1.1.1
 	github.com/grafana/grafana-plugin-sdk-go v0.75.0

--- a/pkg/azuredx/azuredx.go
+++ b/pkg/azuredx/azuredx.go
@@ -66,14 +66,15 @@ type Client struct {
 	Log hclog.Logger
 }
 
-// Options that can be set on the ADX Connection string
+// options are properties that can be set on the ADX Connection string.
+// https://docs.microsoft.com/en-us/azure/data-explorer/kusto/api/netfx/request-properties
 type options struct {
 	DataConsistency string `json:"queryconsistency,omitempty"`
 	CacheMaxAge     string `json:"query_results_cache_max_age,omitempty"`
 	ServerTimeout   string `json:"servertimeout,omitempty"`
 }
 
-// Properties property bag of connection string options
+// Properties is a property bag of connection string options.
 type Properties struct {
 	Options *options `json:"options,omitempty"`
 }
@@ -88,6 +89,7 @@ type RequestPayload struct {
 // newDataSourceData creates a dataSourceData from the plugin API's DatasourceInfo's
 // JSONData and Encrypted JSONData which contains the information needed to connected to
 // the datasource.
+// It also sets the QueryTimeout and ServerTimeoutValues by parsing QueryTimeoutRaw.
 func newDataSourceData(dInfo *backend.DataSourceInstanceSettings) (*dataSourceData, error) {
 	d := dataSourceData{}
 	err := json.Unmarshal(dInfo.JSONData, &d)

--- a/pkg/azuredx/azuredx.go
+++ b/pkg/azuredx/azuredx.go
@@ -159,6 +159,8 @@ func NewClient(ctx context.Context, dInfo *backend.DataSourceInstanceSettings) (
 		// for queries. The server execution timeout does not apply to retrieving data, so when
 		// a query returns a large amount of data, timeouts will still occur while the data is
 		// being downloaded.
+		// In the future, if we get the timeout value from Grafana's data source proxy setting, we
+		// may have to flip this to subtract time.
 		Timeout: c.dataSourceData.QueryTimeout + 5*time.Second,
 	}
 

--- a/pkg/azuredx/azuredx.go
+++ b/pkg/azuredx/azuredx.go
@@ -168,11 +168,15 @@ func NewClient(ctx context.Context, dInfo *backend.DataSourceInstanceSettings) (
 }
 
 // formatTimeout creates some sort of MS TimeSpan string for durations
-// that under an hour. It is used for the servertimeout request property
+// that up to an hour. It is used for the servertimeout request property
 // option.
+// https://docs.microsoft.com/en-us/azure/data-explorer/kusto/concepts/querylimits#limit-execution-timeout
 func formatTimeout(d time.Duration) (string, error) {
-	if d >= 3600*time.Second {
-		return "", fmt.Errorf("timeout should be less than 1 hour")
+	if d > time.Hour {
+		return "", fmt.Errorf("timeout must be one hour or less")
+	}
+	if d == time.Hour {
+		return "01:00:00", nil
 	}
 	if d < time.Minute {
 		return fmt.Sprintf("00:00:%02.0f", d.Seconds()), nil

--- a/src/partials/config.html
+++ b/src/partials/config.html
@@ -100,6 +100,15 @@
 <div class ="gf-form-group">
   <div class="gf-form-inline">
     <div class="gf-form">
+      <span class="gf-form-label width-11">Query timeout</span>
+      <input class="gf-form-input width-9" type="text" spellcheck="false" ng-model='ctrl.current.jsonData.queryTimeout' placeholder="30s" ng-pattern="/^(\d{1,3}(\.\d{0,2})?(d|m|s|h|ms))$/"></input>
+      <info-popover mode="right-absolute">
+        This value controls the client query timeout.
+      </info-popover>
+    </div>
+  </div>
+  <div class="gf-form-inline">
+    <div class="gf-form">
       <gf-form-switch label="Use dynamic caching" checked="ctrl.current.jsonData.dynamicCaching" label-class="width-11">
       </gf-form-switch>
       <info-popover mode="right-normal">

--- a/src/partials/config.html
+++ b/src/partials/config.html
@@ -88,7 +88,7 @@
   <div class="gf-form-inline">
     <div class="gf-form">
       <span class="gf-form-label width-11">Query timeout</span>
-      <input class="gf-form-input width-9" type="text" spellcheck="false" ng-model='ctrl.current.jsonData.queryTimeout' placeholder="30s" ng-pattern="/^(\d{1,3}(\.\d{0,2})?(d|m|s|h|ms))$/"></input>
+      <input class="gf-form-input width-9" type="text" spellcheck="false" ng-model='ctrl.current.jsonData.queryTimeout' placeholder="30s" ng-pattern="/(^[1-5][0-9]?[sm]$)|(^60[sm]$)|(^1h$)/"></input>
       <info-popover mode="right-absolute">
         This value controls the client query timeout.
       </info-popover>

--- a/src/types.ts
+++ b/src/types.ts
@@ -64,6 +64,7 @@ export interface AdxDataSourceOptions extends DataSourceJsonData {
   defaultDatabase: string;
   minimalCache: number;
   defaultEditorMode: EditorMode;
+  queryTimeout: number;
 }
 
 export interface AdxSchema {

--- a/src/types.ts
+++ b/src/types.ts
@@ -64,7 +64,7 @@ export interface AdxDataSourceOptions extends DataSourceJsonData {
   defaultDatabase: string;
   minimalCache: number;
   defaultEditorMode: EditorMode;
-  queryTimeout: number;
+  queryTimeout: string;
 }
 
 export interface AdxSchema {


### PR DESCRIPTION
For https://github.com/grafana/azure-data-explorer-datasource/issues/183

- Add data source setting queryTimeout, default is 30 seconds
- Set API client timeout to queryTimeout+5 seconds
- Set server execution timeout via connection property object to queryTimeout

Based on my (Kyle) testing:
 - If you make a CPU expensive query, you get a "Watchdog" error from Azure
 - If you make a quick query that returns a lot of data, you may hit our client timeout while receiving the data
 - Query that do not hit the timeout continue to work normally.

I think the client for auth may still have no timeout.