### PR TITLE
Fix Monaco not loading when Grafana is served from sub path

### DIFF
--- a/src/components/RawQueryEditor.tsx
+++ b/src/components/RawQueryEditor.tsx
@@ -7,6 +7,8 @@ import { QueryEditorProps, SelectableValue } from '@grafana/data';
 import { KustoMonacoEditor } from '../monaco/KustoMonacoEditor';
 import { QueryEditorResultFormat, selectResultFormat } from 'components/QueryEditorResultFormat';
 
+import config from 'grafana/app/core/config';
+
 type Props = QueryEditorProps<AdxDataSource, KustoQuery, AdxDataSourceOptions>;
 
 interface RawQueryEditorProps extends Props {
@@ -57,6 +59,7 @@ export class RawQueryEditor extends PureComponent<RawQueryEditorProps, State> {
     const { query, datasource, lastQueryError, lastQuery, timeNotASC, schema } = this.props;
     const { showLastQuery, showHelp } = this.state;
     const resultFormat = selectResultFormat(query.resultFormat, true);
+    const baseUrl = `${config.appSubUrl}/${datasource.meta.baseUrl}`;
 
     const styles = getStyles();
 
@@ -68,7 +71,7 @@ export class RawQueryEditor extends PureComponent<RawQueryEditorProps, State> {
       <div>
         <KustoMonacoEditor
           defaultTimeField="Timestamp"
-          pluginBaseUrl={datasource.meta.baseUrl}
+          pluginBaseUrl={baseUrl}
           content={query.query || defaultQuery}
           getSchema={async () => schema}
           onChange={this.onRawQueryChange}

--- a/src/monaco/KustoMonacoEditor.tsx
+++ b/src/monaco/KustoMonacoEditor.tsx
@@ -37,7 +37,8 @@ export class KustoMonacoEditor extends React.Component<Props, MonacoState> {
     };
 
     if (!window.hasOwnProperty('monaco')) {
-      (window as any).System.import(`/${props.pluginBaseUrl}/libs/monaco.min.js`).then(() => {
+      // using the standard import() here causes issues with webpack/babel/typescript because monaco is just so large
+      (window as any).System.import(`${props.pluginBaseUrl}/libs/monaco.min.js`).then(() => {
         setTimeout(() => {
           this.initMonaco();
         }, 1);


### PR DESCRIPTION
Get `appSubUrl` from Grafana config so we're pointing to the right path.
 
Fixes #203

![image](https://user-images.githubusercontent.com/46142/106740585-844cc400-6612-11eb-8913-ab06a8b8a536.png)

(note the url is prefixed with the `/grafana` sub path)