### PR TITLE
e2e : Added panel creation scenario

### DIFF
--- a/cypress/dashboards/example.json
+++ b/cypress/dashboards/example.json
@@ -199,8 +199,8 @@
     "list": []
   },
   "time": {
-    "from": "now-6h",
-    "to": "now"
+    "from": "2019-10-06T04:00:00.000Z",
+    "to": "2019-10-15T04:00:00.000Z"
   },
   "timepicker": {},
   "timezone": "",

--- a/cypress/dashboards/example.json
+++ b/cypress/dashboards/example.json
@@ -199,8 +199,8 @@
     "list": []
   },
   "time": {
-    "from": "2019-10-06T04:00:00.000Z",
-    "to": "2019-10-15T04:00:00.000Z"
+    "from": "now-6h",
+    "to": "now"
   },
   "timepicker": {},
   "timezone": "",

--- a/cypress/integration/smoke.spec.ts
+++ b/cypress/integration/smoke.spec.ts
@@ -37,6 +37,18 @@ function addCommonProvisioningADXDatasource(ADXProvisions: ADXProvision[]) {
 }
 
 e2e.scenario({
+  describeName: 'Add ADX datasource',
+  itName: 'fills out datasource connection configuration',
+  scenario: () => {
+    e2e()
+      .readProvisions(['datasources/adx.yaml'])
+      .then((ADXProvisions: ADXProvision[]) => {
+        addCommonProvisioningADXDatasource(ADXProvisions);
+      });
+  },
+});
+
+e2e.scenario({
   describeName: 'Import dashboard',
   itName: 'fills out datasource connection configuration, imports JSON dashboard, adds panel and run query',
   scenario: () => {

--- a/cypress/integration/smoke.spec.ts
+++ b/cypress/integration/smoke.spec.ts
@@ -75,12 +75,49 @@ e2e.scenario({
             e2eSelectors.queryEditor.database.input().click({ force: true });
             cy.contains('PerfTest').click();
             e2eSelectors.queryEditor.codeEditorLegacy
-              .container()
-              .click({ force: true })
-              .type(`{selectall} {backspace} PerfTest | where $__timeFilter(_Timestamp_) | order by _Timestamp_ asc`);
+              .textarea()
+              .should('be.visible')
+              .clear()
+              .click()
+              .type(`PerfTest | where $__timeFilter(_Timestamp_) | order by _Timestamp_ asc`);
             e2eSelectors.queryEditor.runQuery.button().click({ force: true });
             cy.get('.panel-loading');
             cy.get('.panel-loading', { timeout: 10000 }).should('not.exist');
+          },
+        });
+      });
+  },
+});
+
+e2e.scenario({
+  describeName: 'Creates Panel run query via builder',
+  itName: 'fills out datasource connection configuration, adds panel and runs query via builder',
+  scenario: () => {
+    e2e()
+      .readProvisions(['datasources/adx.yaml'])
+      .then((ADXProvisions: ADXProvision[]) => {
+        addCommonProvisioningADXDatasource(ADXProvisions);
+
+        e2e.flows.addDashboard({
+          timeRange: {
+            from: '2022-01-05 19:00:00',
+            to: '2022-01-10 19:00:00',
+          },
+          variables: [],
+        });
+
+        e2e.flows.addPanel({
+          matchScreenshot: false,
+          visitDashboardAtStart: false,
+          queriesForm: () => {
+            e2eSelectors.queryEditor.database.input().click({ force: true });
+            cy.contains('PerfTest').click();
+
+            e2eSelectors.queryEditor.tableFrom.input().click({ force: true });
+            cy.contains('events.all').click();
+
+            e2eSelectors.queryEditor.runQuery.button().click({ force: true });
+            cy.contains('No graphable fields').should('exist');
           },
         });
       });

--- a/cypress/integration/smoke.spec.ts
+++ b/cypress/integration/smoke.spec.ts
@@ -71,18 +71,17 @@ e2e.scenario({
           matchScreenshot: false,
           visitDashboardAtStart: false,
           queriesForm: () => {
-            e2eSelectors.queryEditor.editKQL.button().click({ force: true });
             e2eSelectors.queryEditor.database.input().click({ force: true });
             cy.contains('PerfTest').click();
+            e2eSelectors.queryEditor.editKQL.button().click({ force: true });
             e2eSelectors.queryEditor.codeEditorLegacy
               .textarea()
               .should('be.visible')
-              .clear()
-              .click()
+              .click({ force: true })
+              .type('{del}'.repeat(100))
               .type(`PerfTest | where $__timeFilter(_Timestamp_) | order by _Timestamp_ asc`);
             e2eSelectors.queryEditor.runQuery.button().click({ force: true });
-            cy.get('.panel-loading');
-            cy.get('.panel-loading', { timeout: 10000 }).should('not.exist');
+            cy.contains('Lonely period range deg');
           },
         });
       });

--- a/cypress/integration/smoke.spec.ts
+++ b/cypress/integration/smoke.spec.ts
@@ -116,7 +116,7 @@ e2e.scenario({
             cy.contains('events.all').click();
 
             e2eSelectors.queryEditor.runQuery.button().click({ force: true });
-            cy.contains('No graphable fields').should('exist');
+            cy.contains('Data is missing a number field').should('exist');
           },
         });
       });

--- a/cypress/integration/smoke.spec.ts
+++ b/cypress/integration/smoke.spec.ts
@@ -36,21 +36,21 @@ function addCommonProvisioningADXDatasource(ADXProvisions: ADXProvision[]) {
   });
 }
 
-e2e.scenario({
-  describeName: 'Add ADX datasource',
-  itName: 'fills out datasource connection configuration',
-  scenario: () => {
-    e2e()
-      .readProvisions(['datasources/adx.yaml'])
-      .then((ADXProvisions: ADXProvision[]) => {
-        addCommonProvisioningADXDatasource(ADXProvisions);
-      });
-  },
-});
+// e2e.scenario({
+//   describeName: 'Add ADX datasource',
+//   itName: 'fills out datasource connection configuration',
+//   scenario: () => {
+//     e2e()
+//       .readProvisions(['datasources/adx.yaml'])
+//       .then((ADXProvisions: ADXProvision[]) => {
+//         addCommonProvisioningADXDatasource(ADXProvisions);
+//       });
+//   },
+// });
 
 e2e.scenario({
   describeName: 'Import dashboard',
-  itName: 'adds JSON',
+  itName: 'fills out datasource connection configuration, imports JSON dashboard, Adds panel',
   scenario: () => {
     e2e()
       .readProvisions(['datasources/adx.yaml'])
@@ -58,6 +58,23 @@ e2e.scenario({
         addCommonProvisioningADXDatasource(ADXProvisions);
 
         e2e.flows.importDashboard(TEST_DASHBOARD);
+
+        e2e.flows.addPanel({
+          matchScreenshot: false,
+          visitDashboardAtStart: false,
+          queriesForm: () => {
+            e2eSelectors.queryEditor.editKQL.button().click({ force: true });
+            // e2eSelectors.queryEditor.codeEditor
+            //   .container()
+            //   .click({ force: true })
+            //   .type(
+            //     `PerfTest
+            //     | where $__timeFilter(_Timestamp_)
+            //     | order by _Timestamp_ asc`
+            //   );
+            e2eSelectors.queryEditor.runQuery.button().click({ force: true });
+          },
+        });
       });
   },
 });

--- a/cypress/integration/smoke.spec.ts
+++ b/cypress/integration/smoke.spec.ts
@@ -38,7 +38,7 @@ function addCommonProvisioningADXDatasource(ADXProvisions: ADXProvision[]) {
 };
 
 e2e.scenario({
-  describeName: 'Add ADX datasource',
+  describeName: 'Add ADX datasource Import Dashoard',
   itName: 'fills out datasource connection configuration and imports JSON dashboard',
   scenario: () => {
     e2e()
@@ -51,7 +51,7 @@ e2e.scenario({
 });
 
 e2e.scenario({
-  describeName: 'Import dashboard',
+  describeName: 'Creates Panel run KQL query',
   itName: 'fills out datasource connection configuration, adds panel and runs query',
   scenario: () => {
     e2e()
@@ -74,7 +74,7 @@ e2e.scenario({
             e2eSelectors.queryEditor.editKQL.button().click({ force: true });
             e2eSelectors.queryEditor.database.input().click({ force: true });
             cy.contains('PerfTest').click();
-            e2eSelectors.queryEditor.codeEditor
+            e2eSelectors.queryEditor.codeEditorLegacy
               .container()
               .click({ force: true })
               .type(`{selectall} {backspace} PerfTest | where $__timeFilter(_Timestamp_) | order by _Timestamp_ asc`);

--- a/cypress/integration/smoke.spec.ts
+++ b/cypress/integration/smoke.spec.ts
@@ -36,21 +36,9 @@ function addCommonProvisioningADXDatasource(ADXProvisions: ADXProvision[]) {
   });
 }
 
-// e2e.scenario({
-//   describeName: 'Add ADX datasource',
-//   itName: 'fills out datasource connection configuration',
-//   scenario: () => {
-//     e2e()
-//       .readProvisions(['datasources/adx.yaml'])
-//       .then((ADXProvisions: ADXProvision[]) => {
-//         addCommonProvisioningADXDatasource(ADXProvisions);
-//       });
-//   },
-// });
-
 e2e.scenario({
   describeName: 'Import dashboard',
-  itName: 'fills out datasource connection configuration, imports JSON dashboard, Adds panel',
+  itName: 'fills out datasource connection configuration, imports JSON dashboard, adds panel and run query',
   scenario: () => {
     e2e()
       .readProvisions(['datasources/adx.yaml'])
@@ -63,15 +51,7 @@ e2e.scenario({
           matchScreenshot: false,
           visitDashboardAtStart: false,
           queriesForm: () => {
-            e2eSelectors.queryEditor.editKQL.button().click({ force: true });
-            // e2eSelectors.queryEditor.codeEditor
-            //   .container()
-            //   .click({ force: true })
-            //   .type(
-            //     `PerfTest
-            //     | where $__timeFilter(_Timestamp_)
-            //     | order by _Timestamp_ asc`
-            //   );
+            e2eSelectors.queryEditor.editKQL.button().click({ timeout: 5000 });
             e2eSelectors.queryEditor.runQuery.button().click({ force: true });
           },
         });

--- a/cypress/integration/smoke.spec.ts
+++ b/cypress/integration/smoke.spec.ts
@@ -73,7 +73,7 @@ e2e.scenario({
           queriesForm: () => {
             e2eSelectors.queryEditor.editKQL.button().click({ force: true });
             // Wait for the selectors to load
-            e2eSelectors.queryEditor.codeEditor.container().click({ force: true }).type(
+            e2eSelectors.queryEditor.codeEditor.container().type(
               `PerfTest
                   | where $__timeFilter(_Timestamp_)
                   | order by _Timestamp_ asc`

--- a/cypress/integration/smoke.spec.ts
+++ b/cypress/integration/smoke.spec.ts
@@ -72,13 +72,15 @@ e2e.scenario({
           visitDashboardAtStart: false,
           queriesForm: () => {
             e2eSelectors.queryEditor.editKQL.button().click({ force: true });
-            // Wait for the selectors to load
-            e2eSelectors.queryEditor.codeEditor.container().type(
-              `PerfTest
-                  | where $__timeFilter(_Timestamp_)
-                  | order by _Timestamp_ asc`
-            );
+            e2eSelectors.queryEditor.database.input().click({ force: true });
+            cy.contains('PerfTest').click();
+            e2eSelectors.queryEditor.codeEditor
+              .container()
+              .click({ force: true })
+              .type(`{selectall} {backspace} PerfTest | where $__timeFilter(_Timestamp_) | order by _Timestamp_ asc`);
             e2eSelectors.queryEditor.runQuery.button().click({ force: true });
+            cy.get('.panel-loading');
+            cy.get('.panel-loading', { timeout: 10000 }).should('not.exist');
           },
         });
       });

--- a/cypress/integration/smoke.spec.ts
+++ b/cypress/integration/smoke.spec.ts
@@ -116,7 +116,7 @@ e2e.scenario({
             cy.contains('events.all').click();
 
             e2eSelectors.queryEditor.runQuery.button().click({ force: true });
-            cy.contains('Data is missing a number field').should('exist');
+            cy.contains('No graphable fields').should('exist');
           },
         });
       });

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "@emotion/core": "^11.0.0",
     "@grafana/data": "8.2.6",
     "@grafana/e2e": "8.2.6",
+    "@grafana/e2e-selectors": "8.2.6",
     "@grafana/runtime": "8.2.6",
     "@grafana/toolkit": "8.2.6",
     "@grafana/ui": "8.2.6",

--- a/src/components/QueryEditorToolbar.tsx
+++ b/src/components/QueryEditorToolbar.tsx
@@ -57,7 +57,11 @@ export const QueryEditorToolbar: React.FC<Props> = (props) => {
         {props.editorMode === EditorMode.Visual ? 'Edit KQL' : 'Switch to builder'}
       </Button>
       <div className={styles.spacing} />
-      <Button variant={props.dirty ? 'primary' : 'secondary'} aria-label={selectors.components.queryEditor.runQuery.button} onClick={props.onRunQuery}>
+      <Button
+        variant={props.dirty ? 'primary' : 'secondary'}
+        aria-label={selectors.components.queryEditor.runQuery.button}
+        onClick={props.onRunQuery}
+      >
         Run Query
       </Button>
       <ConfirmModal

--- a/src/components/QueryEditorToolbar.tsx
+++ b/src/components/QueryEditorToolbar.tsx
@@ -52,11 +52,11 @@ export const QueryEditorToolbar: React.FC<Props> = (props) => {
       <div className="gf-form gf-form--grow">
         <div className="gf-form-label--grow" />
       </div>
-      <Button variant="secondary" onClick={onToggleMode}>
+      <Button variant="secondary" aria-label="Edit KQL" onClick={onToggleMode}>
         {props.editorMode === EditorMode.Visual ? 'Edit KQL' : 'Switch to builder'}
       </Button>
       <div className={styles.spacing} />
-      <Button variant={props.dirty ? 'primary' : 'secondary'} onClick={props.onRunQuery}>
+      <Button variant={props.dirty ? 'primary' : 'secondary'} aria-label="Run Query" onClick={props.onRunQuery}>
         Run Query
       </Button>
       <ConfirmModal

--- a/src/components/QueryEditorToolbar.tsx
+++ b/src/components/QueryEditorToolbar.tsx
@@ -5,6 +5,7 @@ import React, { useCallback, useState } from 'react';
 import { EditorMode } from 'types';
 
 import { QueryEditorSection } from '../editor/components/QueryEditorSection';
+import { selectors } from '../test/selectors';
 
 interface Props {
   database: string;
@@ -52,11 +53,11 @@ export const QueryEditorToolbar: React.FC<Props> = (props) => {
       <div className="gf-form gf-form--grow">
         <div className="gf-form-label--grow" />
       </div>
-      <Button variant="secondary" aria-label="Edit KQL" onClick={onToggleMode}>
+      <Button variant="secondary" aria-label={selectors.components.queryEditor.editKQL.button} onClick={onToggleMode}>
         {props.editorMode === EditorMode.Visual ? 'Edit KQL' : 'Switch to builder'}
       </Button>
       <div className={styles.spacing} />
-      <Button variant={props.dirty ? 'primary' : 'secondary'} aria-label="Run Query" onClick={props.onRunQuery}>
+      <Button variant={props.dirty ? 'primary' : 'secondary'} aria-label={selectors.components.queryEditor.runQuery.button} onClick={props.onRunQuery}>
         Run Query
       </Button>
       <ConfirmModal

--- a/src/components/QueryEditorToolbar.tsx
+++ b/src/components/QueryEditorToolbar.tsx
@@ -36,6 +36,7 @@ export const QueryEditorToolbar: React.FC<Props> = (props) => {
         width={30}
         options={props.databases}
         placeholder="Select database"
+        aria-label={selectors.components.queryEditor.database.input}
         value={props.database}
         onChange={(selected) => {
           if (!selected || !selected.value) {

--- a/src/components/RawQueryEditor.test.tsx
+++ b/src/components/RawQueryEditor.test.tsx
@@ -1,6 +1,7 @@
 import { config } from '@grafana/runtime';
 import { render, screen } from '@testing-library/react';
 import React from 'react';
+import { selectors } from 'test/selectors';
 
 import { mockDatasource, mockQuery } from './__fixtures__/Datasource';
 import { RawQueryEditor } from './RawQueryEditor';
@@ -32,13 +33,13 @@ describe('RawQueryEditor', () => {
 
   it('should render legacy editor', () => {
     render(<RawQueryEditor {...defaultProps} />);
-    expect(screen.getByTestId('legacy-editor')).toBeInTheDocument();
+    expect(screen.getByTestId(selectors.components.queryEditor.codeEditorLegacy.container)).toBeInTheDocument();
   });
 
   it('should render the new code editor', async () => {
     config.featureToggles.adxNewCodeEditor = true;
     render(<RawQueryEditor {...defaultProps} />);
-    expect(screen.getByTestId('code-editor')).toBeInTheDocument();
+    expect(screen.getByTestId(selectors.components.queryEditor.codeEditor.container)).toBeInTheDocument();
     await screen.findByText('Loading...');
   });
 });

--- a/src/components/RawQueryEditor.tsx
+++ b/src/components/RawQueryEditor.tsx
@@ -5,6 +5,7 @@ import { CodeEditor, Icon, Monaco, MonacoEditor, useStyles2 } from '@grafana/ui'
 import { QueryEditorResultFormat, selectResultFormat } from 'components/QueryEditorResultFormat';
 import { AdxDataSource } from 'datasource';
 import React, { useCallback, useState } from 'react';
+import { selectors } from 'test/selectors';
 import { AdxDataSourceOptions, AdxSchema, KustoQuery } from 'types';
 
 import { KustoMonacoEditor } from '../monaco/KustoMonacoEditor';
@@ -85,7 +86,7 @@ export const RawQueryEditor: React.FC<RawQueryEditorProps> = (props) => {
           />
         </div>
       ) : (
-        <div data-testid="legacy-editor">
+        <div data-testid={selectors.components.queryEditor.codeEditor.container}>
           <KustoMonacoEditor
             defaultTimeField="Timestamp"
             pluginBaseUrl={baseUrl}

--- a/src/components/RawQueryEditor.tsx
+++ b/src/components/RawQueryEditor.tsx
@@ -74,7 +74,7 @@ export const RawQueryEditor: React.FC<RawQueryEditorProps> = (props) => {
   return (
     <div>
       {config.featureToggles.adxNewCodeEditor ? (
-        <div data-testid="code-editor">
+        <div data-testid={selectors.components.queryEditor.codeEditor.container}>
           <CodeEditor
             language="kusto"
             value={query.query || defaultQuery}
@@ -86,7 +86,7 @@ export const RawQueryEditor: React.FC<RawQueryEditorProps> = (props) => {
           />
         </div>
       ) : (
-        <div data-testid={selectors.components.queryEditor.codeEditor.container}>
+        <div data-testid={selectors.components.queryEditor.codeEditorLegacy.container}>
           <KustoMonacoEditor
             defaultTimeField="Timestamp"
             pluginBaseUrl={baseUrl}

--- a/src/components/VisualQueryEditor.tsx
+++ b/src/components/VisualQueryEditor.tsx
@@ -11,6 +11,7 @@ import {
 } from 'editor/expressions';
 import React, { useCallback, useMemo } from 'react';
 import { useAsync } from 'react-use';
+import { selectors } from 'test/selectors';
 
 import { QueryEditorResultFormat, selectResultFormat } from '../components/QueryEditorResultFormat';
 import { SchemaError, SchemaLoading, SchemaWarning } from '../components/SchemaMessages';
@@ -213,16 +214,23 @@ export const VisualQueryEditor: React.FC<Props> = (props) => {
     [onChangeQuery, query, resultFormat, database, table, parseExpression, tableSchema.value]
   );
 
+  const KustoTable = (kustoTableProps: { children?: React.ReactElement }) => (
+    <KustoPropertyEditorSection
+      templateVariableOptions={props.templateVariableOptions}
+      label="From"
+      value={table}
+      fields={tables}
+      onChange={onChangeTable}
+      aria-label={selectors.components.queryEditor.tableFrom.input}
+    >
+      {kustoTableProps.children}
+    </KustoPropertyEditorSection>
+  );
+
   if (tableSchema.loading) {
     return (
       <>
-        <KustoPropertyEditorSection
-          templateVariableOptions={props.templateVariableOptions}
-          label="From"
-          value={table}
-          fields={tables}
-          onChange={onChangeTable}
-        />
+        <KustoTable />
         <SchemaLoading />
       </>
     );
@@ -231,13 +239,7 @@ export const VisualQueryEditor: React.FC<Props> = (props) => {
   if (tableSchema.error) {
     return (
       <>
-        <KustoPropertyEditorSection
-          templateVariableOptions={props.templateVariableOptions}
-          label="From"
-          value={table}
-          fields={tables}
-          onChange={onChangeTable}
-        />
+        <KustoTable />
         <SchemaError message={`Could not load table schema: ${tableSchema.error?.message}`} />
       </>
     );
@@ -246,13 +248,7 @@ export const VisualQueryEditor: React.FC<Props> = (props) => {
   if (tableSchema.value?.length === 0) {
     return (
       <>
-        <KustoPropertyEditorSection
-          templateVariableOptions={props.templateVariableOptions}
-          label="From"
-          value={table}
-          fields={tables}
-          onChange={onChangeTable}
-        />
+        <KustoTable />
         <SchemaWarning message="Table schema loaded successfully but without any columns" />
       </>
     );
@@ -260,19 +256,13 @@ export const VisualQueryEditor: React.FC<Props> = (props) => {
 
   return (
     <>
-      <KustoPropertyEditorSection
-        templateVariableOptions={props.templateVariableOptions}
-        label="From"
-        value={table}
-        fields={tables}
-        onChange={onChangeTable}
-      >
+      <KustoTable>
         <QueryEditorResultFormat
           format={resultFormat}
           includeAdxTimeFormat={false}
           onChangeFormat={onChangeResultFormat}
         />
-      </KustoPropertyEditorSection>
+      </KustoTable>
       <KustoWhereEditorSection
         templateVariableOptions={props.templateVariableOptions}
         label="Where (filter)"

--- a/src/editor/components/field/QueryEditorField.tsx
+++ b/src/editor/components/field/QueryEditorField.tsx
@@ -12,6 +12,7 @@ interface Props {
   onChange: (property: QueryEditorProperty) => void;
   placeholder?: string;
   allowCustom?: boolean;
+  'aria-label'?: string;
 }
 
 export const definitionToProperty = (definition: QueryEditorPropertyDefinition): QueryEditorProperty => {
@@ -61,6 +62,7 @@ export const QueryEditorField: React.FC<Props> = (props) => {
         backspaceRemovesValue={true}
         isClearable={true}
         onCloseMenu={onCloseMenu}
+        aria-label={props['aria-label']}
       />
     </div>
   );

--- a/src/editor/components/field/QueryEditorFieldSection.tsx
+++ b/src/editor/components/field/QueryEditorFieldSection.tsx
@@ -1,5 +1,5 @@
-import React from 'react';
 import { SelectableValue } from '@grafana/data';
+import React from 'react';
 
 import { QueryEditorExpression, QueryEditorExpressionType, QueryEditorPropertyExpression } from '../../expressions';
 import { isFieldExpression } from '../../guards';
@@ -17,6 +17,7 @@ export interface QueryEditorFieldSectionProps extends React.PropsWithChildren<Qu
   value?: QueryEditorExpression;
   onChange: (value: QueryEditorExpression) => void;
   allowCustom?: boolean;
+  'aria-label'?: string;
 }
 
 export const QueryEditorFieldSection = (config: FieldSectionConfiguration): React.FC<QueryEditorFieldSectionProps> => {
@@ -36,6 +37,7 @@ export const QueryEditorFieldSection = (config: FieldSectionConfiguration): Reac
           onChange={onChange(propsOnChange)}
           value={expression.property}
           allowCustom={props.allowCustom}
+          aria-label={props['aria-label']}
         />
         {props.children}
       </QueryEditorSection>

--- a/src/test/selectors.ts
+++ b/src/test/selectors.ts
@@ -22,6 +22,9 @@ export const components = {
     editKQL: {
       button: 'Edit KQL',
     },
+    codeEditorLegacy: {
+      container: 'data-testid code-editor',
+    },
     codeEditor: {
       container: 'data-testid legacy-editor',
     },

--- a/src/test/selectors.ts
+++ b/src/test/selectors.ts
@@ -22,11 +22,11 @@ export const components = {
     editKQL: {
       button: 'Edit KQL',
     },
-    runQuery: {
-      button: 'Run Query',
-    },
     codeEditor: {
       container: 'Editor content;Press Alt+F1 for Accessibility Options.',
+    },
+    runQuery: {
+      button: 'Run Query',
     },
   },
 };

--- a/src/test/selectors.ts
+++ b/src/test/selectors.ts
@@ -18,6 +18,17 @@ export const components = {
       input: 'data-testid client-secret',
     },
   },
+  queryEditor: {
+    editKQL: {
+      button: 'Edit KQL',
+    },
+    runQuery: {
+      button: 'Run Query',
+    },
+    codeEditor: {
+      container: 'Editor content;Press Alt+F1 for Accessibility Options.',
+    },
+  },
 };
 
 export const selectors: { components: E2ESelectors<typeof components> } = {

--- a/src/test/selectors.ts
+++ b/src/test/selectors.ts
@@ -23,7 +23,10 @@ export const components = {
       button: 'Edit KQL',
     },
     codeEditor: {
-      container: 'Editor content;Press Alt+F1 for Accessibility Options.',
+      container: 'data-testid legacy-editor',
+    },
+    database: {
+      input: 'Database',
     },
     runQuery: {
       button: 'Run Query',

--- a/src/test/selectors.ts
+++ b/src/test/selectors.ts
@@ -24,12 +24,16 @@ export const components = {
     },
     codeEditorLegacy: {
       container: 'data-testid code-editor',
+      textarea: 'Editor content;Press Alt+F1 for Accessibility Options.',
     },
     codeEditor: {
       container: 'data-testid legacy-editor',
     },
     database: {
       input: 'Database',
+    },
+    tableFrom: {
+      input: 'From table',
     },
     runQuery: {
       button: 'Run Query',


### PR DESCRIPTION
Fixes #313 

Added two e2e scenarios:

1. Types in a KQL query (`PerfTest | where $__timeFilter(_Timestamp_) | order by _Timestamp_ asc`) and runs it
      -> check that panel loads and some data is shown (looking for flag: `Lonely period range deg`)
      
<img src="https://user-images.githubusercontent.com/42030685/162184837-217e0104-d167-4a6a-9dc9-7c18b6a89b01.png" width="400" />

      
2. Uses the builder to run a query returning no results (looking at `events.all` table)
      -> check that the panel display message : `No graphable fields`

<img src="https://user-images.githubusercontent.com/42030685/162184858-df828395-b058-4eb7-9234-b371169cfa30.png" width="400" />
