### PR TITLE
Bugfix: Fix query variables 

### DIFF
--- a/src/QueryEditor.tsx
+++ b/src/QueryEditor.tsx
@@ -140,6 +140,8 @@ const useSelectedDatabase = (
   query: KustoQuery,
   datasource: AdxDataSource
 ): string => {
+  const variables = datasource.getVariables();
+
   return useMemo(() => {
     const selected = options.find(option => option.value === query.database);
 
@@ -147,7 +149,7 @@ const useSelectedDatabase = (
       return selected.value;
     }
 
-    const variable = datasource.variables.find(variable => variable === query.database);
+    const variable = variables.find(variable => variable === query.database);
 
     if (variable) {
       return variable;
@@ -158,7 +160,7 @@ const useSelectedDatabase = (
     }
 
     return '';
-  }, [options, query.database, datasource.variables]);
+  }, [options, variables, query.database]);
 };
 
 const useDatabaseOptions = (schema?: AdxSchema): QueryEditorPropertyDefinition[] => {
@@ -207,7 +209,8 @@ const useExecutedQueryError = (data?: PanelData): string | undefined => {
 };
 
 const useTemplateVariables = (datasource: AdxDataSource) => {
-  const { variables } = datasource;
+  const variables = datasource.getVariables();
+
   return useMemo(() => {
     return {
       label: 'Template Variables',

--- a/src/components/VisualQueryEditor.tsx
+++ b/src/components/VisualQueryEditor.tsx
@@ -339,7 +339,8 @@ const useSelectedTable = (
   query: KustoQuery,
   datasource: AdxDataSource
 ): QueryEditorPropertyExpression | undefined => {
-  const variables = datasource.variables;
+  const variables = datasource.getVariables();
+
   const from = query.expression?.from?.property.name;
 
   return useMemo(() => {

--- a/src/datasource.ts
+++ b/src/datasource.ts
@@ -259,7 +259,7 @@ export class AdxDataSource extends DataSourceWithBackend<KustoQuery, AdxDataSour
     return dynamicSchemaParser(response.data as DataFrame[]);
   }
 
-  get variables() {
+  getVariables() {
     return this.templateSrv.getVariables().map(v => `$${v.name}`);
   }
 


### PR DESCRIPTION
The `variables` member on the datasource class was conflicting with Grafana internals, causing query variables to not work.

This just renames the member to be a normal function and updates references.

It works again: !!!

![image](https://user-images.githubusercontent.com/46142/104909187-6844f380-597f-11eb-9857-a44d4f144859.png)
