### PR TITLE
chore: add template for GH discussions

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,1 +1,8 @@
 blank_issues_enabled: false
+contact_links:
+  - name: Feature Request
+    url: https://github.com/grafana/azure-data-explorer-datasource/discussions/new
+    about: Discuss ideas for new features or changes
+  - name: Questions & Help
+    url: https://community.grafana.com
+    about: Please ask and answer questions here


### PR DESCRIPTION
Copied the config yml from Grafana: https://github.com/grafana/grafana/blob/main/.github/ISSUE_TEMPLATE/config.yml

This should allow new feature requests to go to GH Discussions and allow questions to be asked on the community site