### PR TITLE
Fixed token scope for Azure Government ADX access

### DIFF
--- a/pkg/azuredx/datasource.go
+++ b/pkg/azuredx/datasource.go
@@ -26,8 +26,6 @@ type AzureDataExplorer struct {
 
 var tokenCache = tokenprovider.NewConcurrentTokenCache()
 
-const AdxScope = "https://kusto.kusto.windows.net/.default"
-
 func NewDatasource(settings backend.DataSourceInstanceSettings) (instancemgmt.Instance, error) {
 	adx := &AzureDataExplorer{}
 	datasourceSettings := &models.DatasourceSettings{}

--- a/pkg/azuredx/datasource.go
+++ b/pkg/azuredx/datasource.go
@@ -35,10 +35,8 @@ func NewDatasource(settings backend.DataSourceInstanceSettings) (instancemgmt.In
 	}
 	adx.settings = datasourceSettings
 
-	adxScope := "https://kusto.kusto.windows.net/.default"
-	if datasourceSettings.AzureCloud == "govazuremonitor" {
-		adxScope = datasourceSettings.ClusterURL + "/.default"
-	}
+	adxScope := getAdxScope(datasourceSettings.AzureCloud, datasourceSettings.ClusterURL)
+
 	tokenProvider := tokenprovider.NewAccessTokenProvider(tokenCache, datasourceSettings.ClientID, datasourceSettings.TenantID, datasourceSettings.AzureCloud, datasourceSettings.Secret, []string{adxScope})
 
 	httpClientProvider := sdkhttpclient.NewProvider(sdkhttpclient.ProviderOptions{
@@ -65,6 +63,16 @@ func NewDatasource(settings backend.DataSourceInstanceSettings) (instancemgmt.In
 	adx.CallResourceHandler = httpadapter.New(mux)
 
 	return adx, nil
+}
+
+func getAdxScope(cloudName string, clusterUrl string) string {
+	switch cloudName {
+	case tokenprovider.AzureChina:
+		return "https://kusto.kusto.chinacloudapi.cn/.default"
+	case tokenprovider.AzureUSGovernment:
+		return clusterUrl + "/.default"
+	}
+	return "https://kusto.kusto.windows.net/.default"
 }
 
 func (adx *AzureDataExplorer) Dispose() {

--- a/pkg/azuredx/datasource.go
+++ b/pkg/azuredx/datasource.go
@@ -25,6 +25,7 @@ type AzureDataExplorer struct {
 }
 
 var tokenCache = tokenprovider.NewConcurrentTokenCache()
+
 const AdxScope = "https://kusto.kusto.windows.net/.default"
 
 func NewDatasource(settings backend.DataSourceInstanceSettings) (instancemgmt.Instance, error) {
@@ -36,7 +37,11 @@ func NewDatasource(settings backend.DataSourceInstanceSettings) (instancemgmt.In
 	}
 	adx.settings = datasourceSettings
 
-	tokenProvider := tokenprovider.NewAccessTokenProvider(tokenCache, datasourceSettings.ClientID, datasourceSettings.TenantID, datasourceSettings.AzureCloud, datasourceSettings.Secret, []string{"https://kusto.kusto.windows.net/.default"})
+	adxScope := "https://kusto.kusto.windows.net/.default"
+	if datasourceSettings.AzureCloud == "govazuremonitor" {
+		adxScope = datasourceSettings.ClusterURL + "/.default"
+	}
+	tokenProvider := tokenprovider.NewAccessTokenProvider(tokenCache, datasourceSettings.ClientID, datasourceSettings.TenantID, datasourceSettings.AzureCloud, datasourceSettings.Secret, []string{adxScope})
 
 	httpClientProvider := sdkhttpclient.NewProvider(sdkhttpclient.ProviderOptions{
 		Middlewares: []sdkhttpclient.Middleware{


### PR DESCRIPTION
We run this version of the plugin for customers in the public and government cloud and thus tested it in production. I can't speak for the China Cloud as I don't have access to such environment.