### PR TITLE
QueryEditor: Fix expression condition

### DIFF
--- a/src/editor/components/QueryEditorRepeater.test.tsx
+++ b/src/editor/components/QueryEditorRepeater.test.tsx
@@ -1,0 +1,36 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+import React from 'react';
+
+import { QueryEditorExpressionType } from '../expressions';
+import { QueryEditorRepeater } from './QueryEditorRepeater';
+
+const props = {
+  id: 'id',
+  value: {
+    type: QueryEditorExpressionType.Property,
+    expressions: [
+      {
+        type: QueryEditorExpressionType.And,
+      },
+    ],
+  },
+  onChange: jest.fn(),
+  children: jest.fn().mockReturnValue(<>hello</>),
+};
+
+it('renders the component', async () => {
+  render(<QueryEditorRepeater {...props} />);
+  expect(screen.getByText('hello')).toBeInTheDocument();
+});
+
+it('forward expressions', async () => {
+  const onChange = jest.fn();
+  const children = jest.fn((props) => <input data-testid="foo" onChange={props.onChange} />);
+  render(<QueryEditorRepeater {...props} onChange={onChange} children={children} />);
+
+  const c = await screen.findByTestId('foo');
+  fireEvent.change(c, { target: { value: 'bar' } });
+
+  expect(onChange).toHaveBeenCalledTimes(1);
+  expect(onChange.mock.calls[0][0].expressions).toHaveLength(1);
+});

--- a/src/editor/components/QueryEditorRepeater.test.tsx
+++ b/src/editor/components/QueryEditorRepeater.test.tsx
@@ -26,7 +26,11 @@ it('renders the component', async () => {
 it('forward expressions', async () => {
   const onChange = jest.fn();
   const children = jest.fn((props) => <input data-testid="foo" onChange={props.onChange} />);
-  render(<QueryEditorRepeater {...props} onChange={onChange} children={children} />);
+  render(
+    <QueryEditorRepeater {...props} onChange={onChange}>
+      {children}
+    </QueryEditorRepeater>
+  );
 
   const c = await screen.findByTestId('foo');
   fireEvent.change(c, { target: { value: 'bar' } });

--- a/src/editor/components/QueryEditorRepeater.tsx
+++ b/src/editor/components/QueryEditorRepeater.tsx
@@ -1,5 +1,6 @@
 import React, { useCallback } from 'react';
-import { QueryEditorExpression, QueryEditorArrayExpression } from '../expressions';
+
+import { QueryEditorArrayExpression, QueryEditorExpression } from '../expressions';
 
 interface Props {
   id: string;
@@ -35,7 +36,7 @@ export const QueryEditorRepeater: React.FC<Props> = (props) => {
         if ('expressions' in v) {
           return (v as QueryEditorArrayExpression).expressions.length > 0;
         }
-        return false;
+        return true;
       });
 
       propsOnChange({


### PR DESCRIPTION
I introduced a bug in this condition https://github.com/grafana/azure-data-explorer-datasource/pull/298/files#diff-489931d192d84e6c767bc4e81b14a4f7e9ab16db0766b874337640a97bbdb56fL35

Which caused the query editor to fail when adding new expressions.

Fixes #319
