### PR TITLE
Fix: Include quotes when identifier has space, dot, or dash

### DIFF
--- a/pkg/azuredx/models/macro.go
+++ b/pkg/azuredx/models/macro.go
@@ -35,7 +35,7 @@ func NewMacroData(tr *backend.TimeRange, intervalMS int64) MacroData {
 // macroRE is a regular expression to match available macros
 var macroRE = regexp.MustCompile(`\$__` + // Prefix: $__
 	`(timeFilter|timeFrom|timeTo|timeInterval)` + // one of macro root names
-	`(\([a-zA-Z0-9_-]*?\))?`) // optional () or optional (someArg)
+	`(\([a-zA-Z0-9_ .-]*?\))?`) // optional () or optional (someArg)
 
 // Interpolate replaces macros with their values for the given query.
 func (md MacroData) Interpolate(query string) (string, error) {
@@ -55,7 +55,7 @@ func (md MacroData) Interpolate(query string) (string, error) {
 		}
 		arg := ""
 		if len(varSplit) > 1 {
-			arg = varSplit[1]
+			arg = quoteForSpacesDotsDashes(varSplit[1])
 		}
 		return funcToCall(arg, md)
 	}
@@ -64,6 +64,13 @@ func (md MacroData) Interpolate(query string) (string, error) {
 		return "", fmt.Errorf("failed to interpolate query, errors: %v", strings.Join(errorStrings, "\n"))
 	}
 	return interpolated, nil
+}
+
+func quoteForSpacesDotsDashes(s string) string {
+	if strings.ContainsAny(s, " .-") {
+		return fmt.Sprintf("['%s']", s)
+	}
+	return s
 }
 
 var interpolationFuncs = map[string]func(string, MacroData) string{

--- a/pkg/azuredx/models/macro.go
+++ b/pkg/azuredx/models/macro.go
@@ -35,7 +35,7 @@ func NewMacroData(tr *backend.TimeRange, intervalMS int64) MacroData {
 // macroRE is a regular expression to match available macros
 var macroRE = regexp.MustCompile(`\$__` + // Prefix: $__
 	`(timeFilter|timeFrom|timeTo|timeInterval)` + // one of macro root names
-	`(\([a-zA-Z0-9_ .-]*?\))?`) // optional () or optional (someArg)
+	`(\([a-zA-Z0-9_\s.-]*?\))?`) // optional () or optional (someArg)
 
 // Interpolate replaces macros with their values for the given query.
 func (md MacroData) Interpolate(query string) (string, error) {
@@ -67,6 +67,7 @@ func (md MacroData) Interpolate(query string) (string, error) {
 }
 
 func quoteForSpacesDotsDashes(s string) string {
+	// https://docs.microsoft.com/en-us/azure/data-explorer/kusto/query/schema-entities/entity-names#identifier-quoting
 	if strings.ContainsAny(s, " .-") {
 		return fmt.Sprintf("['%s']", s)
 	}

--- a/pkg/azuredx/models/macro_test.go
+++ b/pkg/azuredx/models/macro_test.go
@@ -84,15 +84,37 @@ func TestMacroData_Interpolate(t *testing.T) {
 			returnVal: fmt.Sprintf("CatCount >= %v and CatCount <= %v", fromString, toString),
 		},
 		{
-			name: "should parse $__timeFilter(value-with-hyphens)",
+			name: "should parse and quote identifier with space",
 			macroData: NewMacroData(&backend.TimeRange{
 				From: fromTime,
 				To:   toTime,
 			}, 0),
 			errorIs:   assert.NoError,
-			query:     "$__timeFilter(value-with-hyphens)",
+			query:     "$__timeFilter(value with space)",
 			returnIs:  assert.Equal,
-			returnVal: fmt.Sprintf("value-with-hyphens >= %v and value-with-hyphens <= %v", fromString, toString),
+			returnVal: fmt.Sprintf("['value with space'] >= %v and ['value with space'] <= %v", fromString, toString),
+		},
+		{
+			name: "should parse and quote identifier with dot",
+			macroData: NewMacroData(&backend.TimeRange{
+				From: fromTime,
+				To:   toTime,
+			}, 0),
+			errorIs:   assert.NoError,
+			query:     "$__timeFilter(identifier.with.dot)",
+			returnIs:  assert.Equal,
+			returnVal: fmt.Sprintf("['identifier.with.dot'] >= %v and ['identifier.with.dot'] <= %v", fromString, toString),
+		},
+		{
+			name: "should parse and quote identifier with dashes",
+			macroData: NewMacroData(&backend.TimeRange{
+				From: fromTime,
+				To:   toTime,
+			}, 0),
+			errorIs:   assert.NoError,
+			query:     "$__timeFilter(identifier-with-dashes)",
+			returnIs:  assert.Equal,
+			returnVal: fmt.Sprintf("['identifier-with-dashes'] >= %v and ['identifier-with-dashes'] <= %v", fromString, toString),
 		},
 	}
 


### PR DESCRIPTION
Need to at least quote identifiers with spaces, dots, or dashes.
https://docs.microsoft.com/en-us/azure/data-explorer/kusto/query/schema-entities/entity-names#identifier-quoting

Fixes #296