### PR TITLE
Untangle Response Mapping

### DIFF
--- a/pkg/azuredx/client/client_test.go
+++ b/pkg/azuredx/client/client_test.go
@@ -36,9 +36,7 @@ func TestClient(t *testing.T) {
 		}
 
 		client := New(server.Client())
-		table, statusCode, message, err := client.KustoRequest(server.URL, payload, nil)
-		require.Equal(t, http.StatusOK, statusCode)
-		require.Empty(t, message)
+		table, err := client.KustoRequest(server.URL, payload, nil)
 		require.NoError(t, err)
 		require.NotNil(t, table)
 	})
@@ -65,11 +63,10 @@ func TestClient(t *testing.T) {
 		}
 
 		client := New(server.Client())
-		table, statusCode, message, err := client.KustoRequest(server.URL, payload, nil)
-		require.Equal(t, http.StatusBadRequest, statusCode)
-		require.Equal(t, "Request is invalid and cannot be processed: Syntax error: SYN0002: A recognition error occurred. [line:position=1:9]. Query: 'PerfTest take 5'", message)
+		table, err := client.KustoRequest(server.URL, payload, nil)
 		require.Nil(t, table)
 		require.NotNil(t, err)
+		require.Contains(t, err.Error(), "Request is invalid and cannot be processed: Syntax error: SYN0002: A recognition error occurred. [line:position=1:9]. Query: 'PerfTest take 5'")
 	})
 
 	t.Run("Headers are set", func(t *testing.T) {
@@ -93,10 +90,8 @@ func TestClient(t *testing.T) {
 		}
 
 		client := New(server.Client())
-		table, statusCode, message, err := client.KustoRequest(server.URL, payload, headers)
-		require.NotNil(t, statusCode)
+		table, err := client.KustoRequest(server.URL, payload, headers)
 		require.Nil(t, table)
-		require.NotNil(t, message)
 		require.NotNil(t, err)
 	})
 }

--- a/pkg/azuredx/datasource.go
+++ b/pkg/azuredx/datasource.go
@@ -13,7 +13,8 @@ import (
 	"github.com/grafana/grafana-plugin-sdk-go/backend/instancemgmt"
 	"github.com/grafana/grafana-plugin-sdk-go/backend/resource/httpadapter"
 	"github.com/grafana/grafana-plugin-sdk-go/data"
-	jsoniter "github.com/json-iterator/go"
+	// 100% compatible drop-in replacement of "encoding/json"
+	json "github.com/json-iterator/go"
 	"golang.org/x/net/context"
 )
 
@@ -75,7 +76,7 @@ func (adx *AzureDataExplorer) QueryData(ctx context.Context, req *backend.QueryD
 	res := backend.NewQueryDataResponse()
 
 	for _, q := range req.Queries {
-		res.Responses[q.RefID] = adx.handleQuery(q, req.PluginContext.User)
+		res.Responses[q.RefID] = adx.dataQuery(q, req.PluginContext.User)
 	}
 
 	return res, nil
@@ -97,38 +98,34 @@ func (adx *AzureDataExplorer) CheckHealth(ctx context.Context, req *backend.Chec
 	}, nil
 }
 
-func (adx *AzureDataExplorer) handleQuery(q backend.DataQuery, user *backend.User) backend.DataResponse {
-	resp := backend.DataResponse{}
-	qm := &models.QueryModel{}
-
-	err := jsoniter.Unmarshal(q.JSON, qm)
+func (adx *AzureDataExplorer) dataQuery(q backend.DataQuery, user *backend.User) backend.DataResponse {
+	var qm models.QueryModel
+	err := json.Unmarshal(q.JSON, &qm)
 	if err != nil {
-		resp.Error = err
-		return resp
+		return backend.DataResponse{Error: fmt.Errorf("malformed request query: %w", err)}
 	}
 
-	cs := models.NewCacheSettings(adx.settings, &q, qm)
+	cs := models.NewCacheSettings(adx.settings, &q, &qm)
 	qm.MacroData = models.NewMacroData(cs.TimeRange, q.Interval.Milliseconds())
-
 	if err := qm.Interpolate(); err != nil {
-		resp.Error = err
-		return resp
+		return backend.DataResponse{Error: err}
 	}
+	props := models.NewConnectionProperties(adx.settings, cs)
 
-	interpolatedQuery := qm.Query
-
-	appendFrame := func(f *data.Frame) {
-		resp.Frames = append(resp.Frames, f)
-	}
-
-	errorWithFrame := func(err error) {
-		fm := &data.FrameMeta{ExecutedQueryString: interpolatedQuery}
-		appendFrame(&data.Frame{RefID: q.RefID, Meta: fm})
+	resp, err := adx.modelQuery(qm, props, user)
+	if err != nil {
+		resp.Frames = append(resp.Frames, &data.Frame{
+			RefID: q.RefID,
+			Meta:  &data.FrameMeta{ExecutedQueryString: qm.Query},
+		})
 		resp.Error = err
 	}
+	return resp
+}
 
+func (adx *AzureDataExplorer) modelQuery(q models.QueryModel, props *models.Properties, user *backend.User) (backend.DataResponse, error) {
 	headers := map[string]string{}
-	msClientRequestIDHeader := fmt.Sprintf("KGC.%s;%s", qm.QuerySource, uuid.Must(uuid.NewRandom()).String())
+	msClientRequestIDHeader := fmt.Sprintf("KGC.%s;%s", q.QuerySource, uuid.Must(uuid.NewRandom()).String())
 	if adx.settings.EnableUserTracking {
 		if user != nil {
 			msClientRequestIDHeader += fmt.Sprintf(";%v", user.Login)
@@ -137,32 +134,29 @@ func (adx *AzureDataExplorer) handleQuery(q backend.DataQuery, user *backend.Use
 	}
 	headers["x-ms-client-request-id"] = msClientRequestIDHeader
 
-	var tableRes *models.TableResponse
-	tableRes, err = adx.client.KustoRequest(adx.settings.ClusterURL+"/v1/rest/query", models.RequestPayload{
-		CSL:         qm.Query,
-		DB:          qm.Database,
-		Properties:  models.NewConnectionProperties(adx.settings, cs),
-		QuerySource: qm.QuerySource,
+	tableRes, err := adx.client.KustoRequest(adx.settings.ClusterURL+"/v1/rest/query", models.RequestPayload{
+		CSL:         q.Query,
+		DB:          q.Database,
+		Properties:  props,
+		QuerySource: q.QuerySource,
 	}, headers)
-
 	if err != nil {
 		backend.Logger.Debug("error building kusto request", "error", err.Error())
-		errorWithFrame(err)
-		return resp
+		return backend.DataResponse{}, err
 	}
-	switch qm.Format {
+
+	var resp backend.DataResponse
+	switch q.Format {
 	case "table":
-		resp.Frames, err = tableRes.ToDataFrames(interpolatedQuery)
+		resp.Frames, err = tableRes.ToDataFrames(q.Query)
 		if err != nil {
 			backend.Logger.Debug("error converting response to data frames", "error", err.Error())
-			errorWithFrame(fmt.Errorf("error converting response to data frames: %w", err))
-			return resp
+			return resp, fmt.Errorf("error converting response to data frames: %w", err)
 		}
 	case "time_series":
-		frames, err := tableRes.ToDataFrames(interpolatedQuery)
+		frames, err := tableRes.ToDataFrames(q.Query)
 		if err != nil {
-			errorWithFrame(err)
-			return resp
+			return resp, err
 		}
 		for _, f := range frames {
 			tsSchema := f.TimeSeriesSchema()
@@ -172,7 +166,7 @@ func (adx *AzureDataExplorer) handleQuery(q backend.DataQuery, user *backend.Use
 					Severity: data.NoticeSeverityWarning,
 					Text:     "Returned frame is not a time series, returning table format instead. The response must have at least one datetime field and one numeric field.",
 				})
-				appendFrame(f)
+				resp.Frames = append(resp.Frames, f)
 				continue
 			case data.TimeSeriesTypeLong:
 				wideFrame, err := data.LongToWide(f, nil)
@@ -181,27 +175,25 @@ func (adx *AzureDataExplorer) handleQuery(q backend.DataQuery, user *backend.Use
 						Severity: data.NoticeSeverityWarning,
 						Text:     fmt.Sprintf("detected long formatted time series but failed to convert from long frame: %v. Returning table format instead.", err),
 					})
-					appendFrame(f)
+					resp.Frames = append(resp.Frames, f)
 					continue
 				}
-				appendFrame(wideFrame)
+				resp.Frames = append(resp.Frames, wideFrame)
 			default:
-				appendFrame(f)
+				resp.Frames = append(resp.Frames, f)
 			}
 		}
 	case "time_series_adx_series":
-		orginalDFs, err := tableRes.ToDataFrames(interpolatedQuery)
+		orginalDFs, err := tableRes.ToDataFrames(q.Query)
 		if err != nil {
-			errorWithFrame(fmt.Errorf("error converting response to data frames: %w", err))
-			return resp
+			return resp, fmt.Errorf("error converting response to data frames: %w", err)
 		}
 		for _, f := range orginalDFs {
 			formatedDF, err := models.ToADXTimeSeries(f)
 			if err != nil {
-				errorWithFrame(err)
-				return resp
+				return resp, err
 			}
-			appendFrame(formatedDF)
+			resp.Frames = append(resp.Frames, formatedDF)
 		}
 
 	// 	series, timeNotASC, err := tableRes.ToTimeSeries()
@@ -213,8 +205,8 @@ func (adx *AzureDataExplorer) handleQuery(q backend.DataQuery, user *backend.Use
 	// 	qr.Series = series
 
 	default:
-		resp.Error = fmt.Errorf("unsupported query type: '%v'", qm.Format)
+		resp.Error = fmt.Errorf("unsupported query type: '%v'", q.Format)
 	}
 
-	return resp
+	return resp, nil
 }

--- a/pkg/azuredx/datasource.go
+++ b/pkg/azuredx/datasource.go
@@ -76,7 +76,7 @@ func (adx *AzureDataExplorer) QueryData(ctx context.Context, req *backend.QueryD
 	res := backend.NewQueryDataResponse()
 
 	for _, q := range req.Queries {
-		res.Responses[q.RefID] = adx.dataQuery(q, req.PluginContext.User)
+		res.Responses[q.RefID] = adx.handleQuery(q, req.PluginContext.User)
 	}
 
 	return res, nil
@@ -98,7 +98,7 @@ func (adx *AzureDataExplorer) CheckHealth(ctx context.Context, req *backend.Chec
 	}, nil
 }
 
-func (adx *AzureDataExplorer) dataQuery(q backend.DataQuery, user *backend.User) backend.DataResponse {
+func (adx *AzureDataExplorer) handleQuery(q backend.DataQuery, user *backend.User) backend.DataResponse {
 	var qm models.QueryModel
 	err := json.Unmarshal(q.JSON, &qm)
 	if err != nil {

--- a/pkg/azuredx/datasource_test.go
+++ b/pkg/azuredx/datasource_test.go
@@ -45,7 +45,7 @@ func TestDatasource(t *testing.T) {
 			require.Contains(t, additionalHeaders["x-ms-client-request-id"], UserLogin)
 			return table, nil
 		}
-		res := adx.dataQuery(query, &backend.User{Login: UserLogin})
+		res := adx.handleQuery(query, &backend.User{Login: UserLogin})
 		require.NoError(t, res.Error)
 	})
 }

--- a/pkg/azuredx/datasource_test.go
+++ b/pkg/azuredx/datasource_test.go
@@ -45,7 +45,7 @@ func TestDatasource(t *testing.T) {
 			require.Contains(t, additionalHeaders["x-ms-client-request-id"], UserLogin)
 			return table, nil
 		}
-		res := adx.handleQuery(query, &backend.User{Login: UserLogin})
+		res := adx.dataQuery(query, &backend.User{Login: UserLogin})
 		require.NoError(t, res.Error)
 	})
 }

--- a/pkg/azuredx/resource_handler.go
+++ b/pkg/azuredx/resource_handler.go
@@ -25,9 +25,9 @@ func (adx *AzureDataExplorer) getSchema(rw http.ResponseWriter, req *http.Reques
 		QuerySource: "schema",
 	}
 
-	response, statusCode, kustoErr, err := adx.client.KustoRequest(adx.settings.ClusterURL+ManagementApiPath, payload, nil)
+	response, err := adx.client.KustoRequest(adx.settings.ClusterURL+ManagementApiPath, payload, nil)
 	if err != nil {
-		respondWithError(rw, statusCode, kustoErr, err)
+		respondWithError(rw, http.StatusInternalServerError, "Azure query unsuccessful", err)
 		return
 	}
 
@@ -48,9 +48,9 @@ func (adx *AzureDataExplorer) getDatabases(rw http.ResponseWriter, req *http.Req
 		CSL: ".show databases",
 	}
 
-	response, statusCode, kustoErr, err := adx.client.KustoRequest(adx.settings.ClusterURL+ManagementApiPath, payload, nil)
+	response, err := adx.client.KustoRequest(adx.settings.ClusterURL+ManagementApiPath, payload, nil)
 	if err != nil {
-		respondWithError(rw, statusCode, kustoErr, err)
+		respondWithError(rw, http.StatusInternalServerError, "Azure query unsuccessful", err)
 		return
 	}
 

--- a/pkg/azuredx/resource_handler_test.go
+++ b/pkg/azuredx/resource_handler_test.go
@@ -11,8 +11,6 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-const errorMessage string = "Request is invalid and cannot be executed."
-
 func TestResourceHandler(t *testing.T) {
 	var res *httptest.ResponseRecorder
 	var adx AzureDataExplorer
@@ -43,7 +41,6 @@ func TestResourceHandler(t *testing.T) {
 		httpError := models.HttpError{}
 		err := json.NewDecoder(res.Body).Decode(&httpError)
 		require.Nil(t, err)
-		require.Equal(t, errorMessage, httpError.Message)
 		require.Equal(t, http.StatusInternalServerError, httpError.StatusCode)
 		require.Contains(t, httpError.Error, fmt.Sprintf("HTTP error: %v", http.StatusBadRequest))
 	})
@@ -69,8 +66,8 @@ func (c *failingClient) TestRequest(datasourceSettings *models.DatasourceSetting
 	panic("not implemented")
 }
 
-func (c *failingClient) KustoRequest(url string, payload models.RequestPayload, additionalHeaders map[string]string) (*models.TableResponse, int, string, error) {
-	return nil, http.StatusInternalServerError, errorMessage, fmt.Errorf("HTTP error: %v - %v", http.StatusBadRequest, "")
+func (c *failingClient) KustoRequest(url string, payload models.RequestPayload, additionalHeaders map[string]string) (*models.TableResponse, error) {
+	return nil, fmt.Errorf("HTTP error: %v - %v", http.StatusBadRequest, "")
 }
 
 type workingClient struct{}
@@ -79,7 +76,7 @@ func (c *workingClient) TestRequest(datasourceSettings *models.DatasourceSetting
 	panic("not implemented")
 }
 
-func (c *workingClient) KustoRequest(url string, payload models.RequestPayload, additionalHeaders map[string]string) (*models.TableResponse, int, string, error) {
+func (c *workingClient) KustoRequest(url string, payload models.RequestPayload, additionalHeaders map[string]string) (*models.TableResponse, error) {
 	return &models.TableResponse{
 		Tables: []models.Table{
 			{
@@ -98,5 +95,5 @@ func (c *workingClient) KustoRequest(url string, payload models.RequestPayload, 
 				},
 			},
 		},
-	}, http.StatusOK, "", nil
+	}, nil
 }

--- a/src/QueryEditor.tsx
+++ b/src/QueryEditor.tsx
@@ -195,16 +195,7 @@ const useDirty = (query: string, executedQuery: string): boolean => {
 
 const useExecutedQueryError = (data?: PanelData): string | undefined => {
   return useMemo(() => {
-    const kustoError = data?.series[0]?.meta?.custom?.KustoError;
-
-    if (data?.error && !kustoError) {
-      if (data.error.message) {
-        return `${data.error.message}`;
-      }
-      return `${data.error}`;
-    }
-
-    return kustoError;
+    return data?.error?.message;
   }, [data]);
 };
 


### PR DESCRIPTION
Grafana can't just replicate the HTTP response code from Azure because they apply to an internal request context. For example, an HTTP 404 would mean that configured backend URL may be invalid. If we just reply the 404 in Grafana it would falsely state that the requested URL does not exist.

We can use error checks (like `errors.Is`) for more fine grained response codes, if needed.