### PR TITLE
Fix HTTP timeout setting not being used

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,9 @@
 # Change Log
 
 ## [next]
+
 - Bugfix: Fixed issue when typing vs copy/pasting client secret in configuration
+- Bugfix: Fixed issue where HTTP timeout setting was not being applied
 
 ## [3.5.0]
 

--- a/pkg/azuredx/datasource.go
+++ b/pkg/azuredx/datasource.go
@@ -13,6 +13,7 @@ import (
 	"github.com/grafana/grafana-plugin-sdk-go/backend/instancemgmt"
 	"github.com/grafana/grafana-plugin-sdk-go/backend/resource/httpadapter"
 	"github.com/grafana/grafana-plugin-sdk-go/data"
+
 	// 100% compatible drop-in replacement of "encoding/json"
 	json "github.com/json-iterator/go"
 	"golang.org/x/net/context"
@@ -51,6 +52,8 @@ func NewDatasource(settings backend.DataSourceInstanceSettings) (instancemgmt.In
 		backend.Logger.Error("failed to create HTTP client options", "error", err.Error())
 		return nil, err
 	}
+
+	httpClientOptions.Timeouts.Timeout = datasourceSettings.QueryTimeout
 
 	httpClient, err := httpClientProvider.New(httpClientOptions)
 	if err != nil {


### PR DESCRIPTION
Fixes #262

Tested by setting the ADX timeout in settings to 999s and using the following query which (aside from probably setting the cluster on fire...) takes roughly 3.5 minutes to run

```
range N from 1 to 70000 step 1
| extend Sub = range(1, N)
| mv-apply X=Sub on (
    where N % X == 0
    | summarize divisors=make_list(X)
  )
| where array_length(divisors) == 2
| project Prime=N
```

![image](https://user-images.githubusercontent.com/46142/133771411-f83194a7-4625-4805-8fa2-7aa82cf71f93.png)

I do still want to test to make sure that the default timeout of 30s is still applied if the user has not specified a timeout.
