### PR TITLE
Add import dashboard e2e scenario

### DIFF
--- a/cypress/dashboards/example.json
+++ b/cypress/dashboards/example.json
@@ -22,12 +22,12 @@
   "fiscalYearStartMonth": 0,
   "gnetId": null,
   "graphTooltip": 0,
-  "id": 2,
+  "id": null,
   "links": [],
   "liveNow": false,
   "panels": [
     {
-      "datasource": null,
+      "datasource": "e2e-azure-data-explorer-datasource",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -113,9 +113,9 @@
             }
           },
           "pluginVersion": "3.6.1",
-          "query": "PerfTest\n| where $__timeFilter(_Timestamp_)\n| order by _Timestamp_ asc",
-          "querySource": "visual",
-          "rawMode": false,
+          "query": "PerfTest\n| limit 10\n| order by _Timestamp_ asc",
+          "querySource": "raw",
+          "rawMode": true,
           "refId": "A",
           "resultFormat": "time_series"
         }
@@ -124,7 +124,7 @@
       "type": "timeseries"
     },
     {
-      "datasource": null,
+      "datasource": "e2e-azure-data-explorer-datasource",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -180,7 +180,7 @@
             }
           },
           "pluginVersion": "3.6.1",
-          "query": "PerfTest\n",
+          "query": "PerfTest\n| limit 10\n| order by _Timestamp_ asc",
           "querySource": "raw",
           "rawMode": true,
           "refId": "A",
@@ -206,5 +206,5 @@
   "timezone": "",
   "title": "Example Dashboard",
   "uid": "EYtcnAx7k",
-  "version": 3
+  "version": 1
 }

--- a/cypress/dashboards/example.json
+++ b/cypress/dashboards/example.json
@@ -1,0 +1,210 @@
+{
+  "annotations": {
+    "list": [
+      {
+        "builtIn": 1,
+        "datasource": "-- Grafana --",
+        "enable": true,
+        "hide": true,
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "name": "Annotations & Alerts",
+        "target": {
+          "limit": 100,
+          "matchAny": false,
+          "tags": [],
+          "type": "dashboard"
+        },
+        "type": "dashboard"
+      }
+    ]
+  },
+  "editable": true,
+  "fiscalYearStartMonth": 0,
+  "gnetId": null,
+  "graphTooltip": 0,
+  "id": 2,
+  "links": [],
+  "liveNow": false,
+  "panels": [
+    {
+      "datasource": null,
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 9,
+        "w": 12,
+        "x": 0,
+        "y": 0
+      },
+      "id": 2,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "single"
+        }
+      },
+      "targets": [
+        {
+          "database": "PerfTest",
+          "expression": {
+            "groupBy": {
+              "expressions": [],
+              "type": "and"
+            },
+            "reduce": {
+              "expressions": [],
+              "type": "and"
+            },
+            "where": {
+              "expressions": [],
+              "type": "and"
+            }
+          },
+          "pluginVersion": "3.6.1",
+          "query": "PerfTest\n| where $__timeFilter(_Timestamp_)\n| order by _Timestamp_ asc",
+          "querySource": "visual",
+          "rawMode": false,
+          "refId": "A",
+          "resultFormat": "time_series"
+        }
+      ],
+      "title": "Time series",
+      "type": "timeseries"
+    },
+    {
+      "datasource": null,
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "custom": {
+            "align": "auto",
+            "displayMode": "auto"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 9,
+        "w": 12,
+        "x": 12,
+        "y": 0
+      },
+      "id": 3,
+      "options": {
+        "showHeader": true
+      },
+      "pluginVersion": "8.2.6",
+      "targets": [
+        {
+          "database": "PerfTest",
+          "expression": {
+            "groupBy": {
+              "expressions": [],
+              "type": "and"
+            },
+            "reduce": {
+              "expressions": [],
+              "type": "and"
+            },
+            "where": {
+              "expressions": [],
+              "type": "and"
+            }
+          },
+          "pluginVersion": "3.6.1",
+          "query": "PerfTest\n",
+          "querySource": "raw",
+          "rawMode": true,
+          "refId": "A",
+          "resultFormat": "time_series"
+        }
+      ],
+      "title": "Table view",
+      "type": "table"
+    }
+  ],
+  "refresh": "",
+  "schemaVersion": 32,
+  "style": "dark",
+  "tags": [],
+  "templating": {
+    "list": []
+  },
+  "time": {
+    "from": "now-6h",
+    "to": "now"
+  },
+  "timepicker": {},
+  "timezone": "",
+  "title": "Example Dashboard",
+  "uid": "EYtcnAx7k",
+  "version": 3
+}

--- a/cypress/integration/smoke.spec.ts
+++ b/cypress/integration/smoke.spec.ts
@@ -48,6 +48,25 @@ e2e.scenario({
   describeName: 'Import dashboard',
   itName: 'adds JSON',
   scenario: () => {
-    e2e.flows.importDashboard(TEST_DASHBOARD);
+    e2e()
+      .readProvisions(['datasources/adx.yaml'])
+      .then((ADXProvisions: ADXProvision[]) => {
+        const datasource = ADXProvisions[0].datasources[1]; // Second entry in our common provisioning file
+
+        e2e.flows.addDataSource({
+          name: 'e2e-azure-data-explorer-datasource',
+          type: 'Azure Data Explorer Datasource',
+          form: () => {
+            e2eSelectors.configEditor.azureCloud.input().type('Azure');
+            e2eSelectors.configEditor.clusterURL.input().click({ force: true }).type(datasource.jsonData.clusterUrl);
+            e2eSelectors.configEditor.tenantID.input().type(datasource.jsonData.tenantId);
+            e2eSelectors.configEditor.clientID.input().type(datasource.jsonData.clientId);
+            e2eSelectors.configEditor.clientSecret.input().type(datasource.secureJsonData.clientSecret);
+          },
+          expectedAlertMessage: 'Success',
+        });
+
+        e2e.flows.importDashboard(TEST_DASHBOARD);
+      });
   },
 });

--- a/cypress/integration/smoke.spec.ts
+++ b/cypress/integration/smoke.spec.ts
@@ -19,6 +19,23 @@ type ADXProvision = {
   datasources: ADXConfig[];
 };
 
+function addCommonProvisioningADXDatasource(ADXProvisions: ADXProvision[]) {
+  const datasource = ADXProvisions[0].datasources[1]; // Second entry in our common provisioning file
+
+  e2e.flows.addDataSource({
+    name: 'e2e-azure-data-explorer-datasource',
+    type: 'Azure Data Explorer Datasource',
+    form: () => {
+      e2eSelectors.configEditor.azureCloud.input().type('Azure');
+      e2eSelectors.configEditor.clusterURL.input().click({ force: true }).type(datasource.jsonData.clusterUrl);
+      e2eSelectors.configEditor.tenantID.input().type(datasource.jsonData.tenantId);
+      e2eSelectors.configEditor.clientID.input().type(datasource.jsonData.clientId);
+      e2eSelectors.configEditor.clientSecret.input().type(datasource.secureJsonData.clientSecret);
+    },
+    expectedAlertMessage: 'Success',
+  });
+}
+
 e2e.scenario({
   describeName: 'Add ADX datasource',
   itName: 'fills out datasource connection configuration',
@@ -26,20 +43,7 @@ e2e.scenario({
     e2e()
       .readProvisions(['datasources/adx.yaml'])
       .then((ADXProvisions: ADXProvision[]) => {
-        const datasource = ADXProvisions[0].datasources[1]; // Second entry in our common provisioning file
-
-        e2e.flows.addDataSource({
-          name: 'e2e-azure-data-explorer-datasource',
-          type: 'Azure Data Explorer Datasource',
-          form: () => {
-            e2eSelectors.configEditor.azureCloud.input().type('Azure');
-            e2eSelectors.configEditor.clusterURL.input().click({ force: true }).type(datasource.jsonData.clusterUrl);
-            e2eSelectors.configEditor.tenantID.input().type(datasource.jsonData.tenantId);
-            e2eSelectors.configEditor.clientID.input().type(datasource.jsonData.clientId);
-            e2eSelectors.configEditor.clientSecret.input().type(datasource.secureJsonData.clientSecret);
-          },
-          expectedAlertMessage: 'Success',
-        });
+        addCommonProvisioningADXDatasource(ADXProvisions);
       });
   },
 });
@@ -51,20 +55,7 @@ e2e.scenario({
     e2e()
       .readProvisions(['datasources/adx.yaml'])
       .then((ADXProvisions: ADXProvision[]) => {
-        const datasource = ADXProvisions[0].datasources[1]; // Second entry in our common provisioning file
-
-        e2e.flows.addDataSource({
-          name: 'e2e-azure-data-explorer-datasource',
-          type: 'Azure Data Explorer Datasource',
-          form: () => {
-            e2eSelectors.configEditor.azureCloud.input().type('Azure');
-            e2eSelectors.configEditor.clusterURL.input().click({ force: true }).type(datasource.jsonData.clusterUrl);
-            e2eSelectors.configEditor.tenantID.input().type(datasource.jsonData.tenantId);
-            e2eSelectors.configEditor.clientID.input().type(datasource.jsonData.clientId);
-            e2eSelectors.configEditor.clientSecret.input().type(datasource.secureJsonData.clientSecret);
-          },
-          expectedAlertMessage: 'Success',
-        });
+        addCommonProvisioningADXDatasource(ADXProvisions);
 
         e2e.flows.importDashboard(TEST_DASHBOARD);
       });

--- a/cypress/integration/smoke.spec.ts
+++ b/cypress/integration/smoke.spec.ts
@@ -1,5 +1,6 @@
 import { e2e } from '@grafana/e2e';
 import { selectors } from '../../src/test/selectors';
+import TEST_DASHBOARD from '../dashboards/example.json';
 
 const e2eSelectors = e2e.getSelectors(selectors.components);
 
@@ -19,8 +20,8 @@ type ADXProvision = {
 };
 
 e2e.scenario({
-  describeName: 'Smoke tests',
-  itName: 'Adds ADX datasource',
+  describeName: 'Add ADX datasource',
+  itName: 'fills out datasource connection configuration',
   scenario: () => {
     e2e()
       .readProvisions(['datasources/adx.yaml'])
@@ -40,5 +41,13 @@ e2e.scenario({
           expectedAlertMessage: 'Success',
         });
       });
+  },
+});
+
+e2e.scenario({
+  describeName: 'Import dashboard',
+  itName: 'adds JSON',
+  scenario: () => {
+    e2e.flows.importDashboard(TEST_DASHBOARD);
   },
 });

--- a/cypress/tsconfig.json
+++ b/cypress/tsconfig.json
@@ -5,6 +5,7 @@
     "types": [
       "cypress",
       "@grafana/e2e/cypress/support"
-    ]
+    ],
+    "resolveJsonModule": true
   }
 }


### PR DESCRIPTION
Adds a dashboard from a JSON (2 panels: one timeseries and one table view)

<s>Notes for reviewer:
* I don't really understand the expected use of `describe` vs `it` in the @grafana/e2e package. Having a talk with Vicky about that in a few hours...
* It seems like importing dashboard passes *without* adding the datasource first. (For example running this test alone.) Does that sound right?
* There is always a `temporary` test in the cypress UI. I think this might be coming from the @grafana/e2e `after` each test flow?</s>

Closes #241