### PR TITLE
Stop throwing errors when url is not defined

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Change Log
 
+## [next]
+- Bugfix: Fix an error loading schemas on the configuration page.
+
 ## [3.4.0]
 
 Note: The minimum required version of Grafana is now 7.4

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "@grafana/toolkit": "7.3.1",
     "@grafana/ui": "7.5.0-beta.1",
     "@testing-library/react": "^11.2.5",
+    "@testing-library/user-event": "^13.1.9",
     "@types/angular": "1.6.49",
     "@types/debounce-promise": "^3.1.2",
     "@types/grafana": "github:CorpGlory/types-grafana.git",

--- a/src/components/ConfigEditor/ConfigEditor.test.tsx
+++ b/src/components/ConfigEditor/ConfigEditor.test.tsx
@@ -1,0 +1,88 @@
+import React from 'react';
+import { render, screen, waitFor } from '@testing-library/react';
+import '@testing-library/jest-dom/extend-expect';
+import ConfigEditor from './index';
+import { EditorMode } from 'types';
+import * as refreshSchema from './refreshSchema';
+
+describe('ConfigEditor', () => {
+  let refreshSchemaSpy;
+
+  beforeEach(() => {
+    refreshSchemaSpy = jest
+      .spyOn(refreshSchema, 'refreshSchema')
+      .mockImplementation((url: string) => Promise.resolve({ databases: [], schemaMappingOptions: [] }));
+  });
+
+  afterEach(() => {
+    refreshSchemaSpy.mockRestore();
+  });
+
+  it('renders the component', async () => {
+    render(<ConfigEditor {...createMockConfigEditorProps()} />);
+    await waitFor(() => expect(screen.getByTestId('azure-data-explorer-config-editor')).toBeInTheDocument());
+  });
+
+  it('calls refreshSchema on render if id and url are defined', async () => {
+    render(<ConfigEditor {...createMockConfigEditorProps({ id: 123, url: 'grafana.com' })} />);
+    await waitFor(() => expect(screen.getByTestId('azure-data-explorer-config-editor')).toBeInTheDocument());
+    expect(refreshSchemaSpy).toHaveBeenCalled();
+  });
+
+  it('does not call refreshSchema on render if the id or url are missing', async () => {
+    render(<ConfigEditor {...createMockConfigEditorProps({ id: 123, url: '' })} />);
+    await waitFor(() => expect(screen.getByTestId('azure-data-explorer-config-editor')).toBeInTheDocument());
+    expect(refreshSchemaSpy).not.toHaveBeenCalled();
+  });
+});
+
+const createMockConfigEditorProps = (optionsOverrides?: any) => ({
+  options: {
+    id: 123,
+    orgId: 123,
+    name: '',
+    typeLogoUrl: '',
+    type: '',
+    access: '',
+    url: '',
+    password: '',
+    user: '',
+    database: '',
+    basicAuth: true,
+    basicAuthPassword: '',
+    basicAuthUser: '',
+    isDefault: true,
+    jsonData: {
+      readOnly: true,
+      withCredentials: true,
+      defaultDatabase: '',
+      minimalCache: 123,
+      defaultEditorMode: EditorMode.Raw,
+      queryTimeout: '',
+      dataConsistency: '',
+      cacheMaxAge: '',
+      dynamicCaching: true,
+      useSchemaMapping: false,
+      enableUserTracking: true,
+      clusterUrl: '',
+      tenantId: '',
+      clientId: '',
+    },
+    readOnly: true,
+    withCredentials: true,
+    defaultDatabase: '',
+    minimalCache: 123,
+    defaultEditorMode: EditorMode.Raw,
+    queryTimeout: '',
+    dataConsistency: '',
+    cacheMaxAge: '',
+    dynamicCaching: true,
+    useSchemaMapping: false,
+    enableUserTracking: true,
+    clusterUrl: '',
+    tenantId: '',
+    clientId: '',
+    ...optionsOverrides,
+  },
+  onOptionsChange: () => {},
+});

--- a/src/components/ConfigEditor/index.tsx
+++ b/src/components/ConfigEditor/index.tsx
@@ -8,7 +8,6 @@ import DatabaseConfig from './DatabaseConfig';
 import QueryConfig from './QueryConfig';
 import { refreshSchema, Schema } from './refreshSchema';
 import TrackingConfig from './TrackingConfig';
-import { alertError } from '@grafana/data/types/appEvents';
 import { Alert } from '@grafana/ui';
 
 interface ConfigEditorProps
@@ -20,19 +19,24 @@ type FetchErrorResponse = FetchResponse<{
   response?: string;
 }>;
 
-const ConfigEditor: React.FC<ConfigEditorProps> = props => {
+const ConfigEditor: React.FC<ConfigEditorProps> = (props) => {
   const { options, onOptionsChange } = props;
   const [schema, setSchema] = useState<Schema>({ databases: [], schemaMappingOptions: [] });
   const [schemaError, setSchemaError] = useState<FetchErrorResponse['data']>();
   const { jsonData } = options;
-
   const updateSchema = (url: string) => {
+    if (!url.length) {
+      return;
+    }
     refreshSchema(url)
-      .then(data => {
+      .then((data) => {
         setSchema(data);
         setSchemaError(undefined);
       })
-      .catch((err: FetchErrorResponse) => setSchemaError(err.data));
+      .catch((err: FetchErrorResponse) => {
+        // TODO: make sure err.data is the format we are expecting
+        setSchemaError(err.data);
+      });
   };
 
   const updateJsonData = useCallback(

--- a/src/components/ConfigEditor/index.tsx
+++ b/src/components/ConfigEditor/index.tsx
@@ -19,7 +19,7 @@ type FetchErrorResponse = FetchResponse<{
   response?: string;
 }>;
 
-const ConfigEditor: React.FC<ConfigEditorProps> = (props) => {
+const ConfigEditor: React.FC<ConfigEditorProps> = props => {
   const { options, onOptionsChange } = props;
   const [schema, setSchema] = useState<Schema>({ databases: [], schemaMappingOptions: [] });
   const [schemaError, setSchemaError] = useState<FetchErrorResponse['data']>();
@@ -29,7 +29,7 @@ const ConfigEditor: React.FC<ConfigEditorProps> = (props) => {
       return;
     }
     refreshSchema(url)
-      .then((data) => {
+      .then(data => {
         setSchema(data);
         setSchemaError(undefined);
       })
@@ -81,7 +81,7 @@ const ConfigEditor: React.FC<ConfigEditorProps> = (props) => {
   }, [onOptionsChange, options]);
 
   return (
-    <>
+    <div data-testid="azure-data-explorer-config-editor">
       <ConfigHelp />
 
       <ConnectionConfig
@@ -108,7 +108,7 @@ const ConfigEditor: React.FC<ConfigEditorProps> = (props) => {
           {schemaError.message}
         </Alert>
       )}
-    </>
+    </div>
   );
 };
 

--- a/src/components/ConfigEditor/index.tsx
+++ b/src/components/ConfigEditor/index.tsx
@@ -20,7 +20,7 @@ type FetchErrorResponse = FetchResponse<{
   response?: string;
 }>;
 
-const ConfigEditor: React.FC<ConfigEditorProps> = (props) => {
+const ConfigEditor: React.FC<ConfigEditorProps> = props => {
   const { options, onOptionsChange } = props;
   const [schema, setSchema] = useState<Schema>({ databases: [], schemaMappingOptions: [] });
   const [schemaError, setSchemaError] = useState<FetchErrorResponse['data']>();
@@ -59,7 +59,7 @@ const ConfigEditor: React.FC<ConfigEditorProps> = (props) => {
       // TODO: make sure err.data is the format we are expecting
       setSchemaError(err.data);
     }
-  }, [getDatasource]);
+  }, [getDatasource, options.secureJsonFields]);
 
   const updateJsonData = useCallback(
     <T extends keyof AdxDataSourceOptions>(fieldName: T, value: AdxDataSourceOptions[T]) => {
@@ -76,7 +76,7 @@ const ConfigEditor: React.FC<ConfigEditorProps> = (props) => {
 
   useEffect(() => {
     options.id && updateSchema();
-  }, [options.id]);
+  }, [options.id, updateSchema]);
 
   useEffect(() => {
     if (!jsonData.defaultDatabase && schema?.databases.length) {

--- a/src/datasource.ts
+++ b/src/datasource.ts
@@ -37,7 +37,7 @@ export class AdxDataSource extends DataSourceWithBackend<KustoQuery, AdxDataSour
   private templateSrv: TemplateSrv;
   private baseUrl: string;
   private defaultOrFirstDatabase: string;
-  private url?: string;
+  url?: string;
   private expressionParser: KustoExpressionParser;
   private defaultEditorMode: EditorMode;
   private schemaMapper: AdxSchemaMapper;

--- a/yarn.lock
+++ b/yarn.lock
@@ -2178,6 +2178,13 @@
     "@babel/runtime" "^7.12.5"
     "@testing-library/dom" "^7.28.1"
 
+"@testing-library/user-event@^13.1.9":
+  version "13.1.9"
+  resolved "https://registry.yarnpkg.com/@testing-library/user-event/-/user-event-13.1.9.tgz#29e49a42659ac3c1023565ff56819e0153a82e99"
+  integrity sha512-NZr0zL2TMOs2qk+dNlqrAdbaRW5dAmYwd1yuQ4r7HpkVEOj0MWuUjDWwKhcLd/atdBy8ZSMHSKp+kXSQe47ezg==
+  dependencies:
+    "@babel/runtime" "^7.12.5"
+
 "@torkelo/react-select@3.0.8":
   version "3.0.8"
   resolved "https://registry.yarnpkg.com/@torkelo/react-select/-/react-select-3.0.8.tgz#04bfc877118af425f97eac2b471b66705484ee4a"


### PR DESCRIPTION
Right now when you load the config editor for Azure Data Explorer you see 2 errors (one an orange-y toast, the other a static red error) that both show raw html. 

They don't block you from loading the datasource, but they are confusing.

I think there are a few things happening that we should fix:
1) we are making a request to update the schema without a url which is throwing an error. There's no need to make a request that we know will fail. (What this PR fixes)
2) props.options.url seems to always be an empty string. It's not clear to me what is supposed to set this or where these props are coming from exactly, but we should work on that. (Should fix!)
3) we are always setting these errors even when we get back html which seems unnecessary. Perhaps there is some way to only set the error if it's in a format we expect, or otherwise translate errors back to users in ways that are predictable. (This is optional to me but nice to fix if we can).

I'm not sure how to tackle 2 or 3 at the moment, but this pr felt like an improvement until we can figure out what's going on for 2 