### PR TITLE
Call resource handler

### DIFF
--- a/pkg/azuredx/client/client.go
+++ b/pkg/azuredx/client/client.go
@@ -6,21 +6,25 @@ import (
 	"io/ioutil"
 	"net/http"
 
-	"github.com/google/uuid"
 	jsoniter "github.com/json-iterator/go"
 
 	"github.com/grafana/azure-data-explorer-datasource/pkg/azuredx/models"
 	"github.com/grafana/grafana-plugin-sdk-go/backend"
 )
 
+type AdxClient interface {
+	TestRequest(datasourceSettings *models.DatasourceSettings, properties *models.Properties) error
+	KustoRequest(url string, payload models.RequestPayload, additionalHeaders map[string]string) (*models.TableResponse, int, string, error)
+}
+
 // Client is an http.Client used for API requests.
 type Client struct {
-	*http.Client
+	httpClient *http.Client
 }
 
 // NewClient creates a Grafana Plugin SDK Go Http Client
 func New(client *http.Client) *Client {
-	return &Client{Client: client}
+	return &Client{httpClient: client}
 }
 
 // TestRequest handles a data source test request in Grafana's Datasource configuration UI.
@@ -34,7 +38,7 @@ func (c *Client) TestRequest(datasourceSettings *models.DatasourceSettings, prop
 	if err != nil {
 		return err
 	}
-	resp, err := c.Post(datasourceSettings.ClusterURL+"/v1/rest/query", "application/json", &buf)
+	resp, err := c.httpClient.Post(datasourceSettings.ClusterURL+"/v1/rest/query", "application/json", &buf)
 	if err != nil {
 		return err
 	}
@@ -48,53 +52,50 @@ func (c *Client) TestRequest(datasourceSettings *models.DatasourceSettings, prop
 // KustoRequest executes a Kusto Query language request to Azure's Data Explorer V1 REST API
 // and returns a TableResponse. If there is a query syntax error, the error message inside
 // the API's JSON error response is returned as well (if available).
-func (c *Client) KustoRequest(datasourceSettings *models.DatasourceSettings, payload models.RequestPayload, querySource string, user *backend.User) (*models.TableResponse, string, error) {
+func (c *Client) KustoRequest(url string, payload models.RequestPayload, additionalHeaders map[string]string) (*models.TableResponse, int, string, error) {
 	var buf bytes.Buffer
 	err := jsoniter.NewEncoder(&buf).Encode(payload)
 	if err != nil {
-		return nil, "", err
+		return nil, http.StatusInternalServerError, "", err
 	}
-	req, err := http.NewRequest(http.MethodPost, datasourceSettings.ClusterURL+"/v1/rest/query", &buf)
+	req, err := http.NewRequest(http.MethodPost, url, &buf)
 	if err != nil {
-		return nil, "", err
+		return nil, http.StatusInternalServerError, "", err
 	}
 	req.Header.Set("Accept", "application/json")
 	req.Header.Set("Content-Type", "application/json")
 	req.Header.Set("x-ms-app", "Grafana-ADX")
-	if querySource == "" {
-		querySource = "unspecified"
+	if payload.QuerySource == "" {
+		payload.QuerySource = "unspecified"
 	}
 
-	msClientRequestIDHeader := fmt.Sprintf("KGC.%v;%v", querySource, uuid.Must(uuid.NewRandom()).String())
-	if datasourceSettings.EnableUserTracking {
-		if user != nil {
-			msClientRequestIDHeader += fmt.Sprintf(";%v", user.Login)
-			req.Header.Set("x-ms-user-id", user.Login)
-		}
+	for key, value := range additionalHeaders {
+		req.Header.Set(key, value)
 	}
-	req.Header.Set("x-ms-client-request-id", msClientRequestIDHeader)
 
-	resp, err := c.Do(req)
+	resp, err := c.httpClient.Do(req)
+	statusCode := resp.StatusCode
 	if err != nil {
-		return nil, "", err
+		return nil, statusCode, "", err
 	}
 	defer resp.Body.Close()
 	if resp.StatusCode > 299 {
 		bodyBytes, err := ioutil.ReadAll(resp.Body)
 		if err != nil {
-			return nil, "", err
+			return nil, http.StatusInternalServerError, "", err
 		}
 		bodyString := string(bodyBytes)
 		if resp.StatusCode == 401 { // 401 does not have a JSON body
-			return nil, "", fmt.Errorf("HTTP error: %v - %v", resp.Status, bodyString)
+			return nil, statusCode, "", fmt.Errorf("HTTP error: %v - %v", resp.Status, bodyString)
 		}
 		errorData := &models.ErrorResponse{}
 		err = jsoniter.Unmarshal(bodyBytes, errorData)
 		if err != nil {
 			backend.Logger.Debug("failed to unmarshal error body from response", "error", err)
+			statusCode = http.StatusInternalServerError
 		}
-		return nil, errorData.Error.Message, fmt.Errorf("HTTP error: %v - %v", resp.Status, bodyString)
+		return nil, statusCode, errorData.Error.Message, fmt.Errorf("HTTP error: %v - %v", resp.Status, bodyString)
 	}
 	tr, err := models.TableFromJSON(resp.Body)
-	return tr, "", err
+	return tr, statusCode, "", err
 }

--- a/pkg/azuredx/datasource.go
+++ b/pkg/azuredx/datasource.go
@@ -60,6 +60,9 @@ func NewDatasource(settings backend.DataSourceInstanceSettings) (instancemgmt.In
 	adx.registerRoutes(mux)
 	adx.CallResourceHandler = httpadapter.New(mux)
 
+	return adx, nil
+}
+
 func (adx *AzureDataExplorer) Dispose() {
 	tokenCache.Purge()
 }

--- a/pkg/azuredx/datasource.go
+++ b/pkg/azuredx/datasource.go
@@ -2,32 +2,38 @@ package azuredx
 
 import (
 	"fmt"
+	"net/http"
 
+	"github.com/google/uuid"
 	"github.com/grafana/azure-data-explorer-datasource/pkg/azuredx/client"
 	"github.com/grafana/azure-data-explorer-datasource/pkg/azuredx/models"
 	"github.com/grafana/azure-data-explorer-datasource/pkg/azuredx/tokenprovider"
 	"github.com/grafana/grafana-plugin-sdk-go/backend"
 	sdkhttpclient "github.com/grafana/grafana-plugin-sdk-go/backend/httpclient"
 	"github.com/grafana/grafana-plugin-sdk-go/backend/instancemgmt"
+	"github.com/grafana/grafana-plugin-sdk-go/backend/resource/httpadapter"
 	"github.com/grafana/grafana-plugin-sdk-go/data"
 	jsoniter "github.com/json-iterator/go"
 	"golang.org/x/net/context"
 )
 
-// GrafanaAzureDXDatasource stores reference to plugin and logger
-type GrafanaAzureDXDatasource struct {
-	client   *client.Client
+// AzureDataExplorer stores reference to plugin and logger
+type AzureDataExplorer struct {
+	backend.CallResourceHandler
+	client   client.AdxClient
 	settings *models.DatasourceSettings
 }
 
 var tokenCache = tokenprovider.NewConcurrentTokenCache()
 
 func NewDatasource(settings backend.DataSourceInstanceSettings) (instancemgmt.Instance, error) {
-	datasourceSettings := models.DatasourceSettings{}
+	adx := &AzureDataExplorer{}
+	datasourceSettings := &models.DatasourceSettings{}
 	err := datasourceSettings.Load(settings)
 	if err != nil {
 		return nil, err
 	}
+	adx.settings = datasourceSettings
 
 	tokenProvider := tokenprovider.NewAccessTokenProvider(tokenCache, datasourceSettings.ClientID, datasourceSettings.TenantID, "AzurePublic", datasourceSettings.Secret, []string{"https://kusto.kusto.windows.net/.default"})
 
@@ -48,32 +54,31 @@ func NewDatasource(settings backend.DataSourceInstanceSettings) (instancemgmt.In
 		backend.Logger.Error("failed to create HTTP client", "error", err.Error())
 		return nil, err
 	}
+	adx.client = client.New(httpClient)
 
-	return &GrafanaAzureDXDatasource{
-		client:   client.New(httpClient),
-		settings: &datasourceSettings,
-	}, nil
-}
+	mux := http.NewServeMux()
+	adx.registerRoutes(mux)
+	adx.CallResourceHandler = httpadapter.New(mux)
 
-func (s *GrafanaAzureDXDatasource) Dispose() {
+func (adx *AzureDataExplorer) Dispose() {
 	tokenCache.Purge()
 }
 
 // QueryData is the primary method called by grafana-server
-func (plugin *GrafanaAzureDXDatasource) QueryData(ctx context.Context, req *backend.QueryDataRequest) (*backend.QueryDataResponse, error) {
+func (adx *AzureDataExplorer) QueryData(ctx context.Context, req *backend.QueryDataRequest) (*backend.QueryDataResponse, error) {
 	backend.Logger.Debug("Query", "datasource", req.PluginContext.DataSourceInstanceSettings.Name)
 	res := backend.NewQueryDataResponse()
 
 	for _, q := range req.Queries {
-		res.Responses[q.RefID] = plugin.handleQuery(q, req.PluginContext.User)
+		res.Responses[q.RefID] = adx.handleQuery(q, req.PluginContext.User)
 	}
 
 	return res, nil
 }
 
 // CheckHealth handles health checks
-func (plugin *GrafanaAzureDXDatasource) CheckHealth(ctx context.Context, req *backend.CheckHealthRequest) (*backend.CheckHealthResult, error) {
-	err := plugin.client.TestRequest(plugin.settings, models.NewConnectionProperties(plugin.settings, nil))
+func (adx *AzureDataExplorer) CheckHealth(ctx context.Context, req *backend.CheckHealthRequest) (*backend.CheckHealthResult, error) {
+	err := adx.client.TestRequest(adx.settings, models.NewConnectionProperties(adx.settings, nil))
 	if err != nil {
 		return &backend.CheckHealthResult{
 			Status:  backend.HealthStatusError,
@@ -87,7 +92,7 @@ func (plugin *GrafanaAzureDXDatasource) CheckHealth(ctx context.Context, req *ba
 	}, nil
 }
 
-func (plugin *GrafanaAzureDXDatasource) handleQuery(q backend.DataQuery, user *backend.User) backend.DataResponse {
+func (adx *AzureDataExplorer) handleQuery(q backend.DataQuery, user *backend.User) backend.DataResponse {
 	resp := backend.DataResponse{}
 	qm := &models.QueryModel{}
 
@@ -97,7 +102,7 @@ func (plugin *GrafanaAzureDXDatasource) handleQuery(q backend.DataQuery, user *b
 		return resp
 	}
 
-	cs := models.NewCacheSettings(plugin.settings, &q, qm)
+	cs := models.NewCacheSettings(adx.settings, &q, qm)
 	qm.MacroData = models.NewMacroData(cs.TimeRange, q.Interval.Milliseconds())
 
 	if err := qm.Interpolate(); err != nil {
@@ -125,12 +130,24 @@ func (plugin *GrafanaAzureDXDatasource) handleQuery(q backend.DataQuery, user *b
 		resp.Error = err
 	}
 
+	headers := map[string]string{}
+	msClientRequestIDHeader := fmt.Sprintf("KGC.%s;%s", qm.QuerySource, uuid.Must(uuid.NewRandom()).String())
+	if adx.settings.EnableUserTracking {
+		if user != nil {
+			msClientRequestIDHeader += fmt.Sprintf(";%v", user.Login)
+			headers["x-ms-user-id"] = user.Login
+		}
+	}
+	headers["x-ms-client-request-id"] = msClientRequestIDHeader
+
 	var tableRes *models.TableResponse
-	tableRes, kustoError, err = plugin.client.KustoRequest(plugin.settings, models.RequestPayload{
-		CSL:        qm.Query,
-		DB:         qm.Database,
-		Properties: models.NewConnectionProperties(plugin.settings, cs),
-	}, qm.QuerySource, user)
+	tableRes, _, kustoError, err = adx.client.KustoRequest(adx.settings.ClusterURL+"/v1/rest/query", models.RequestPayload{
+		CSL:         qm.Query,
+		DB:          qm.Database,
+		Properties:  models.NewConnectionProperties(adx.settings, cs),
+		QuerySource: qm.QuerySource,
+	}, headers)
+
 	if err != nil {
 		backend.Logger.Debug("error building kusto request", "error", err.Error())
 		errorWithFrame(err)

--- a/pkg/azuredx/datasource_test.go
+++ b/pkg/azuredx/datasource_test.go
@@ -1,0 +1,60 @@
+package azuredx
+
+import (
+	"net/http"
+	"testing"
+
+	"github.com/grafana/azure-data-explorer-datasource/pkg/azuredx/models"
+	"github.com/grafana/grafana-plugin-sdk-go/backend"
+	"github.com/stretchr/testify/require"
+)
+
+var kustoRequestMock func(url string, payload models.RequestPayload, additionalHeaders map[string]string) (*models.TableResponse, int, string, error)
+var table = &models.TableResponse{
+	Tables: []models.Table{
+		{
+			TableName: "Table_0",
+			Columns:   []models.Column{},
+			Rows:      []models.Row{},
+		},
+	},
+}
+
+func TestDatasource(t *testing.T) {
+	var adx AzureDataExplorer
+	const UserLogin string = "user-login"
+	const ClusterURL string = "base-url"
+
+	t.Run("When running a query the right args should be passed to KustoReqest", func(t *testing.T) {
+		adx = AzureDataExplorer{}
+		adx.client = &fakeClient{}
+		adx.settings = &models.DatasourceSettings{EnableUserTracking: true, ClusterURL: ClusterURL}
+		query := backend.DataQuery{
+			RefID:         "",
+			QueryType:     "",
+			MaxDataPoints: 0,
+			Interval:      0,
+			TimeRange:     backend.TimeRange{},
+			JSON:          []byte(`{"resultFormat": "table","querySource": "schema"}`),
+		}
+		kustoRequestMock = func(url string, payload models.RequestPayload, additionalHeaders map[string]string) (*models.TableResponse, int, string, error) {
+			require.Equal(t, ClusterURL+"/v1/rest/query", url)
+			require.Contains(t, additionalHeaders, "x-ms-user-id")
+			require.Equal(t, UserLogin, additionalHeaders["x-ms-user-id"])
+			require.Contains(t, additionalHeaders["x-ms-client-request-id"], UserLogin)
+			return table, http.StatusOK, "", nil
+		}
+		res := adx.handleQuery(query, &backend.User{Login: UserLogin})
+		require.NoError(t, res.Error)
+	})
+}
+
+type fakeClient struct{}
+
+func (c *fakeClient) TestRequest(datasourceSettings *models.DatasourceSettings, properties *models.Properties) error {
+	panic("not implemented")
+}
+
+func (c *fakeClient) KustoRequest(url string, payload models.RequestPayload, additionalHeaders map[string]string) (*models.TableResponse, int, string, error) {
+	return kustoRequestMock(url, payload, additionalHeaders)
+}

--- a/pkg/azuredx/models/http_error.go
+++ b/pkg/azuredx/models/http_error.go
@@ -1,0 +1,19 @@
+package models
+
+type HttpError struct {
+	Message    string
+	Error      string
+	StatusCode int
+}
+
+func NewHttpError(message string, statusCode int, err error) *HttpError {
+	httpError := &HttpError{
+		Message:    message,
+		StatusCode: statusCode,
+	}
+	if err != nil {
+		httpError.Error = err.Error()
+	}
+
+	return httpError
+}

--- a/pkg/azuredx/models/types.go
+++ b/pkg/azuredx/models/types.go
@@ -10,9 +10,10 @@ type options struct {
 
 // RequestPayload is the information that makes up a Kusto query for Azure's Data Explorer API.
 type RequestPayload struct {
-	DB         string      `json:"db"`
-	CSL        string      `json:"csl"`
-	Properties *Properties `json:"properties,omitempty"`
+	DB          string      `json:"db"`
+	CSL         string      `json:"csl"`
+	QuerySource string      `json:"querySource"`
+	Properties  *Properties `json:"properties,omitempty"`
 }
 
 // AzureFrameMD is a type to populate a Frame's Custom metadata property.

--- a/pkg/azuredx/resource_handler.go
+++ b/pkg/azuredx/resource_handler.go
@@ -1,0 +1,77 @@
+package azuredx
+
+import (
+	"encoding/json"
+	"net/http"
+
+	"github.com/grafana/azure-data-explorer-datasource/pkg/azuredx/models"
+)
+
+func (adx *AzureDataExplorer) registerRoutes(mux *http.ServeMux) {
+	mux.HandleFunc("/databases", adx.getDatabases)
+	mux.HandleFunc("/schema", adx.getSchema)
+}
+
+const ManagementApiPath = "/v1/rest/mgmt"
+
+func (adx *AzureDataExplorer) getSchema(rw http.ResponseWriter, req *http.Request) {
+	if req.Method != "GET" {
+		respondWithError(rw, http.StatusMethodNotAllowed, "Invalid method", nil)
+		return
+	}
+
+	payload := models.RequestPayload{
+		CSL:         ".show databases schema as json",
+		QuerySource: "schema",
+	}
+
+	response, statusCode, kustoErr, err := adx.client.KustoRequest(adx.settings.ClusterURL+ManagementApiPath, payload, nil)
+	if err != nil {
+		respondWithError(rw, statusCode, kustoErr, err)
+		return
+	}
+
+	rw.Header().Set("Content-Type", "application/json")
+	err = json.NewEncoder(rw).Encode(response)
+	if err != nil {
+		rw.WriteHeader(http.StatusInternalServerError)
+	}
+}
+
+func (adx *AzureDataExplorer) getDatabases(rw http.ResponseWriter, req *http.Request) {
+	if req.Method != "GET" {
+		respondWithError(rw, http.StatusMethodNotAllowed, "Invalid method", nil)
+		return
+	}
+
+	payload := models.RequestPayload{
+		CSL: ".show databases",
+	}
+
+	response, statusCode, kustoErr, err := adx.client.KustoRequest(adx.settings.ClusterURL+ManagementApiPath, payload, nil)
+	if err != nil {
+		respondWithError(rw, statusCode, kustoErr, err)
+		return
+	}
+
+	rw.Header().Set("Content-Type", "application/json")
+	err = json.NewEncoder(rw).Encode(response)
+	if err != nil {
+		rw.WriteHeader(http.StatusInternalServerError)
+	}
+}
+
+func respondWithError(rw http.ResponseWriter, code int, message string, err error) {
+	httpError := models.NewHttpError(message, code, err)
+	response, err := json.Marshal(httpError)
+	if err != nil {
+		rw.WriteHeader(http.StatusInternalServerError)
+		return
+	}
+	rw.Header().Set("Content-Type", "application/json")
+	rw.WriteHeader(code)
+	_, err = rw.Write(response)
+	if err != nil {
+		rw.WriteHeader(http.StatusInternalServerError)
+	}
+}

--- a/pkg/azuredx/resource_handler_test.go
+++ b/pkg/azuredx/resource_handler_test.go
@@ -1,0 +1,102 @@
+package azuredx
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/grafana/azure-data-explorer-datasource/pkg/azuredx/models"
+	"github.com/stretchr/testify/require"
+)
+
+const errorMessage string = "Request is invalid and cannot be executed."
+
+func TestResourceHandler(t *testing.T) {
+	var res *httptest.ResponseRecorder
+	var adx AzureDataExplorer
+	var mux *http.ServeMux
+
+	setup := func() {
+		res = httptest.NewRecorder()
+		adx = AzureDataExplorer{}
+		mux = http.NewServeMux()
+		adx.registerRoutes(mux)
+	}
+
+	t.Run("When incorrect method is used a 405 should be returned", func(t *testing.T) {
+		setup()
+		mux.ServeHTTP(res, httptest.NewRequest("POST", "/databases", nil))
+		require.Equal(t, http.StatusMethodNotAllowed, res.Code)
+
+		mux.ServeHTTP(res, httptest.NewRequest("PUT", "/schema", nil))
+		require.Equal(t, http.StatusMethodNotAllowed, res.Code)
+	})
+
+	t.Run("When kust request fails route should return an error", func(t *testing.T) {
+		setup()
+		adx.client = &failingClient{}
+		adx.settings = &models.DatasourceSettings{ClusterURL: "some-baseurl"}
+		mux.ServeHTTP(res, httptest.NewRequest("GET", "/databases", nil))
+		require.Equal(t, http.StatusInternalServerError, res.Code)
+		httpError := models.HttpError{}
+		err := json.NewDecoder(res.Body).Decode(&httpError)
+		require.Nil(t, err)
+		require.Equal(t, errorMessage, httpError.Message)
+		require.Equal(t, http.StatusInternalServerError, httpError.StatusCode)
+		require.Contains(t, httpError.Error, fmt.Sprintf("HTTP error: %v", http.StatusBadRequest))
+	})
+
+	t.Run("When kust request was successful route should return a json table", func(t *testing.T) {
+		setup()
+		adx.client = &workingClient{}
+		adx.settings = &models.DatasourceSettings{ClusterURL: "some-baseurl"}
+		mux.ServeHTTP(res, httptest.NewRequest("GET", "/databases", nil))
+		require.Equal(t, http.StatusOK, res.Code)
+		tableResponse := models.TableResponse{}
+		err := json.NewDecoder(res.Body).Decode(&tableResponse)
+		require.Nil(t, err)
+		require.Len(t, tableResponse.Tables, 1)
+		require.Len(t, tableResponse.Tables[0].Columns, 2)
+		require.Len(t, tableResponse.Tables[0].Rows, 2)
+	})
+}
+
+type failingClient struct{}
+
+func (c *failingClient) TestRequest(datasourceSettings *models.DatasourceSettings, properties *models.Properties) error {
+	panic("not implemented")
+}
+
+func (c *failingClient) KustoRequest(url string, payload models.RequestPayload, additionalHeaders map[string]string) (*models.TableResponse, int, string, error) {
+	return nil, http.StatusInternalServerError, errorMessage, fmt.Errorf("HTTP error: %v - %v", http.StatusBadRequest, "")
+}
+
+type workingClient struct{}
+
+func (c *workingClient) TestRequest(datasourceSettings *models.DatasourceSettings, properties *models.Properties) error {
+	panic("not implemented")
+}
+
+func (c *workingClient) KustoRequest(url string, payload models.RequestPayload, additionalHeaders map[string]string) (*models.TableResponse, int, string, error) {
+	return &models.TableResponse{
+		Tables: []models.Table{
+			{
+				TableName: "table1",
+				Columns: []models.Column{
+					{ColumnName: "col1"},
+					{ColumnName: "col2"},
+				},
+				Rows: []models.Row{
+					{
+						"val1",
+					},
+					{
+						"val2",
+					},
+				},
+			},
+		},
+	}, http.StatusOK, "", nil
+}

--- a/pkg/azuredx/testdata/error-response.json
+++ b/pkg/azuredx/testdata/error-response.json
@@ -1,0 +1,54 @@
+{
+  "error": {
+    "code": "General_BadRequest",
+    "message": "Request is invalid and cannot be executed.",
+    "@type": "Kusto.Data.Exceptions.KustoBadRequestException",
+    "@message": "Request is invalid and cannot be processed: Syntax error: SYN0002: A recognition error occurred. [line:position=1:9]. Query: 'PerfTest take 5'",
+    "@context": {
+      "timestamp": "2021-05-26T13:23:26.2867367Z",
+      "serviceAlias": "GRAFANAADXDEV",
+      "machineName": "KEngine000000",
+      "processName": "Kusto.WinSvc.Svc",
+      "processId": 5912,
+      "threadId": 5496,
+      "appDomainName": "Kusto.WinSvc.Svc.exe",
+      "clientRequestId": "unspecified;d6ad5874-e639-4bff-b416-0cbc01366931",
+      "activityId": "3e4d89dc-38af-40a3-af81-a7e7d9b04055",
+      "subActivityId": "73bd30e3-f3de-4337-a96d-baea760771f9",
+      "activityType": "DN.FE.ExecuteQuery",
+      "parentActivityId": "bcf895b7-9a74-4dcf-92c2-8ade172102fe",
+      "activityStack": "(Activity stack: CRID=unspecified;d6ad5874-e639-4bff-b416-0cbc01366931 ARID=3e4d89dc-38af-40a3-af81-a7e7d9b04055 > KD.Query.Client.ExecuteQueryAsKustoDataStream/8e7bc1d4-96c4-4053-909a-77c51cbc9dc4 > P.WCF.Service.ExecuteQueryInternalAsKustoDataStream..IClientServiceCommunicationContract/bcf895b7-9a74-4dcf-92c2-8ade172102fe > DN.FE.ExecuteQuery/73bd30e3-f3de-4337-a96d-baea760771f9)"
+    },
+    "@permanent": true,
+    "@text": "PerfTest take 5",
+    "@database": "PerfTest",
+    "@ClientRequestLogger": "",
+    "innererror": {
+      "code": "SYN0002",
+      "message": "A recognition error occurred.",
+      "@type": "Kusto.Data.Exceptions.SyntaxException",
+      "@message": "Syntax error: SYN0002: A recognition error occurred. [line:position=1:9]. Query: 'PerfTest take 5'",
+      "@context": {
+        "timestamp": "2021-05-26T13:23:26.2867367Z",
+        "serviceAlias": "GRAFANAADXDEV",
+        "machineName": "KEngine000000",
+        "processName": "Kusto.WinSvc.Svc",
+        "processId": 5912,
+        "threadId": 5496,
+        "appDomainName": "Kusto.WinSvc.Svc.exe",
+        "clientRequestId": "unspecified;d6ad5874-e639-4bff-b416-0cbc01366931",
+        "activityId": "3e4d89dc-38af-40a3-af81-a7e7d9b04055",
+        "subActivityId": "73bd30e3-f3de-4337-a96d-baea760771f9",
+        "activityType": "DN.FE.ExecuteQuery",
+        "parentActivityId": "bcf895b7-9a74-4dcf-92c2-8ade172102fe",
+        "activityStack": "(Activity stack: CRID=unspecified;d6ad5874-e639-4bff-b416-0cbc01366931 ARID=3e4d89dc-38af-40a3-af81-a7e7d9b04055 > KD.Query.Client.ExecuteQueryAsKustoDataStream/8e7bc1d4-96c4-4053-909a-77c51cbc9dc4 > P.WCF.Service.ExecuteQueryInternalAsKustoDataStream..IClientServiceCommunicationContract/bcf895b7-9a74-4dcf-92c2-8ade172102fe > DN.FE.ExecuteQuery/73bd30e3-f3de-4337-a96d-baea760771f9)"
+      },
+      "@permanent": true,
+      "@line": "1",
+      "@pos": "9",
+      "@errorCode": "SYN0002",
+      "@errorMessage": "A recognition error occurred.",
+      "@token": "take"
+    }
+  }
+}

--- a/pkg/azuredx/testdata/successful-response.json
+++ b/pkg/azuredx/testdata/successful-response.json
@@ -1,0 +1,172 @@
+{
+  "Tables": [
+    {
+      "TableName": "Table_0",
+      "Columns": [
+        {
+          "ColumnName": "_Timestamp_",
+          "DataType": "DateTime",
+          "ColumnType": "datetime"
+        },
+        {
+          "ColumnName": "_val1_",
+          "DataType": "Double",
+          "ColumnType": "real"
+        },
+        {
+          "ColumnName": "_val2_",
+          "DataType": "Double",
+          "ColumnType": "real"
+        },
+        {
+          "ColumnName": "_flag1_",
+          "DataType": "String",
+          "ColumnType": "string"
+        },
+        {
+          "ColumnName": "_flag2_",
+          "DataType": "String",
+          "ColumnType": "string"
+        }
+      ],
+      "Rows": [
+        ["2011-12-15T03:10:00Z", 9.9812421798706055, 8.8430976867675781, "Clean", "Clean"],
+        ["2018-02-16T03:30:00Z", 3.6511249542236328, 2.4008100032806396, "Clean", "Clean"],
+        ["2008-11-05T04:20:00Z", 0.41963398456573486, 0.80654901266098022, "Clean", "Clean"],
+        ["2013-06-02T04:50:00Z", 8.4751501083374023, 6.987764835357666, "Clean", "Lonely period range deg."],
+        ["2015-11-27T12:00:00Z", 0.37000000476837158, 7.2155637741088867, "Extra severe degradation", "Clean"]
+      ]
+    },
+    {
+      "TableName": "Table_1",
+      "Columns": [
+        {
+          "ColumnName": "Value",
+          "DataType": "String",
+          "ColumnType": "string"
+        }
+      ],
+      "Rows": [
+        [
+          "{\"Visualization\":null,\"Title\":null,\"XColumn\":null,\"Series\":null,\"YColumns\":null,\"AnomalyColumns\":null,\"XTitle\":null,\"YTitle\":null,\"XAxis\":null,\"YAxis\":null,\"Legend\":null,\"YSplit\":null,\"Accumulate\":false,\"IsQuerySorted\":false,\"Kind\":null,\"Ymin\":\"NaN\",\"Ymax\":\"NaN\"}"
+        ]
+      ]
+    },
+    {
+      "TableName": "Table_2",
+      "Columns": [
+        {
+          "ColumnName": "Timestamp",
+          "DataType": "DateTime",
+          "ColumnType": "datetime"
+        },
+        {
+          "ColumnName": "Severity",
+          "DataType": "Int32",
+          "ColumnType": "int"
+        },
+        {
+          "ColumnName": "SeverityName",
+          "DataType": "String",
+          "ColumnType": "string"
+        },
+        {
+          "ColumnName": "StatusCode",
+          "DataType": "Int32",
+          "ColumnType": "int"
+        },
+        {
+          "ColumnName": "StatusDescription",
+          "DataType": "String",
+          "ColumnType": "string"
+        },
+        {
+          "ColumnName": "Count",
+          "DataType": "Int32",
+          "ColumnType": "int"
+        },
+        {
+          "ColumnName": "RequestId",
+          "DataType": "Guid",
+          "ColumnType": "guid"
+        },
+        {
+          "ColumnName": "ActivityId",
+          "DataType": "Guid",
+          "ColumnType": "guid"
+        },
+        {
+          "ColumnName": "SubActivityId",
+          "DataType": "Guid",
+          "ColumnType": "guid"
+        },
+        {
+          "ColumnName": "ClientActivityId",
+          "DataType": "String",
+          "ColumnType": "string"
+        }
+      ],
+      "Rows": [
+        [
+          "2021-05-26T13:16:14.5413204Z",
+          4,
+          "Info",
+          0,
+          "Query completed successfully",
+          1,
+          "0cd8db5b-73e3-410f-98e6-ead779a970f0",
+          "0cd8db5b-73e3-410f-98e6-ead779a970f0",
+          "d14af2b0-1d25-433f-9dea-e1c62b8e5b7f",
+          "unspecified;840bc573-e27e-4c52-a61a-c5788a1395a1"
+        ],
+        [
+          "2021-05-26T13:16:14.5413204Z",
+          6,
+          "Stats",
+          0,
+          "{\"ExecutionTime\":0.0,\"resource_usage\":{\"cache\":{\"memory\":{\"hits\":0,\"misses\":0,\"total\":0},\"disk\":{\"hits\":0,\"misses\":0,\"total\":0},\"shards\":{\"hot\":{\"hitbytes\":105190,\"missbytes\":0,\"retrievebytes\":0},\"cold\":{\"hitbytes\":0,\"missbytes\":0,\"retrievebytes\":0},\"bypassbytes\":0}},\"cpu\":{\"user\":\"00:00:00\",\"kernel\":\"00:00:00\",\"total cpu\":\"00:00:00\"},\"memory\":{\"peak_per_node\":0}},\"input_dataset_statistics\":{\"extents\":{\"total\":1,\"scanned\":1,\"scanned_min_datetime\":\"2021-01-11T23:32:19.9301667Z\",\"scanned_max_datetime\":\"2021-01-11T23:32:19.9301667Z\"},\"rows\":{\"total\":496908,\"scanned\":5},\"rowstores\":{\"scanned_rows\":0,\"scanned_values_size\":0},\"shards\":{\"queries_generic\":1,\"queries_specialized\":0}},\"dataset_statistics\":[{\"table_row_count\":5,\"table_size\":223}]}",
+          1,
+          "0cd8db5b-73e3-410f-98e6-ead779a970f0",
+          "0cd8db5b-73e3-410f-98e6-ead779a970f0",
+          "d14af2b0-1d25-433f-9dea-e1c62b8e5b7f",
+          "unspecified;840bc573-e27e-4c52-a61a-c5788a1395a1"
+        ]
+      ]
+    },
+    {
+      "TableName": "Table_3",
+      "Columns": [
+        {
+          "ColumnName": "Ordinal",
+          "DataType": "Int64",
+          "ColumnType": "long"
+        },
+        {
+          "ColumnName": "Kind",
+          "DataType": "String",
+          "ColumnType": "string"
+        },
+        {
+          "ColumnName": "Name",
+          "DataType": "String",
+          "ColumnType": "string"
+        },
+        {
+          "ColumnName": "Id",
+          "DataType": "String",
+          "ColumnType": "string"
+        },
+        {
+          "ColumnName": "PrettyName",
+          "DataType": "String",
+          "ColumnType": "string"
+        }
+      ],
+      "Rows": [
+        [0, "QueryResult", "PrimaryResult", "87da110a-92af-4b08-9b98-8c7cb17f7690", ""],
+        [1, "QueryProperties", "@ExtendedProperties", "137dbc6a-5799-4e13-8294-bc4b4a8b6a57", ""],
+        [2, "QueryStatus", "QueryStatus", "00000000-0000-0000-0000-000000000000", ""]
+      ]
+    }
+  ]
+}

--- a/src/components/ConfigEditor/ConfigEditor.test.tsx
+++ b/src/components/ConfigEditor/ConfigEditor.test.tsx
@@ -6,6 +6,7 @@ import ConfigEditor from './index';
 import { EditorMode } from 'types';
 import * as refreshSchema from './refreshSchema';
 import * as grafanaRuntime from '@grafana/runtime';
+import { AdxDataSource } from 'datasource';
 
 describe('ConfigEditor', () => {
   let refreshSchemaSpy, getDatasourceSpy;
@@ -13,7 +14,7 @@ describe('ConfigEditor', () => {
   beforeEach(() => {
     refreshSchemaSpy = jest
       .spyOn(refreshSchema, 'refreshSchema')
-      .mockImplementation((url: string) => Promise.resolve({ databases: [], schemaMappingOptions: [] }));
+      .mockImplementation((datasource: AdxDataSource) => Promise.resolve({ databases: [], schemaMappingOptions: [] }));
 
     getDatasourceSpy = jest.spyOn(grafanaRuntime, 'getDataSourceSrv').mockImplementation(
       () =>

--- a/src/components/ConfigEditor/index.tsx
+++ b/src/components/ConfigEditor/index.tsx
@@ -26,9 +26,9 @@ const ConfigEditor: React.FC<ConfigEditorProps> = props => {
   const [schemaError, setSchemaError] = useState<FetchErrorResponse['data']>();
   const { jsonData } = options;
 
-  const getDatasource = useCallback(async () => {
+  const getDatasource = useCallback(async (): Promise<AdxDataSource> => {
     const datasource = await getDataSourceSrv().get(options.name);
-    return datasource;
+    return datasource as AdxDataSource;
   }, [options.name]);
 
   const updateSchema = useCallback(async () => {
@@ -37,17 +37,9 @@ const ConfigEditor: React.FC<ConfigEditorProps> = props => {
       return;
     }
 
-    // TODO: it seems as though url should be defined on options, but it never is so we have to manually fetch it.
-    // why is url undefined on options? If we can figure that out, we don't need to manually fetch it.
-    const datasource = await getDatasource();
-    const url = (datasource as AdxDataSource).url;
-
-    if (!url) {
-      return;
-    }
-
     try {
-      const schemaData = await refreshSchema(url);
+      const datasource = await getDatasource();
+      const schemaData = await refreshSchema(datasource);
 
       if (!schemaData) {
         return;

--- a/src/components/ConfigEditor/refreshSchema.ts
+++ b/src/components/ConfigEditor/refreshSchema.ts
@@ -1,4 +1,5 @@
 import { getBackendSrv } from '@grafana/runtime';
+import { AdxDataSource } from 'datasource';
 import { ResponseParser } from '../../response_parser';
 import { SchemaMappingOption, SchemaMappingType } from '../../types';
 
@@ -10,23 +11,11 @@ export interface Schema {
   schemaMappingOptions: SchemaMappingOption[];
 }
 
-export async function refreshSchema(baseUrl: string): Promise<Schema> {
+export async function refreshSchema(datasource: AdxDataSource): Promise<Schema> {
   const databases: Array<{ label: string; value: string }> = [];
   const schemaMappingOptions: SchemaMappingOption[] = [];
 
-  const data = {
-    querySource: 'schema',
-    csl: `.show databases schema as json`,
-  };
-
-  const response = await getBackendSrv().datasourceRequest({
-    url: `${baseUrl}/azuredataexplorer/v1/rest/mgmt`,
-    method: 'POST',
-    data: data,
-  });
-
-  const schema = new ResponseParser().parseSchemaResult(response.data);
-
+  const schema = await datasource.getSchema();
   for (const database of Object.values(schema.Databases)) {
     databases.push({
       label: database.Name,

--- a/src/datasource.test.ts
+++ b/src/datasource.test.ts
@@ -21,11 +21,8 @@ describe('AdxDataSource', () => {
     const response = setupTableResponse();
 
     beforeEach(() => {
-      setupBackendSrv({
-        url: 'http://kustodb.com/azuredataexplorer/v1/rest/mgmt',
-        response: response,
-      });
       ctx.ds = new AdxDataSource(ctx.instanceSettings);
+      ctx.ds.getResource = jest.fn().mockResolvedValue(response);
     });
 
     it('should return a list of databases', () => {
@@ -41,11 +38,8 @@ describe('AdxDataSource', () => {
       let queryResults;
 
       beforeEach(async () => {
-        setupBackendSrv({
-          url: 'http://kustodb.com/azuredataexplorer/v1/rest/mgmt',
-          response: setupTableResponse(),
-        });
         ctx.ds = new AdxDataSource(ctx.instanceSettings);
+        ctx.ds.getResource = jest.fn().mockResolvedValue(setupTableResponse());
 
         queryResults = await ctx.ds.metricFindQuery('databases()');
       });
@@ -87,11 +81,8 @@ describe('AdxDataSource', () => {
     };
 
     beforeEach(() => {
-      setupBackendSrv({
-        url: 'http://kustodb.com/azuredataexplorer/v1/rest/mgmt',
-        response: response,
-      });
       ctx.ds = new AdxDataSource(ctx.instanceSettings);
+      ctx.ds.getResource = jest.fn().mockResolvedValue(response);
     });
 
     it('should return a parsed schema', () => {

--- a/src/datasource.ts
+++ b/src/datasource.ts
@@ -12,7 +12,7 @@ import {
 } from '@grafana/data';
 import { map } from 'lodash';
 import { getBackendSrv, BackendSrv, getTemplateSrv, TemplateSrv, DataSourceWithBackend } from '@grafana/runtime';
-import { ResponseParser, DatabaseItem } from './response_parser';
+import { ResponseParser, DatabaseItem, KustoDatabaseList } from './response_parser';
 import {
   AdxDataSourceOptions,
   KustoQuery,
@@ -35,7 +35,6 @@ import { AdxSchemaMapper } from 'schema/AdxSchemaMapper';
 export class AdxDataSource extends DataSourceWithBackend<KustoQuery, AdxDataSourceOptions> {
   private backendSrv: BackendSrv;
   private templateSrv: TemplateSrv;
-  private baseUrl: string;
   private defaultOrFirstDatabase: string;
   url?: string;
   private expressionParser: KustoExpressionParser;
@@ -50,7 +49,6 @@ export class AdxDataSource extends DataSourceWithBackend<KustoQuery, AdxDataSour
 
     this.backendSrv = getBackendSrv();
     this.templateSrv = getTemplateSrv();
-    this.baseUrl = '/azuredataexplorer';
     this.defaultOrFirstDatabase = instanceSettings.jsonData.defaultDatabase;
     this.url = instanceSettings.url;
     this.defaultEditorMode = instanceSettings.jsonData.defaultEditorMode ?? EditorMode.Visual;
@@ -165,14 +163,13 @@ export class AdxDataSource extends DataSourceWithBackend<KustoQuery, AdxDataSour
   }
 
   async getDatabases(): Promise<DatabaseItem[]> {
-    const url = `${this.baseUrl}/v1/rest/mgmt`;
-    const req = {
-      csl: '.show databases',
-    };
-
-    return this.doRequest(url, req).then((response: any) => {
+    return this.getResource('databases').then((response: KustoDatabaseList) => {
       return new ResponseParser().parseDatabases(response);
     });
+  }
+
+  async getResource(path: string): Promise<any> {
+    return super.getResource(path);
   }
 
   async getDefaultOrFirstDatabase(): Promise<string> {
@@ -189,17 +186,7 @@ export class AdxDataSource extends DataSourceWithBackend<KustoQuery, AdxDataSour
   async getSchema(refreshCache = false): Promise<AdxSchema> {
     return cache<AdxSchema>(
       `${this.id}.schema.overview`,
-      () => {
-        const url = `${this.baseUrl}/v1/rest/mgmt`;
-        const req = {
-          querySource: 'schema',
-          csl: `.show databases schema as json`,
-        };
-
-        return this.doRequest(url, req).then(response => {
-          return new ResponseParser().parseSchemaResult(response.data);
-        });
-      },
+      () => this.getResource('schema').then(new ResponseParser().parseSchemaResult),
       refreshCache
     );
   }

--- a/src/datasource.ts
+++ b/src/datasource.ts
@@ -163,12 +163,12 @@ export class AdxDataSource extends DataSourceWithBackend<KustoQuery, AdxDataSour
   }
 
   async getDatabases(): Promise<DatabaseItem[]> {
-    return this.getResource('databases').then((response: KustoDatabaseList) => {
+    return this.getResource<KustoDatabaseList>('databases').then(response => {
       return new ResponseParser().parseDatabases(response);
     });
   }
 
-  async getResource(path: string): Promise<any> {
+  async getResource<T = unknown>(path: string): Promise<any> {
     return super.getResource(path);
   }
 

--- a/src/plugin.json
+++ b/src/plugin.json
@@ -27,28 +27,6 @@
     "version": "%VERSION%",
     "updated": "%TODAY%"
   },
-  "routes": [
-    {
-      "path": "azuredataexplorer",
-      "method": "POST",
-      "url": "{{.JsonData.clusterUrl}}",
-      "headers": [
-        {
-          "name": "x-ms-app",
-          "content": "Grafana-ADX"
-        }
-      ],
-      "tokenAuth": {
-        "url": "https://login.microsoftonline.com/{{.JsonData.tenantId}}/oauth2/token",
-        "params": {
-          "grant_type": "client_credentials",
-          "client_id": "{{.JsonData.clientId}}",
-          "client_secret": "{{.SecureJsonData.clientSecret}}",
-          "resource": "https://kusto.kusto.windows.net"
-        }
-      }
-    }
-  ],
   "dependencies": {
     "grafanaDependency": ">=7.4.0",
     "grafanaVersion": "7.4.x",

--- a/src/response_parser.ts
+++ b/src/response_parser.ts
@@ -28,9 +28,7 @@ export interface Variable {
 
 // API interfaces
 export interface KustoDatabaseList {
-  data: {
-    Tables: KustoDatabaseItem[];
-  };
+  Tables: KustoDatabaseItem[];
 }
 
 export interface KustoDatabaseItem {
@@ -74,11 +72,11 @@ export interface DatabaseItem {
 export class ResponseParser {
   parseDatabases(results: KustoDatabaseList): DatabaseItem[] {
     const databases: DatabaseItem[] = [];
-    if (!results || !results.data || !results.data.Tables || results.data.Tables.length === 0) {
+    if (!results) {
       return databases;
     }
 
-    for (const table of results.data.Tables) {
+    for (const table of results.Tables) {
       for (const row of table.Rows) {
         databases.push({ text: row[5] || row[0], value: row[0] });
       }


### PR DESCRIPTION
**What this PR does**
This PR replaces the usage of the plugin proxy in core grafana with a call resource handler in the adx backend. 

Before this PR, all client side requests went through the plugin proxy in grafana, receiving token based on credentials specified in the route in plugin.json. For reasons explained in [this](https://github.com/grafana/grafana/issues/33809) pr, we don't want to use the proxy in core grafana anymore.

All client side requests now go through the call resource handler that the backend implements. It's a basic http api the currently only has two routes.  The handler use the same http client as the QueryData method does, so auth will be handled in the same way for both types of requests. 

Fixes #232

**Notes to reviewer**
The client KustRequest could use some more refactoring, but I'd like to limit the amount of changes for now since there were no tests for this. 

Also note that the two routes, getSchema and getDatabases are very similar. It could have been just one handler for the management api, accepting a POST method with the payload in the body, but I think this is cleaner for now.  