### PR TITLE
Bugfix: Fixed issue when typing vs copy/pasting client secret in config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Change Log
 
+## [next]
+- Bugfix: Fixed issue when typing vs copy/pasting client secret in configuration
+
 ## [3.5.0]
 
 - Add support for national clouds

--- a/src/components/ConfigEditor/ConnectionConfig.tsx
+++ b/src/components/ConfigEditor/ConnectionConfig.tsx
@@ -139,7 +139,7 @@ const ConnectionConfig: React.FC<ConnectionConfigProps> = ({
         inputWidth={30}
         placeholder=""
         onReset={() => handleClearClientSecret()}
-        onChange={handleClientSecretChange}
+        onBlur={handleClientSecretChange}
         isConfigured={!!secureJsonData?.clientSecret || !!secureJsonFields?.clientSecret}
         tooltip={clientSecretTooltip}
       />

--- a/src/components/ConfigEditor/ConnectionConfig.tsx
+++ b/src/components/ConfigEditor/ConnectionConfig.tsx
@@ -139,8 +139,8 @@ const ConnectionConfig: React.FC<ConnectionConfigProps> = ({
         inputWidth={30}
         placeholder=""
         onReset={() => handleClearClientSecret()}
-        onBlur={handleClientSecretChange}
-        isConfigured={!!secureJsonData?.clientSecret || !!secureJsonFields?.clientSecret}
+        onChange={handleClientSecretChange}
+        isConfigured={!!secureJsonFields?.clientSecret}
         tooltip={clientSecretTooltip}
       />
     </FieldSet>


### PR DESCRIPTION
Fixes: https://github.com/grafana/azure-data-explorer-datasource/issues/237

To reproduce on master branch:
trying typing in client secret instead of copying and pasting a client secret, you'll notice it loses focus when it should not. 