### PR TITLE
Fix: Replace variables within template variable queries

### DIFF
--- a/src/datasource.ts
+++ b/src/datasource.ts
@@ -269,10 +269,11 @@ export class AdxDataSource extends DataSourceWithBackend<KustoQuery, AdxDataSour
       options = {};
     }
     if (!options.hasOwnProperty('scopedVars')) {
-      options['scopedVars'] = {};
+      options.scopedVars = {};
     }
 
-    const interpolatedQuery = interpolateKustoQuery(query, options['scopedVars']);
+    const replacedQuery = this.templateSrv.replace(query, options.scopedVars, this.interpolateVariable);
+    const interpolatedQuery = interpolateKustoQuery(replacedQuery, options.scopedVars);
 
     return {
       ...defaultQuery,


### PR DESCRIPTION
Fixes #214

I created a `$states` template variable with the query `PopulationData | project State`, selected "Multi-value", "Include all option" and made the all value `all`.

Then I made a `$population` variable with the query

```
PopulationData
| where $__contains(State, $states)
| distinct Population
| limit 100
```

which was being sent over the wire (incorrectly) as 


```
PopulationData
| where State in ('all')
| distinct Population
| limit 101
```

After this change the query is sent as 

```
PopulationData
| where 1 == 1
| distinct Population
| limit 101
```

I was not able to get the second query to actually populate options for the variable for some reason, despite the same query producing results in a regular Grafana ADX panel.