### PR TITLE
Add symbols for timespan types

### DIFF
--- a/src/components/VisualQueryEditorSections.tsx
+++ b/src/components/VisualQueryEditorSections.tsx
@@ -1,10 +1,9 @@
 import {
   buildFieldQueryEditorSection,
   buildFilterQueryEditorSection,
-  buildReduceQueryEditorSection,
   buildGroupByQueryEditorSection,
+  buildReduceQueryEditorSection,
 } from '../editor';
-
 import { QueryEditorPropertyType } from '../editor/types';
 
 export const KustoPropertyEditorSection = buildFieldQueryEditorSection((fieldSection) => fieldSection.build());
@@ -43,12 +42,20 @@ export const KustoWhereEditorSection = buildFilterQueryEditorSection((filterSect
         .add();
 
       operator('>')
-        .supportTypes([QueryEditorPropertyType.Number, QueryEditorPropertyType.DateTime])
+        .supportTypes([
+          QueryEditorPropertyType.Number,
+          QueryEditorPropertyType.DateTime,
+          QueryEditorPropertyType.TimeSpan,
+        ])
         .withDescription('greater than')
         .add();
 
       operator('<')
-        .supportTypes([QueryEditorPropertyType.Number, QueryEditorPropertyType.DateTime])
+        .supportTypes([
+          QueryEditorPropertyType.Number,
+          QueryEditorPropertyType.DateTime,
+          QueryEditorPropertyType.TimeSpan,
+        ])
         .withDescription('less than')
         .add();
 

--- a/src/schema/mapper.ts
+++ b/src/schema/mapper.ts
@@ -1,6 +1,7 @@
-import { AdxTableSchema, AdxColumnSchema, AdxDatabaseSchema } from '../types';
-import { QueryEditorPropertyDefinition, QueryEditorPropertyType } from '../editor/types';
 import { SelectableValue } from '@grafana/data';
+
+import { QueryEditorPropertyDefinition, QueryEditorPropertyType } from '../editor/types';
+import { AdxColumnSchema, AdxDatabaseSchema, AdxTableSchema } from '../types';
 
 export const tableToDefinition = (table: AdxTableSchema): QueryEditorPropertyDefinition => {
   return {
@@ -66,6 +67,8 @@ const toPropertyType = (kustoType: string): QueryEditorPropertyType => {
       return QueryEditorPropertyType.DateTime;
     case 'bool':
       return QueryEditorPropertyType.Boolean;
+    case 'timespan':
+      return QueryEditorPropertyType.TimeSpan;
     default:
       return QueryEditorPropertyType.String;
   }


### PR DESCRIPTION
_From mob sessions_

Fixes https://github.com/grafana/azure-data-explorer-datasource/issues/267

It does not include tests because of https://github.com/grafana/azure-data-explorer-datasource/issues/343

I didn't add more symbols because they may not work with timespans (from the original comment in #267):

> At a minimum, the [numeric operators](https://docs.microsoft.com/en-us/azure/data-explorer/kusto/query/numoperators) should be provided, even if there are some that won't work with timespans.