### PR TITLE
Purge token cache before receiving new ds settings

### DIFF
--- a/pkg/azuredx/client/client_test.go
+++ b/pkg/azuredx/client/client_test.go
@@ -12,7 +12,7 @@ import (
 )
 
 func TestClient(t *testing.T) {
-    testUserLogin := "test-user"
+	testUserLogin := "test-user"
 	t.Run("When server returns 200", func(t *testing.T) {
 		filename := "./testdata/successful-response.json"
 		testDataRes, err := loadTestFile(filename)
@@ -32,19 +32,19 @@ func TestClient(t *testing.T) {
 			ClusterURL: server.URL,
 		}
 		payload := models.RequestPayload{
-			DB: "db-name",
+			DB:  "db-name",
 			CSL: "show databases",
 		}
 		user := &backend.User{
 			Login: testUserLogin,
 		}
-	
+
 		// Use Client & URL from our local test server
 		client := New(server.Client())
 		table, message, err := client.KustoRequest(settings, payload, "schema", user)
-		require.Empty(t, message)	
-		require.NoError(t, err)	
-		require.NotNil(t, table)	
+		require.Empty(t, message)
+		require.NoError(t, err)
+		require.NotNil(t, table)
 	})
 
 	t.Run("When server returns 400", func(t *testing.T) {
@@ -66,18 +66,18 @@ func TestClient(t *testing.T) {
 			ClusterURL: server.URL,
 		}
 		payload := models.RequestPayload{
-			DB: "db-name",
+			DB:  "db-name",
 			CSL: "show databases",
 		}
 		user := &backend.User{
 			Login: testUserLogin,
 		}
-	
+
 		client := New(server.Client())
 		table, message, err := client.KustoRequest(settings, payload, "schema", user)
-		require.Equal(t, "Request is invalid and cannot be processed: Syntax error: SYN0002: A recognition error occurred. [line:position=1:9]. Query: 'PerfTest take 5'", message)	
-		require.Nil(t, table)	
-		require.NotNil(t, err)	
+		require.Equal(t, "Request is invalid and cannot be processed: Syntax error: SYN0002: A recognition error occurred. [line:position=1:9]. Query: 'PerfTest take 5'", message)
+		require.Nil(t, table)
+		require.NotNil(t, err)
 	})
 }
 

--- a/pkg/azuredx/tokenprovider/token_cache.go
+++ b/pkg/azuredx/tokenprovider/token_cache.go
@@ -22,6 +22,7 @@ type TokenCredential interface {
 
 type ConcurrentTokenCache interface {
 	GetAccessToken(ctx context.Context, credential TokenCredential, scopes []string) (string, error)
+	Purge()
 }
 
 func NewConcurrentTokenCache() ConcurrentTokenCache {
@@ -51,6 +52,10 @@ type scopesCacheEntry struct {
 
 func (c *tokenCacheImpl) GetAccessToken(ctx context.Context, credential TokenCredential, scopes []string) (string, error) {
 	return c.getEntryFor(credential).getAccessToken(ctx, scopes)
+}
+
+func (c *tokenCacheImpl) Purge() {
+	c.cache = sync.Map{}
 }
 
 func (c *tokenCacheImpl) getEntryFor(credential TokenCredential) *credentialCacheEntry {

--- a/pkg/azuredx/tokenprovider/token_provider.go
+++ b/pkg/azuredx/tokenprovider/token_provider.go
@@ -11,7 +11,6 @@ import (
 )
 
 var (
-	tokenCache = NewConcurrentTokenCache()
 )
 
 var (
@@ -25,7 +24,10 @@ type AccessTokenProvider struct {
 	authority string
 	secret    string
 	scopes    []string
+	cache 	  ConcurrentTokenCache
 }
+
+var newClientSecretCredential = azidentity.NewClientSecretCredential
 
 func NewAccessTokenProvider(
 	clientId string, tenantId string, authority string, secret string, scopes []string) *AccessTokenProvider {
@@ -35,12 +37,13 @@ func NewAccessTokenProvider(
 		authority: authority,
 		secret:    secret,
 		scopes:    scopes,
+		cache:     NewConcurrentTokenCache(),
 	}
 }
 
 func (provider *AccessTokenProvider) GetAccessToken(ctx context.Context) (string, error) {
 	credential := provider.getClientSecretCredential()
-	accessToken, err := tokenCache.GetAccessToken(ctx, credential, provider.scopes)
+	accessToken, err := provider.cache.GetAccessToken(ctx, credential, provider.scopes)
 	if err != nil {
 		return "", err
 	}

--- a/pkg/azuredx/tokenprovider/token_provider.go
+++ b/pkg/azuredx/tokenprovider/token_provider.go
@@ -26,7 +26,7 @@ type AccessTokenProvider struct {
 	cache     ConcurrentTokenCache
 }
 
-func NewAccessTokenProvider(
+func NewAccessTokenProvider(cache ConcurrentTokenCache,
 	clientId string, tenantId string, authority string, secret string, scopes []string) *AccessTokenProvider {
 	return &AccessTokenProvider{
 		clientID:  clientId,
@@ -34,7 +34,7 @@ func NewAccessTokenProvider(
 		authority: authority,
 		secret:    secret,
 		scopes:    scopes,
-		cache:     NewConcurrentTokenCache(),
+		cache:     cache,
 	}
 }
 

--- a/pkg/azuredx/tokenprovider/token_provider.go
+++ b/pkg/azuredx/tokenprovider/token_provider.go
@@ -10,8 +10,7 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/azidentity"
 )
 
-var (
-)
+var ()
 
 var (
 	// timeNow makes it possible to test usage of time
@@ -24,7 +23,7 @@ type AccessTokenProvider struct {
 	authority string
 	secret    string
 	scopes    []string
-	cache 	  ConcurrentTokenCache
+	cache     ConcurrentTokenCache
 }
 
 func NewAccessTokenProvider(

--- a/pkg/azuredx/tokenprovider/token_provider.go
+++ b/pkg/azuredx/tokenprovider/token_provider.go
@@ -10,8 +10,6 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/azidentity"
 )
 
-var ()
-
 var (
 	// timeNow makes it possible to test usage of time
 	timeNow = time.Now

--- a/pkg/azuredx/tokenprovider/token_provider.go
+++ b/pkg/azuredx/tokenprovider/token_provider.go
@@ -27,8 +27,6 @@ type AccessTokenProvider struct {
 	cache 	  ConcurrentTokenCache
 }
 
-var newClientSecretCredential = azidentity.NewClientSecretCredential
-
 func NewAccessTokenProvider(
 	clientId string, tenantId string, authority string, secret string, scopes []string) *AccessTokenProvider {
 	return &AccessTokenProvider{


### PR DESCRIPTION
The token cache life span is currently equal to the lifespan of the backend. However, the cache was never purged. This PR purges the cache before the datasource receives new settings.

Token provider tests are coming in a separate PR for handling national clouds. 