### PR TITLE
Add national clouds support

### DIFF
--- a/pkg/azuredx/client/client.go
+++ b/pkg/azuredx/client/client.go
@@ -74,10 +74,10 @@ func (c *Client) KustoRequest(url string, payload models.RequestPayload, additio
 	}
 
 	resp, err := c.httpClient.Do(req)
-	statusCode := resp.StatusCode
 	if err != nil {
-		return nil, statusCode, "", err
+		return nil, 500, "", err
 	}
+	statusCode := resp.StatusCode
 	defer resp.Body.Close()
 	if resp.StatusCode > 299 {
 		bodyBytes, err := ioutil.ReadAll(resp.Body)

--- a/pkg/azuredx/datasource.go
+++ b/pkg/azuredx/datasource.go
@@ -25,6 +25,7 @@ type AzureDataExplorer struct {
 }
 
 var tokenCache = tokenprovider.NewConcurrentTokenCache()
+const AdxScope = "https://kusto.kusto.windows.net/.default"
 
 func NewDatasource(settings backend.DataSourceInstanceSettings) (instancemgmt.Instance, error) {
 	adx := &AzureDataExplorer{}
@@ -35,7 +36,7 @@ func NewDatasource(settings backend.DataSourceInstanceSettings) (instancemgmt.In
 	}
 	adx.settings = datasourceSettings
 
-	tokenProvider := tokenprovider.NewAccessTokenProvider(tokenCache, datasourceSettings.ClientID, datasourceSettings.TenantID, "AzurePublic", datasourceSettings.Secret, []string{"https://kusto.kusto.windows.net/.default"})
+	tokenProvider := tokenprovider.NewAccessTokenProvider(tokenCache, datasourceSettings.ClientID, datasourceSettings.TenantID, datasourceSettings.AzureCloud, datasourceSettings.Secret, []string{"https://kusto.kusto.windows.net/.default"})
 
 	httpClientProvider := sdkhttpclient.NewProvider(sdkhttpclient.ProviderOptions{
 		Middlewares: []sdkhttpclient.Middleware{

--- a/pkg/azuredx/models/settings.go
+++ b/pkg/azuredx/models/settings.go
@@ -20,6 +20,7 @@ type DatasourceSettings struct {
 	CacheMaxAge        string `json:"cacheMaxAge"`
 	DynamicCaching     bool   `json:"dynamicCaching"`
 	EnableUserTracking bool   `json:"enableUserTracking"`
+	AzureCloud         string `json:"azureCloud"`
 
 	// QueryTimeoutRaw is a duration string set in the datasource settings and corresponds
 	// to the server execution timeout.

--- a/pkg/azuredx/tokenprovider/clouds.go
+++ b/pkg/azuredx/tokenprovider/clouds.go
@@ -1,0 +1,8 @@
+package tokenprovider
+
+// Must be in synch with azure cloud options in ConfigEditor.tsx
+const (
+	AzurePublic       = "azuremonitor"
+	AzureChina        = "chinaazuremonitor"
+	AzureUSGovernment = "govazuremonitor"
+)

--- a/pkg/azuredx/tokenprovider/token_provider_test.go
+++ b/pkg/azuredx/tokenprovider/token_provider_test.go
@@ -1,0 +1,116 @@
+package tokenprovider
+
+import (
+	"context"
+	"testing"
+
+	"github.com/Azure/azure-sdk-for-go/sdk/azidentity"
+	"github.com/stretchr/testify/require"
+)
+
+const TestClientId = "3c882424-c381-45c0-a123-0a62ebc989dc"
+const TestTenantId = "b931e0dd-f42c-444a-83a9-63de6f2d771a"
+const TestClientSecret = "3093e953-91e1-48f4-9ad0-e8f750c38f93"
+const Scope = "https://kusto.kusto.windows.net/.default"
+const ExpectedToken string = "4cb83b87-0ffb-4abd-82f6-48a8c08afc53"
+
+type tokenCacheFake struct{}
+
+func (c *tokenCacheFake) GetAccessToken(_ context.Context, credential TokenCredential, scopes []string) (string, error) {
+	credential.Init()
+	return ExpectedToken, nil
+}
+
+func (c *tokenCacheFake) Purge() {
+	panic("not implemented")
+}
+
+func TestTokenProvider(t *testing.T) {
+	ctx := context.Background()
+
+	newClientSecretCredentialOriginal := newClientSecretCredential
+
+	tokenCacheFake := &tokenCacheFake{}
+
+	t.Cleanup(func() {
+		newClientSecretCredential = newClientSecretCredentialOriginal
+	})
+
+	t.Run("should resolve public cloud host when nothing is specified", func(t *testing.T) {
+		newClientSecretCredential = func(tenantID string, clientID string, clientSecret string, options *azidentity.ClientSecretCredentialOptions) (*azidentity.ClientSecretCredential, error) {
+			require.Equal(t, TestClientId, clientID)
+			require.Equal(t, TestTenantId, tenantID)
+			require.Equal(t, TestClientSecret, clientSecret)
+			require.Equal(t, azidentity.AzurePublicCloud, options.AuthorityHost)
+
+			return &azidentity.ClientSecretCredential{}, nil
+		}
+
+		// getAccessToken = func(ctx context.Context, credential TokenCredential, scopes []string) (string, error) {
+		// 	credential.Init()
+		// 	return ExpectedToken, nil
+		// }
+		provider := NewAccessTokenProvider(tokenCacheFake, TestClientId, TestTenantId, "", TestClientSecret, []string{Scope})
+		token, err := provider.GetAccessToken(ctx)
+		require.Nil(t, err)
+		require.Equal(t, ExpectedToken, token)
+	})
+
+	t.Run("should resolve public cloud host when public cloud is specified", func(t *testing.T) {
+		newClientSecretCredential = func(tenantID string, clientID string, clientSecret string, options *azidentity.ClientSecretCredentialOptions) (*azidentity.ClientSecretCredential, error) {
+			require.Equal(t, TestClientId, clientID)
+			require.Equal(t, TestTenantId, tenantID)
+			require.Equal(t, TestClientSecret, clientSecret)
+			require.Equal(t, azidentity.AzurePublicCloud, options.AuthorityHost)
+
+			return &azidentity.ClientSecretCredential{}, nil
+		}
+
+		// getAccessToken = func(ctx context.Context, credential TokenCredential, scopes []string) (string, error) {
+		// 	credential.Init()
+		// 	return ExpectedToken, nil
+		// }
+		provider := NewAccessTokenProvider(tokenCacheFake, TestClientId, TestTenantId, AzurePublic, TestClientSecret, []string{Scope})
+		token, err := provider.GetAccessToken(ctx)
+		require.Nil(t, err)
+		require.Equal(t, ExpectedToken, token)
+	})
+
+	t.Run("should resolve china cloud host when china is specified", func(t *testing.T) {
+		newClientSecretCredential = func(tenantID string, clientID string, clientSecret string, options *azidentity.ClientSecretCredentialOptions) (*azidentity.ClientSecretCredential, error) {
+			require.Equal(t, TestClientId, clientID)
+			require.Equal(t, TestTenantId, tenantID)
+			require.Equal(t, TestClientSecret, clientSecret)
+			require.Equal(t, azidentity.AzureChina, options.AuthorityHost)
+
+			return &azidentity.ClientSecretCredential{}, nil
+		}
+		// getAccessToken = func(ctx context.Context, credential TokenCredential, scopes []string) (string, error) {
+		// 	credential.Init()
+		// 	return ExpectedToken, nil
+		// }
+		provider := NewAccessTokenProvider(tokenCacheFake, TestClientId, TestTenantId, AzureChina, TestClientSecret, []string{Scope})
+		token, err := provider.GetAccessToken(ctx)
+		require.Nil(t, err)
+		require.Equal(t, ExpectedToken, token)
+	})
+
+	t.Run("should resolve us gov cloud host when us gov is specified", func(t *testing.T) {
+		newClientSecretCredential = func(tenantID string, clientID string, clientSecret string, options *azidentity.ClientSecretCredentialOptions) (*azidentity.ClientSecretCredential, error) {
+			require.Equal(t, TestClientId, clientID)
+			require.Equal(t, TestTenantId, tenantID)
+			require.Equal(t, TestClientSecret, clientSecret)
+			require.Equal(t, azidentity.AzureGovernment, options.AuthorityHost)
+
+			return &azidentity.ClientSecretCredential{}, nil
+		}
+		// getAccessToken = func(ctx context.Context, credential TokenCredential, scopes []string) (string, error) {
+		// 	credential.Init()
+		// 	return ExpectedToken, nil
+		// }
+		provider := NewAccessTokenProvider(tokenCacheFake, TestClientId, TestTenantId, AzureUSGovernment, TestClientSecret, []string{Scope})
+		token, err := provider.GetAccessToken(ctx)
+		require.Nil(t, err)
+		require.Equal(t, ExpectedToken, token)
+	})
+}

--- a/pkg/azuredx/tokenprovider/token_provider_test.go
+++ b/pkg/azuredx/tokenprovider/token_provider_test.go
@@ -46,10 +46,6 @@ func TestTokenProvider(t *testing.T) {
 			return &azidentity.ClientSecretCredential{}, nil
 		}
 
-		// getAccessToken = func(ctx context.Context, credential TokenCredential, scopes []string) (string, error) {
-		// 	credential.Init()
-		// 	return ExpectedToken, nil
-		// }
 		provider := NewAccessTokenProvider(tokenCacheFake, TestClientId, TestTenantId, "", TestClientSecret, []string{Scope})
 		token, err := provider.GetAccessToken(ctx)
 		require.Nil(t, err)
@@ -66,10 +62,6 @@ func TestTokenProvider(t *testing.T) {
 			return &azidentity.ClientSecretCredential{}, nil
 		}
 
-		// getAccessToken = func(ctx context.Context, credential TokenCredential, scopes []string) (string, error) {
-		// 	credential.Init()
-		// 	return ExpectedToken, nil
-		// }
 		provider := NewAccessTokenProvider(tokenCacheFake, TestClientId, TestTenantId, AzurePublic, TestClientSecret, []string{Scope})
 		token, err := provider.GetAccessToken(ctx)
 		require.Nil(t, err)
@@ -85,10 +77,7 @@ func TestTokenProvider(t *testing.T) {
 
 			return &azidentity.ClientSecretCredential{}, nil
 		}
-		// getAccessToken = func(ctx context.Context, credential TokenCredential, scopes []string) (string, error) {
-		// 	credential.Init()
-		// 	return ExpectedToken, nil
-		// }
+
 		provider := NewAccessTokenProvider(tokenCacheFake, TestClientId, TestTenantId, AzureChina, TestClientSecret, []string{Scope})
 		token, err := provider.GetAccessToken(ctx)
 		require.Nil(t, err)
@@ -104,10 +93,7 @@ func TestTokenProvider(t *testing.T) {
 
 			return &azidentity.ClientSecretCredential{}, nil
 		}
-		// getAccessToken = func(ctx context.Context, credential TokenCredential, scopes []string) (string, error) {
-		// 	credential.Init()
-		// 	return ExpectedToken, nil
-		// }
+
 		provider := NewAccessTokenProvider(tokenCacheFake, TestClientId, TestTenantId, AzureUSGovernment, TestClientSecret, []string{Scope})
 		token, err := provider.GetAccessToken(ctx)
 		require.Nil(t, err)

--- a/pkg/azuredx/tokenprovider/token_provider_test.go
+++ b/pkg/azuredx/tokenprovider/token_provider_test.go
@@ -17,7 +17,10 @@ const ExpectedToken string = "4cb83b87-0ffb-4abd-82f6-48a8c08afc53"
 type tokenCacheFake struct{}
 
 func (c *tokenCacheFake) GetAccessToken(_ context.Context, credential TokenCredential, scopes []string) (string, error) {
-	credential.Init()
+	err := credential.Init()
+	if err != nil {
+		return "", err
+	}
 	return ExpectedToken, nil
 }
 

--- a/src/components/ConfigEditor/ConnectionConfig.tsx
+++ b/src/components/ConfigEditor/ConnectionConfig.tsx
@@ -59,7 +59,7 @@ const ConnectionConfig: React.FC<ConnectionConfigProps> = ({
 
   return (
     <FieldSet label="Connection Details">
-      <InlineField label="Azure cloud" labelWidth={26} tooltip="Select an Azure Cloud.">
+      <InlineField label="Azure cloud" labelWidth={26} tooltip="Select an Azure Cloud." required>
         <Select
           options={azureClouds}
           value={azureClouds.find(v => v.value === jsonData.azureCloud)}

--- a/src/components/ConfigEditor/ConnectionConfig.tsx
+++ b/src/components/ConfigEditor/ConnectionConfig.tsx
@@ -1,9 +1,14 @@
-import { DataSourcePluginOptionsEditorProps } from '@grafana/data';
-import { FieldSet, InlineField, Input, LegacyForms } from '@grafana/ui';
-import React from 'react';
+import { DataSourcePluginOptionsEditorProps, SelectableValue } from '@grafana/data';
+import { FieldSet, InlineField, Input, LegacyForms, Select } from '@grafana/ui';
+import React, { useEffect } from 'react';
 import { AdxDataSourceOptions, AdxDataSourceSecureOptions } from 'types';
 
 const { SecretFormField } = LegacyForms;
+const azureClouds = [
+  { value: 'azuremonitor', label: 'Azure' },
+  { value: 'govazuremonitor', label: 'Azure US Government' },
+  { value: 'chinaazuremonitor', label: 'Azure China' },
+] as SelectableValue[];
 
 interface ConnectionConfigProps
   extends DataSourcePluginOptionsEditorProps<AdxDataSourceOptions, AdxDataSourceSecureOptions> {
@@ -18,6 +23,13 @@ const ConnectionConfig: React.FC<ConnectionConfigProps> = ({
   handleClearClientSecret,
 }) => {
   const { jsonData, secureJsonData, secureJsonFields } = options;
+
+  // Set some default values
+  useEffect(() => {
+    if (!jsonData.azureCloud) {
+      updateJsonData('azureCloud', azureClouds[0].value);
+    }
+  }, [jsonData.azureCloud, updateJsonData]);
 
   const handleClientSecretChange = (ev?: React.ChangeEvent<HTMLInputElement>) => {
     onOptionsChange({
@@ -47,6 +59,18 @@ const ConnectionConfig: React.FC<ConnectionConfigProps> = ({
 
   return (
     <FieldSet label="Connection Details">
+      <InlineField label="Azure cloud" labelWidth={26} tooltip="Select an Azure Cloud.">
+        <Select
+          options={azureClouds}
+          value={azureClouds.find(v => v.value === jsonData.azureCloud)}
+          onChange={(change: SelectableValue<string>) =>
+            updateJsonData('azureCloud', change.value ? change.value : azureClouds[0].value)
+          }
+          isClearable={false}
+          width={60}
+        />
+      </InlineField>
+
       <InlineField label="Cluster URL" labelWidth={26} tooltip="The cluster url for your Azure Data Explorer database.">
         <Input
           value={jsonData.clusterUrl}

--- a/src/components/ConfigEditor/ConnectionConfig.tsx
+++ b/src/components/ConfigEditor/ConnectionConfig.tsx
@@ -4,7 +4,7 @@ import React, { useEffect } from 'react';
 import { AdxDataSourceOptions, AdxDataSourceSecureOptions, AzureCloudType } from 'types';
 
 const { SecretFormField } = LegacyForms;
-const azureClouds: SelectableValue<AzureCloudType>[] = [
+const azureClouds: Array<SelectableValue<AzureCloudType>> = [
   { value: AzureCloudType.AzurePublic, label: 'Azure' },
   { value: AzureCloudType.AzureUSGovernment, label: 'Azure US Government' },
   { value: AzureCloudType.AzureChina, label: 'Azure China' },

--- a/src/components/ConfigEditor/ConnectionConfig.tsx
+++ b/src/components/ConfigEditor/ConnectionConfig.tsx
@@ -7,7 +7,7 @@ const { SecretFormField } = LegacyForms;
 const azureClouds: SelectableValue<AzureCloudType>[] = [
   { value: AzureCloudType.AzurePublic, label: 'Azure' },
   { value: AzureCloudType.AzureUSGovernment, label: 'Azure US Government' },
-  { value: AzureCloudType.AzureUSGovernment, label: 'Azure China' },
+  { value: AzureCloudType.AzureChina, label: 'Azure China' },
 ];
 
 interface ConnectionConfigProps

--- a/src/components/ConfigEditor/ConnectionConfig.tsx
+++ b/src/components/ConfigEditor/ConnectionConfig.tsx
@@ -1,14 +1,14 @@
 import { DataSourcePluginOptionsEditorProps, SelectableValue } from '@grafana/data';
 import { FieldSet, InlineField, Input, LegacyForms, Select } from '@grafana/ui';
 import React, { useEffect } from 'react';
-import { AdxDataSourceOptions, AdxDataSourceSecureOptions } from 'types';
+import { AdxDataSourceOptions, AdxDataSourceSecureOptions, AzureCloudType } from 'types';
 
 const { SecretFormField } = LegacyForms;
-const azureClouds = [
-  { value: 'azuremonitor', label: 'Azure' },
-  { value: 'govazuremonitor', label: 'Azure US Government' },
-  { value: 'chinaazuremonitor', label: 'Azure China' },
-] as SelectableValue[];
+const azureClouds: SelectableValue<AzureCloudType>[] = [
+  { value: AzureCloudType.AzurePublic, label: 'Azure' },
+  { value: AzureCloudType.AzureUSGovernment, label: 'Azure US Government' },
+  { value: AzureCloudType.AzureUSGovernment, label: 'Azure China' },
+];
 
 interface ConnectionConfigProps
   extends DataSourcePluginOptionsEditorProps<AdxDataSourceOptions, AdxDataSourceSecureOptions> {
@@ -27,7 +27,7 @@ const ConnectionConfig: React.FC<ConnectionConfigProps> = ({
   // Set some default values
   useEffect(() => {
     if (!jsonData.azureCloud) {
-      updateJsonData('azureCloud', azureClouds[0].value);
+      updateJsonData('azureCloud', AzureCloudType.AzurePublic);
     }
   }, [jsonData.azureCloud, updateJsonData]);
 
@@ -63,8 +63,8 @@ const ConnectionConfig: React.FC<ConnectionConfigProps> = ({
         <Select
           options={azureClouds}
           value={azureClouds.find(v => v.value === jsonData.azureCloud)}
-          onChange={(change: SelectableValue<string>) =>
-            updateJsonData('azureCloud', change.value ? change.value : azureClouds[0].value)
+          onChange={(change: SelectableValue<AzureCloudType>) =>
+            updateJsonData('azureCloud', change.value ? change.value : AzureCloudType.AzurePublic)
           }
           isClearable={false}
           width={60}

--- a/src/datasource.ts
+++ b/src/datasource.ts
@@ -36,7 +36,7 @@ export class AdxDataSource extends DataSourceWithBackend<KustoQuery, AdxDataSour
   private backendSrv: BackendSrv;
   private templateSrv: TemplateSrv;
   private defaultOrFirstDatabase: string;
-  url?: string;
+  private url?: string;
   private expressionParser: KustoExpressionParser;
   private defaultEditorMode: EditorMode;
   private schemaMapper: AdxSchemaMapper;

--- a/src/types.ts
+++ b/src/types.ts
@@ -83,6 +83,7 @@ export enum SchemaMappingType {
   materializedView = 'materializedView',
 }
 export interface AdxDataSourceOptions extends DataSourceJsonData {
+  azureCloud?: string;
   defaultDatabase: string;
   minimalCache: number;
   defaultEditorMode: EditorMode;

--- a/src/types.ts
+++ b/src/types.ts
@@ -83,7 +83,7 @@ export enum SchemaMappingType {
   materializedView = 'materializedView',
 }
 export interface AdxDataSourceOptions extends DataSourceJsonData {
-  azureCloud?: string;
+  azureCloud?: AzureCloudType;
   defaultDatabase: string;
   minimalCache: number;
   defaultEditorMode: EditorMode;
@@ -134,3 +134,10 @@ export interface AdxFunctionSchema {
 }
 
 export interface AdxFunctionInputParameterSchema extends AdxColumnSchema {}
+
+// must be in synch with clouds.go
+export enum AzureCloudType {
+  AzurePublic = 'azuremonitor',
+  AzureUSGovernment = 'govazuremonitor',
+  AzureChina = 'chinaazuremonitor',
+}


### PR DESCRIPTION
Adding support for national clouds. Been trying to keep names aligned with what we have in Azure Monitor. Will make things easier when we break these things out to a separate go and npm package. 

Will change merge base as soon as the call-resource-handler branch is merged.

Fixes #16
Closes #217