### PR TITLE
Format property names with special characters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change Log
 
+## [3.3.3]
+
+- Bugfix: Fixed issue where query builder did not handle table names that contained special characters
+
 ## [3.3.2]
 
 - Bugfix: Fixed an issue where the KQL Monaco editor wouldn't load when Grafana is served from a sub path

--- a/src/KustoExpressionParser.test.ts
+++ b/src/KustoExpressionParser.test.ts
@@ -176,6 +176,14 @@ describe('KustoExpressionParser', () => {
       expect(parser.toQuery(expression)).toEqual('StormEvents' + "\n| where eventType == 'ThunderStorm'");
     });
 
+    it('should parse an expression with a table name that contains special characters', () => {
+      const expression = createQueryExpression({
+        from: createProperty('events.all'),
+      });
+
+      expect(parser.toQuery(expression)).toEqual("['events.all']");
+    });
+
     it('should parse expression with where equal to boolean value', () => {
       const expression = createQueryExpression({
         from: createProperty('StormEvents'),

--- a/src/KustoExpressionParser.ts
+++ b/src/KustoExpressionParser.ts
@@ -295,8 +295,9 @@ export class KustoExpressionParser {
 
   private formatProperty(property: string): string {
     const specialCharacters = /[\s\.-]/; // space, dot, or dash
-    
-    if (specialCharacters.test(property)) {
+    const schemaMappingCharacters = /[\$\(]/; // $ or (
+
+    if (specialCharacters.test(property) && !schemaMappingCharacters.test(property)) {
       return `['${property}']`;
     }
 

--- a/src/KustoExpressionParser.ts
+++ b/src/KustoExpressionParser.ts
@@ -53,7 +53,7 @@ export class KustoExpressionParser {
     if (!expression || !expression.from) {
       return '';
     }
-    
+
     const context: ParseContext = {
       timeColumn: defaultTimeColumn(tableSchema, expression),
       castIfDynamic: (column: string) => castIfDynamic(column, tableSchema),

--- a/src/KustoExpressionParser.ts
+++ b/src/KustoExpressionParser.ts
@@ -53,7 +53,7 @@ export class KustoExpressionParser {
     if (!expression || !expression.from) {
       return '';
     }
-
+    
     const context: ParseContext = {
       timeColumn: defaultTimeColumn(tableSchema, expression),
       castIfDynamic: (column: string) => castIfDynamic(column, tableSchema),
@@ -290,7 +290,17 @@ export class KustoExpressionParser {
   }
 
   private appendProperty(context: ParseContext, expression: QueryEditorPropertyExpression, parts: string[]) {
-    parts.push(expression.property.name);
+    parts.push(this.formatProperty(expression.property.name));
+  }
+
+  private formatProperty(property: string): string {
+    const specialCharacters = /[\s\.-]/; // space, dot, or dash
+    
+    if (specialCharacters.test(property)) {
+      return `['${property}']`;
+    }
+
+    return property;
   }
 
   private isTemplateVariable(value: string): boolean {


### PR DESCRIPTION
Fix for: https://github.com/grafana/azure-data-explorer-datasource/issues/220

It looks like table names can contain dots, dashes, and spaces, and if they do they are required to be in [quotes](https://docs.microsoft.com/en-us/azure/data-explorer/kusto/query/schema-entities/entity-names#identifier-naming-rules).

As part of this work, we looked into column names containing dots, to see if we have a similar problem there. I don't think we want to change column names into quotes as we can have column names like `column.country` so if we force those into quotes we'll break existing functionality. I sort of suspect there must be some way to get back the type of these properties in the same way we do for the values, but I also haven't heard of users running into this problem, so I decided not to tackle that in this pr.

I spoke briefly with @mckn this morning and we think that tablenames that contain schema mappings will always contain either a `$` a `(` or both, ex: `StormEvents($__from, $__to)` so in those circumstances we do not wish to put the table name in quotes even if there's a space, dot, or dash.