### PR TITLE
Replace references to master with main

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -52,5 +52,5 @@ You need to have commit rights to the GitHub repository to publish a release.
 
 1. Update the version number in the `package.json` file.
 2. Update the `CHANGELOG.md` with the changes contained in the release.
-3. Commit the changes to master and push to GitHub.
+3. Commit the changes to main and push to GitHub.
 4. Follow the Drone release process that you can find [here](https://github.com/grafana/integrations-team/wiki/Plugin-Release-Process#drone-release-process)

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ This plugin requires Grafana 7.1.0 or newer as of version 3.0.0. Plugin versions
 If you do not have a [Grafana Cloud](https://grafana.com/cloud) account, you can sign up for one [here](https://grafana.com/cloud/grafana).
 
 1. Click on the `Install Now` button on the [Azure Data Explorer page on Grafana.com](https://grafana.com/plugins/grafana-azure-data-explorer-datasource/?tab=installation). This will automatically add the plugin to your Grafana instance. It might take up to 30 seconds to install.
-   ![GrafanaCloud Install](https://raw.githubusercontent.com/grafana/azure-data-explorer-datasource/master/src/img/grafana_cloud_install.png)
+   ![GrafanaCloud Install](https://raw.githubusercontent.com/grafana/azure-data-explorer-datasource/main/src/img/grafana_cloud_install.png)
 
 2. Login to your Hosted Grafana instance (go to your instances page in your profile): `https://grafana.com/orgs/<yourUserName>/instances/` and the Azure Data Explorer datasource will be installed.
 

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "build": "grafana-toolkit plugin:build",
     "test": "jest --notify --watch",
     "test:coverage": "jest --coverage",
-    "test:coverage:changes": "jest --coverage --changedSince=origin/master",
+    "test:coverage:changes": "jest --coverage --changedSince=origin/main",
     "dev": "grafana-toolkit plugin:dev",
     "watch": "grafana-toolkit plugin:dev --watch",
     "sign": "grafana-toolkit plugin:sign",

--- a/src/plugin.json
+++ b/src/plugin.json
@@ -20,7 +20,7 @@
       },
       {
         "name": "Apache License",
-        "url": "https://github.com/grafana/azure-data-explorer-datasource/blob/master/LICENSE"
+        "url": "https://github.com/grafana/azure-data-explorer-datasource/blob/main/LICENSE"
       }
     ],
     "screenshots": [],


### PR DESCRIPTION
The default branch is now `main`. Ref #278