### PR TITLE
Fix CSS import

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Change Log
 
+## [4.0.0]
+
+_Not released yet_
+
+- Breaking Change: Azure Data Explorer plugin now requires Grafana 8.0+ to run.
+
 ## [3.7.1]
 
 - Bugfix: Fix scope for national clouds

--- a/src/components/QueryEditorResultFormat.tsx
+++ b/src/components/QueryEditorResultFormat.tsx
@@ -1,7 +1,7 @@
-import React, { useCallback } from 'react';
-import { css } from 'emotion';
+import { css } from '@emotion/css';
 import { SelectableValue } from '@grafana/data';
 import { InlineFormLabel, Select, stylesFactory } from '@grafana/ui';
+import React, { useCallback } from 'react';
 
 interface Props {
   format: string;

--- a/src/components/QueryEditorToolbar.tsx
+++ b/src/components/QueryEditorToolbar.tsx
@@ -1,9 +1,10 @@
-import React, { useState, useCallback } from 'react';
-import { css } from 'emotion';
-import { Select, Button, stylesFactory, ConfirmModal } from '@grafana/ui';
+import { css } from '@emotion/css';
 import { SelectableValue } from '@grafana/data';
-import { QueryEditorSection } from '../editor/components/QueryEditorSection';
+import { Button, ConfirmModal, Select, stylesFactory } from '@grafana/ui';
+import React, { useCallback, useState } from 'react';
 import { EditorMode } from 'types';
+
+import { QueryEditorSection } from '../editor/components/QueryEditorSection';
 
 interface Props {
   database: string;

--- a/src/components/RawQueryEditor.tsx
+++ b/src/components/RawQueryEditor.tsx
@@ -1,12 +1,12 @@
-import React, { PureComponent } from 'react';
-import { Icon, stylesFactory } from '@grafana/ui';
-import { css } from 'emotion';
-import { KustoQuery, AdxDataSourceOptions, AdxSchema } from 'types';
+import { css } from '@emotion/css';
 import { DataSourceApi, QueryEditorProps, SelectableValue } from '@grafana/data';
-import { KustoMonacoEditor } from '../monaco/KustoMonacoEditor';
+import { Icon, stylesFactory } from '@grafana/ui';
 import { QueryEditorResultFormat, selectResultFormat } from 'components/QueryEditorResultFormat';
-
 import config from 'grafana/app/core/config';
+import React, { PureComponent } from 'react';
+import { AdxDataSourceOptions, AdxSchema, KustoQuery } from 'types';
+
+import { KustoMonacoEditor } from '../monaco/KustoMonacoEditor';
 
 type Props = QueryEditorProps<DataSourceApi<KustoQuery, AdxDataSourceOptions>, KustoQuery, AdxDataSourceOptions>;
 

--- a/src/components/SchemaMessages.tsx
+++ b/src/components/SchemaMessages.tsx
@@ -1,7 +1,7 @@
-import React from 'react';
-import { css } from 'emotion';
-import { Icon, stylesFactory, useTheme } from '@grafana/ui';
+import { css } from '@emotion/css';
 import { GrafanaTheme } from '@grafana/data';
+import { Icon, stylesFactory, useTheme } from '@grafana/ui';
+import React from 'react';
 
 export const SchemaLoading: React.FC<{}> = (props) => {
   const theme = useTheme();

--- a/src/components/VisualQueryEditor.tsx
+++ b/src/components/VisualQueryEditor.tsx
@@ -1,31 +1,32 @@
-import React, { useMemo, useCallback } from 'react';
-import { useAsync } from 'react-use';
-import { css } from 'emotion';
-import { KustoQuery, AdxSchema, AdxColumnSchema, defaultQuery } from '../types';
-import { columnsToDefinition } from '../schema/mapper';
+import { css } from '@emotion/css';
+import { SelectableValue } from '@grafana/data';
+import { getTemplateSrv } from '@grafana/runtime';
+import { stylesFactory, TextArea } from '@grafana/ui';
 import {
-  QueryEditorExpressionType,
-  QueryEditorPropertyExpression,
-  QueryEditorExpression,
   QueryEditorArrayExpression,
+  QueryEditorExpression,
+  QueryEditorExpressionType,
   QueryEditorOperatorExpression,
+  QueryEditorPropertyExpression,
 } from 'editor/expressions';
-import { QueryEditorPropertyDefinition, QueryEditorPropertyType } from '../editor/types';
-import {
-  KustoPropertyEditorSection,
-  KustoWhereEditorSection,
-  KustoValueColumnEditorSection,
-  KustoGroupByEditorSection,
-} from './VisualQueryEditorSections';
+import React, { useCallback, useMemo } from 'react';
+import { useAsync } from 'react-use';
+
+import { QueryEditorResultFormat, selectResultFormat } from '../components/QueryEditorResultFormat';
+import { SchemaError, SchemaLoading, SchemaWarning } from '../components/SchemaMessages';
+import { AdxDataSource } from '../datasource';
 import { definitionToProperty } from '../editor/components/field/QueryEditorField';
 import { isFieldExpression } from '../editor/guards';
-import { AdxDataSource } from '../datasource';
+import { QueryEditorPropertyDefinition, QueryEditorPropertyType } from '../editor/types';
 import { AdxSchemaResolver } from '../schema/AdxSchemaResolver';
-import { QueryEditorResultFormat, selectResultFormat } from '../components/QueryEditorResultFormat';
-import { TextArea, stylesFactory } from '@grafana/ui';
-import { SelectableValue } from '@grafana/data';
-import { SchemaLoading, SchemaError, SchemaWarning } from '../components/SchemaMessages';
-import { getTemplateSrv } from '@grafana/runtime';
+import { columnsToDefinition } from '../schema/mapper';
+import { AdxColumnSchema, AdxSchema, defaultQuery, KustoQuery } from '../types';
+import {
+  KustoGroupByEditorSection,
+  KustoPropertyEditorSection,
+  KustoValueColumnEditorSection,
+  KustoWhereEditorSection,
+} from './VisualQueryEditorSections';
 
 interface Props {
   database: string;

--- a/src/editor/components/filter/QueryEditorFieldAndOperator.tsx
+++ b/src/editor/components/filter/QueryEditorFieldAndOperator.tsx
@@ -1,20 +1,20 @@
-import React, { PureComponent } from 'react';
-import { css } from 'emotion';
-import _ from 'lodash';
+import { css } from '@emotion/css';
+import { SelectableValue } from '@grafana/data';
 import { stylesFactory } from '@grafana/ui';
-import { SkippableExpressionSuggestor } from '../types';
+import debounce from 'debounce-promise';
+import React, { PureComponent } from 'react';
+
+import { QueryEditorExpressionType, QueryEditorOperatorExpression } from '../../expressions';
 import {
-  QueryEditorPropertyDefinition,
+  QueryEditorOperator,
   QueryEditorOperatorDefinition,
   QueryEditorProperty,
-  QueryEditorOperator,
+  QueryEditorPropertyDefinition,
 } from '../../types';
 import { QueryEditorField } from '../field/QueryEditorField';
-import { QueryEditorOperatorComponent, definitionToOperator } from '../operators/QueryEditorOperator';
-import { SelectableValue } from '@grafana/data';
-import { QueryEditorExpressionType, QueryEditorOperatorExpression } from '../../expressions';
 import { parseOperatorValue } from '../operators/parser';
-import debounce from 'debounce-promise';
+import { definitionToOperator, QueryEditorOperatorComponent } from '../operators/QueryEditorOperator';
+import { SkippableExpressionSuggestor } from '../types';
 
 interface Props {
   value?: QueryEditorOperatorExpression;

--- a/src/editor/components/filter/QueryEditorFilterSection.tsx
+++ b/src/editor/components/filter/QueryEditorFilterSection.tsx
@@ -1,18 +1,19 @@
-import React from 'react';
-import { css } from 'emotion';
-import { QueryEditorOperatorDefinition, QueryEditorPropertyDefinition } from '../../types';
-import { QueryEditorSectionProps, QueryEditorSection } from '../QueryEditorSection';
+import { css } from '@emotion/css';
 import { SelectableValue } from '@grafana/data';
-import { SearchExpressionSuggestor, SkippableExpressionSuggestor } from '../types';
+import { Button, InlineFormLabel, Select, stylesFactory } from '@grafana/ui';
+import { isFieldAndOperator, isOrExpression } from 'editor/guards';
+import React from 'react';
+
 import {
   QueryEditorArrayExpression,
-  QueryEditorOperatorExpression,
   QueryEditorExpressionType,
+  QueryEditorOperatorExpression,
 } from '../../expressions';
-import { isFieldAndOperator, isOrExpression } from 'editor/guards';
-import { QueryEditorFieldAndOperator } from './QueryEditorFieldAndOperator';
-import { Button, Select, stylesFactory, InlineFormLabel } from '@grafana/ui';
+import { QueryEditorOperatorDefinition, QueryEditorPropertyDefinition } from '../../types';
 import { QueryEditorRepeater } from '../QueryEditorRepeater';
+import { QueryEditorSection, QueryEditorSectionProps } from '../QueryEditorSection';
+import { SearchExpressionSuggestor, SkippableExpressionSuggestor } from '../types';
+import { QueryEditorFieldAndOperator } from './QueryEditorFieldAndOperator';
 
 interface FilterSectionConfiguration {
   operators: QueryEditorOperatorDefinition[];

--- a/src/editor/components/groupBy/QueryEditorGroupBy.tsx
+++ b/src/editor/components/groupBy/QueryEditorGroupBy.tsx
@@ -1,10 +1,11 @@
-import React, { useCallback, useEffect, useState } from 'react';
-import { css } from 'emotion';
-import { stylesFactory } from '@grafana/ui';
-import { QueryEditorPropertyDefinition, QueryEditorPropertyType, QueryEditorProperty } from '../../types';
-import { QueryEditorField } from '../field/QueryEditorField';
+import { css } from '@emotion/css';
 import { SelectableValue } from '@grafana/data';
-import { QueryEditorGroupByExpression, QueryEditorExpressionType } from '../../expressions';
+import { stylesFactory } from '@grafana/ui';
+import React, { useCallback, useEffect, useState } from 'react';
+
+import { QueryEditorExpressionType, QueryEditorGroupByExpression } from '../../expressions';
+import { QueryEditorProperty, QueryEditorPropertyDefinition, QueryEditorPropertyType } from '../../types';
+import { QueryEditorField } from '../field/QueryEditorField';
 
 interface Props {
   fields: QueryEditorPropertyDefinition[];

--- a/src/editor/components/groupBy/QueryEditorGroupBySection.tsx
+++ b/src/editor/components/groupBy/QueryEditorGroupBySection.tsx
@@ -1,12 +1,13 @@
-import React from 'react';
+import { css } from '@emotion/css';
 import { SelectableValue } from '@grafana/data';
 import { Button, stylesFactory } from '@grafana/ui';
-import { css } from 'emotion';
-import { QueryEditorPropertyDefinition } from '../../types';
-import { QueryEditorSection, QueryEditorSectionProps } from '../QueryEditorSection';
-import { QueryEditorExpression, QueryEditorArrayExpression } from '../../expressions';
-import { QueryEditorRepeater } from '../QueryEditorRepeater';
+import React from 'react';
+
+import { QueryEditorArrayExpression, QueryEditorExpression } from '../../expressions';
 import { isGroupBy } from '../../guards';
+import { QueryEditorPropertyDefinition } from '../../types';
+import { QueryEditorRepeater } from '../QueryEditorRepeater';
+import { QueryEditorSection, QueryEditorSectionProps } from '../QueryEditorSection';
 import { QueryEditorGroupBy } from './QueryEditorGroupBy';
 
 interface GroupBySectionConfiguration {

--- a/src/editor/components/operators/QueryEditorOperator.tsx
+++ b/src/editor/components/operators/QueryEditorOperator.tsx
@@ -1,21 +1,22 @@
-import React, { PureComponent } from 'react';
-import { css } from 'emotion';
-import { Select, stylesFactory, Button } from '@grafana/ui';
+import { css } from '@emotion/css';
 import { SelectableValue } from '@grafana/data';
-import { ExpressionSuggestor } from '../types';
+import { Button, Select, stylesFactory } from '@grafana/ui';
+import React, { PureComponent } from 'react';
+
+import { isBoolOperator, isDateTimeOperator, isMultiOperator, isNumberOperator, isSingleOperator } from '../../guards';
 import {
-  QueryEditorOperatorDefinition,
   QueryEditorOperator,
+  QueryEditorOperatorDefinition,
   QueryEditorProperty,
   QueryEditorPropertyType,
 } from '../../types';
-import { QueryEditorMultiOperator } from './QueryEditorMultiOperator';
-import { QueryEditorSingleOperator } from './QueryEditorSingleOperator';
-import { QueryEditorBoolOperator } from './QueryEditorBoolOperator';
-import { isMultiOperator, isBoolOperator, isSingleOperator, isDateTimeOperator, isNumberOperator } from '../../guards';
+import { ExpressionSuggestor } from '../types';
 import { parseOperatorValue } from './parser';
-import { QueryEditorStringOperator } from './QueryEditorStringOperator';
+import { QueryEditorBoolOperator } from './QueryEditorBoolOperator';
+import { QueryEditorMultiOperator } from './QueryEditorMultiOperator';
 import { QueryEditorNumberOperator } from './QueryEditorNumberOperator';
+import { QueryEditorSingleOperator } from './QueryEditorSingleOperator';
+import { QueryEditorStringOperator } from './QueryEditorStringOperator';
 
 interface Props {
   value?: QueryEditorOperator;

--- a/src/editor/components/reduce/QueryEditorReduce.tsx
+++ b/src/editor/components/reduce/QueryEditorReduce.tsx
@@ -1,21 +1,22 @@
-import React, { useCallback, useEffect, useState, useMemo } from 'react';
-import { css } from 'emotion';
+import { css } from '@emotion/css';
+import { SelectableValue } from '@grafana/data';
 import { InlineFormLabel, stylesFactory } from '@grafana/ui';
+import React, { useCallback, useEffect, useMemo, useState } from 'react';
+
 import {
-  QueryEditorPropertyDefinition,
+  QueryEditorExpressionType,
+  QueryEditorFunctionParameterExpression,
+  QueryEditorReduceExpression,
+} from '../../expressions';
+import {
   QueryEditorFunctionDefinition,
   QueryEditorFunctionParameter,
-  QueryEditorPropertyType,
   QueryEditorProperty,
+  QueryEditorPropertyDefinition,
+  QueryEditorPropertyType,
 } from '../../types';
 import { QueryEditorField } from '../field/QueryEditorField';
-import { SelectableValue } from '@grafana/data';
 import { QueryEditorFunctionParameterSection } from '../field/QueryEditorFunctionParameterSection';
-import {
-  QueryEditorReduceExpression,
-  QueryEditorFunctionParameterExpression,
-  QueryEditorExpressionType,
-} from '../../expressions';
 
 interface Props {
   fields: QueryEditorPropertyDefinition[];

--- a/src/editor/components/reduce/QueryEditorReduceSection.tsx
+++ b/src/editor/components/reduce/QueryEditorReduceSection.tsx
@@ -1,13 +1,14 @@
-import React from 'react';
-import { css } from 'emotion';
-import { QueryEditorFunctionDefinition, QueryEditorPropertyDefinition } from '../../types';
-import { QueryEditorSection, QueryEditorSectionProps } from '../QueryEditorSection';
+import { css } from '@emotion/css';
 import { SelectableValue } from '@grafana/data';
-import { QueryEditorExpression, QueryEditorArrayExpression } from '../../expressions';
-import { isReduceExpression } from 'editor/guards';
-import { QueryEditorReduce } from './QueryEditorReduce';
 import { Button, stylesFactory } from '@grafana/ui';
+import { isReduceExpression } from 'editor/guards';
+import React from 'react';
+
+import { QueryEditorArrayExpression, QueryEditorExpression } from '../../expressions';
+import { QueryEditorFunctionDefinition, QueryEditorPropertyDefinition } from '../../types';
 import { QueryEditorRepeater } from '../QueryEditorRepeater';
+import { QueryEditorSection, QueryEditorSectionProps } from '../QueryEditorSection';
+import { QueryEditorReduce } from './QueryEditorReduce';
 
 interface ReduceSectionConfiguration {
   defaultValue: QueryEditorExpression;

--- a/src/monaco/KustoMonacoEditor.tsx
+++ b/src/monaco/KustoMonacoEditor.tsx
@@ -3,14 +3,14 @@
 ///<reference path="../../node_modules/monaco-editor/monaco.d.ts" />
 /* tslint:enable */
 /* eslint-enable */
-
+import { css } from '@emotion/css';
+import { stylesFactory } from '@grafana/ui';
+import config from 'grafana/app/core/config';
 import React from 'react';
+
 import { AdxSchema } from '../types';
 import KustoCodeEditor from './kusto_code_editor';
-import { css } from 'emotion';
-import { stylesFactory } from '@grafana/ui';
 
-import config from 'grafana/app/core/config';
 
 interface Props {
   content: string;

--- a/src/monaco/KustoMonacoEditor.tsx
+++ b/src/monaco/KustoMonacoEditor.tsx
@@ -11,7 +11,6 @@ import React from 'react';
 import { AdxSchema } from '../types';
 import KustoCodeEditor from './kusto_code_editor';
 
-
 interface Props {
   content: string;
   defaultTimeField: string;

--- a/src/plugin.json
+++ b/src/plugin.json
@@ -28,8 +28,8 @@
     "updated": "%TODAY%"
   },
   "dependencies": {
-    "grafanaDependency": ">=7.4.0",
-    "grafanaVersion": "7.4.x",
+    "grafanaDependency": ">=8.0.0",
+    "grafanaVersion": "8.0.x",
     "plugins": []
   },
   "metrics": true,


### PR DESCRIPTION
Fixes #343

Fixes import path for the `css` package. Note that this breaks compatibility with Grafana 7.5 since it uses an old version of the package. That's why I have updated the changelog for a future major version release.

@taleena can you confirm if this is okay? 