### PR TITLE
Add @grafana/ui CodeEditor behind a feature flag

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,5 +44,8 @@
     "react-select-event": "^5.2.0",
     "react-use": "^15.3.3",
     "tslib": "^2.3.1"
+  },
+  "resolutions": {
+    "rxjs": "6.6.3"
   }
 }

--- a/src/QueryEditor.tsx
+++ b/src/QueryEditor.tsx
@@ -1,19 +1,19 @@
-import React, { useMemo, useCallback, useEffect } from 'react';
-import { useAsync } from 'react-use';
-import { QueryEditorProps, PanelData, DataSourceApi } from '@grafana/data';
-// Hack for issue: https://github.com/grafana/grafana/issues/26512
-import {} from '@emotion/core';
-import { AdxDataSource } from './datasource';
-import { KustoQuery, AdxDataSourceOptions, AdxSchema, EditorMode } from 'types';
-import { QueryEditorPropertyDefinition } from './editor/types';
-import { RawQueryEditor } from './components/RawQueryEditor';
-import { databaseToDefinition } from './schema/mapper';
-import { VisualQueryEditor } from './components/VisualQueryEditor';
-import { QueryEditorToolbar } from './components/QueryEditorToolbar';
+import { PanelData, QueryEditorProps } from '@grafana/data';
 import { SchemaLoading } from 'components/SchemaMessages';
-import { needsToBeMigrated, migrateQuery } from 'migrations/query';
+import { migrateQuery, needsToBeMigrated } from 'migrations/query';
+import React, { useCallback, useEffect, useMemo } from 'react';
+import { useAsync } from 'react-use';
+import { AdxDataSourceOptions, AdxSchema, EditorMode, KustoQuery } from 'types';
 
-type Props = QueryEditorProps<DataSourceApi<KustoQuery, AdxDataSourceOptions>, KustoQuery, AdxDataSourceOptions>;
+import { QueryEditorToolbar } from './components/QueryEditorToolbar';
+import { RawQueryEditor } from './components/RawQueryEditor';
+import { VisualQueryEditor } from './components/VisualQueryEditor';
+import { AdxDataSource } from './datasource';
+import { QueryEditorPropertyDefinition } from './editor/types';
+import { databaseToDefinition } from './schema/mapper';
+
+// Hack for issue: https://github.com/grafana/grafana/issues/26512
+type Props = QueryEditorProps<AdxDataSource, KustoQuery, AdxDataSourceOptions>;
 
 export const QueryEditor: React.FC<Props> = (props) => {
   const { datasource, onChange, onRunQuery, query } = props;

--- a/src/QueryEditor.tsx
+++ b/src/QueryEditor.tsx
@@ -12,7 +12,6 @@ import { AdxDataSource } from './datasource';
 import { QueryEditorPropertyDefinition } from './editor/types';
 import { databaseToDefinition } from './schema/mapper';
 
-// Hack for issue: https://github.com/grafana/grafana/issues/26512
 type Props = QueryEditorProps<AdxDataSource, KustoQuery, AdxDataSourceOptions>;
 
 export const QueryEditor: React.FC<Props> = (props) => {

--- a/src/components/QueryEditorResultFormat.tsx
+++ b/src/components/QueryEditorResultFormat.tsx
@@ -42,6 +42,7 @@ export const QueryEditorResultFormat: React.FC<Props> = (props) => {
         options={props.includeAdxTimeFormat ? [...formats, adxTimeFormat] : formats}
         value={props.format}
         onChange={onFormatChange}
+        menuShouldPortal
       />
     </div>
   );

--- a/src/components/RawQueryEditor.test.tsx
+++ b/src/components/RawQueryEditor.test.tsx
@@ -1,0 +1,44 @@
+import { config } from '@grafana/runtime';
+import { render, screen } from '@testing-library/react';
+import React from 'react';
+
+import { mockDatasource, mockQuery } from './__fixtures__/Datasource';
+import { RawQueryEditor } from './RawQueryEditor';
+
+jest.mock('../monaco/KustoMonacoEditor', () => {
+  return {
+    KustoMonacoEditor: () => {
+      return <></>;
+    },
+  };
+});
+
+const defaultProps = {
+  database: 'default',
+  templateVariableOptions: {},
+  onChange: jest.fn(),
+  onRunQuery: jest.fn(),
+  datasource: mockDatasource,
+  query: mockQuery,
+  schema: { Databases: {} },
+};
+
+describe('RawQueryEditor', () => {
+  const featureToggles = { ...config.featureToggles };
+
+  afterEach(() => {
+    config.featureToggles = featureToggles;
+  });
+
+  it('should render legacy editor', () => {
+    render(<RawQueryEditor {...defaultProps} />);
+    expect(screen.getByTestId('legacy-editor')).toBeInTheDocument();
+  });
+
+  it('should render the new code editor', async () => {
+    config.featureToggles.adxNewCodeEditor = true;
+    render(<RawQueryEditor {...defaultProps} />);
+    expect(screen.getByTestId('code-editor')).toBeInTheDocument();
+    await screen.findByText('Loading...');
+  });
+});

--- a/src/components/RawQueryEditor.test.tsx
+++ b/src/components/RawQueryEditor.test.tsx
@@ -7,7 +7,7 @@ import { RawQueryEditor } from './RawQueryEditor';
 
 jest.mock('../monaco/KustoMonacoEditor', () => {
   return {
-    KustoMonacoEditor: () => {
+    KustoMonacoEditor: function C() {
       return <></>;
     },
   };

--- a/src/components/RawQueryEditor.tsx
+++ b/src/components/RawQueryEditor.tsx
@@ -1,14 +1,15 @@
 import { css } from '@emotion/css';
-import { DataSourceApi, GrafanaTheme2, QueryEditorProps, SelectableValue } from '@grafana/data';
-import { Icon, useStyles2 } from '@grafana/ui';
+import { GrafanaTheme2, QueryEditorProps, SelectableValue } from '@grafana/data';
+import { config } from '@grafana/runtime';
+import { CodeEditor, Icon, useStyles2 } from '@grafana/ui';
 import { QueryEditorResultFormat, selectResultFormat } from 'components/QueryEditorResultFormat';
-import config from 'grafana/app/core/config';
+import { AdxDataSource } from 'datasource';
 import React, { useState } from 'react';
 import { AdxDataSourceOptions, AdxSchema, KustoQuery } from 'types';
 
 import { KustoMonacoEditor } from '../monaco/KustoMonacoEditor';
 
-type Props = QueryEditorProps<DataSourceApi<KustoQuery, AdxDataSourceOptions>, KustoQuery, AdxDataSourceOptions>;
+type Props = QueryEditorProps<AdxDataSource, KustoQuery, AdxDataSourceOptions>;
 
 interface RawQueryEditorProps extends Props {
   dirty?: boolean;
@@ -63,14 +64,30 @@ export const RawQueryEditor: React.FC<RawQueryEditorProps> = (props) => {
 
   return (
     <div>
-      <KustoMonacoEditor
-        defaultTimeField="Timestamp"
-        pluginBaseUrl={baseUrl}
-        content={query.query || defaultQuery}
-        getSchema={async () => schema}
-        onChange={onRawQueryChange}
-        onExecute={props.onRunQuery}
-      />
+      {config.featureToggles.adxNewCodeEditor ? (
+        <div data-testid="code-editor">
+          <CodeEditor
+            language="kusto"
+            value={query.query || defaultQuery}
+            onBlur={onRawQueryChange}
+            showMiniMap={false}
+            showLineNumbers={true}
+            // getSuggestions={() => TBD}
+            height="240px"
+          />
+        </div>
+      ) : (
+        <div data-testid="legacy-editor">
+          <KustoMonacoEditor
+            defaultTimeField="Timestamp"
+            pluginBaseUrl={baseUrl}
+            content={query.query || defaultQuery}
+            getSchema={async () => schema}
+            onChange={onRawQueryChange}
+            onExecute={props.onRunQuery}
+          />
+        </div>
+      )}
 
       <div className={styles.toolbar}>
         <QueryEditorResultFormat

--- a/src/components/__fixtures__/Datasource.ts
+++ b/src/components/__fixtures__/Datasource.ts
@@ -1,0 +1,93 @@
+import { DataSourcePluginOptionsEditorProps, PluginType } from '@grafana/data';
+
+import { AdxDataSource } from '../../datasource';
+import { QueryEditorExpressionType } from '../../editor/expressions';
+import { AdxDataSourceOptions, AdxDataSourceSecureOptions, EditorMode, KustoQuery } from '../../types';
+
+export const mockDatasourceOptions: DataSourcePluginOptionsEditorProps<
+  AdxDataSourceOptions,
+  AdxDataSourceSecureOptions
+> = {
+  options: {
+    id: 1,
+    uid: 'adx-id',
+    orgId: 1,
+    name: 'ADX Data source',
+    typeLogoUrl: '',
+    type: '',
+    typeName: '',
+    access: '',
+    url: '',
+    password: '',
+    user: '',
+    basicAuth: false,
+    basicAuthPassword: '',
+    basicAuthUser: '',
+    database: '',
+    isDefault: false,
+    jsonData: {
+      defaultDatabase: 'default',
+      minimalCache: 1,
+      defaultEditorMode: EditorMode.Raw,
+      queryTimeout: '',
+      dataConsistency: '',
+      cacheMaxAge: '',
+      dynamicCaching: false,
+      useSchemaMapping: false,
+      enableUserTracking: false,
+      clusterUrl: '',
+      tenantId: '',
+      clientId: '',
+      onBehalfOf: false,
+      oauthPassThru: false,
+    },
+    secureJsonFields: {},
+    readOnly: false,
+    withCredentials: false,
+  },
+  onOptionsChange: jest.fn(),
+};
+
+export const mockDatasource = new AdxDataSource({
+  id: 1,
+  uid: 'adx-id',
+  type: 'adx-datasource',
+  name: 'ADX Data Source',
+  access: 'proxy',
+  jsonData: mockDatasourceOptions.options.jsonData,
+  meta: {
+    id: 'adx-datasource',
+    name: 'ADX Data Source',
+    type: PluginType.datasource,
+    module: '',
+    baseUrl: '',
+    info: {
+      description: '',
+      screenshots: [],
+      updated: '',
+      version: '',
+      logos: {
+        small: '',
+        large: '',
+      },
+      author: {
+        name: '',
+      },
+      links: [],
+    },
+  },
+});
+
+export const mockQuery: KustoQuery = {
+  refId: 'A',
+  query: '',
+  database: '',
+  resultFormat: '',
+  expression: {
+    where: { expressions: [], type: QueryEditorExpressionType.And },
+    reduce: { expressions: [], type: QueryEditorExpressionType.And },
+    groupBy: { expressions: [], type: QueryEditorExpressionType.And },
+  },
+  querySource: 'raw',
+  pluginVersion: '',
+};

--- a/src/module.ts
+++ b/src/module.ts
@@ -6,7 +6,7 @@ import { QueryEditor } from './QueryEditor';
 import { AdxDataSourceOptions, AdxDataSourceSecureOptions, KustoQuery } from './types';
 
 export const plugin = new DataSourcePlugin<AdxDataSource, KustoQuery, AdxDataSourceOptions, AdxDataSourceSecureOptions>(
-  AdxDataSource as any
+  AdxDataSource
 )
   .setConfigEditor(ConfigEditor)
   .setQueryEditor(QueryEditor);

--- a/src/module.ts
+++ b/src/module.ts
@@ -1,14 +1,12 @@
-import { DataSourceApi, DataSourcePlugin } from '@grafana/data';
+import { DataSourcePlugin } from '@grafana/data';
+import ConfigEditor from 'components/ConfigEditor';
+
 import { AdxDataSource } from './datasource';
 import { QueryEditor } from './QueryEditor';
 import { AdxDataSourceOptions, AdxDataSourceSecureOptions, KustoQuery } from './types';
-import ConfigEditor from 'components/ConfigEditor';
 
-export const plugin = new DataSourcePlugin<
-  DataSourceApi<KustoQuery, AdxDataSourceOptions>,
-  KustoQuery,
-  AdxDataSourceOptions,
-  AdxDataSourceSecureOptions
->(AdxDataSource as any)
+export const plugin = new DataSourcePlugin<AdxDataSource, KustoQuery, AdxDataSourceOptions, AdxDataSourceSecureOptions>(
+  AdxDataSource as any
+)
   .setConfigEditor(ConfigEditor)
   .setQueryEditor(QueryEditor);

--- a/src/monaco/KustoMonacoEditor.tsx
+++ b/src/monaco/KustoMonacoEditor.tsx
@@ -4,8 +4,8 @@
 /* tslint:enable */
 /* eslint-enable */
 import { css } from '@emotion/css';
+import { config } from '@grafana/runtime';
 import { stylesFactory } from '@grafana/ui';
-import config from 'grafana/app/core/config';
 import React from 'react';
 
 import { AdxSchema } from '../types';

--- a/yarn.lock
+++ b/yarn.lock
@@ -11797,26 +11797,12 @@ rw@1:
   resolved "https://registry.yarnpkg.com/rw/-/rw-1.3.3.tgz#3f862dfa91ab766b14885ef4d01124bfda074fb4"
   integrity sha1-P4Yt+pGrdmsUiF700BEkv9oHT7Q=
 
-rxjs@7.3.0:
-  version "7.3.0"
-  resolved "https://registry.yarnpkg.com/rxjs/-/rxjs-7.3.0.tgz#39fe4f3461dc1e50be1475b2b85a0a88c1e938c6"
-  integrity sha512-p2yuGIg9S1epc3vrjKf6iVb3RCaAYjYskkO+jHIaV0IjOPlJop4UnodOoFb2xeNwlguqLYvGw1b1McillYb5Gw==
-  dependencies:
-    tslib "~2.1.0"
-
-rxjs@^6.3.3, rxjs@^6.4.0:
-  version "6.6.7"
-  resolved "https://registry.yarnpkg.com/rxjs/-/rxjs-6.6.7.tgz#90ac018acabf491bf65044235d5863c4dab804c9"
-  integrity sha512-hTdwr+7yYNIT5n4AMYp85KA6yw2Va0FLa3Rguvbpa4W3I5xynaBZo41cM3XM+4Q6fRMj3sBYIR1VAmZMXYJvRQ==
+rxjs@6.6.3, rxjs@7.3.0, rxjs@^6.3.3, rxjs@^6.4.0, rxjs@^7.4.0:
+  version "6.6.3"
+  resolved "https://registry.yarnpkg.com/rxjs/-/rxjs-6.6.3.tgz#8ca84635c4daa900c0d3967a6ee7ac60271ee552"
+  integrity sha512-trsQc+xYYXZ3urjOiJOuCOa5N3jAZ3eiSpQB5hIT8zGlL2QfnHLJ2r7GMkBGuIausdJN1OneaI6gQlsqNHHmZQ==
   dependencies:
     tslib "^1.9.0"
-
-rxjs@^7.4.0:
-  version "7.4.0"
-  resolved "https://registry.yarnpkg.com/rxjs/-/rxjs-7.4.0.tgz#a12a44d7eebf016f5ff2441b87f28c9a51cebc68"
-  integrity sha512-7SQDi7xeTMCJpqViXh8gL/lebcwlp3d831F05+9B44A4B0WfsEwUQHR64gsH1kvJ+Ep/J9K2+n1hVl1CsGN23w==
-  dependencies:
-    tslib "~2.1.0"
 
 safe-buffer@^5.0.1, safe-buffer@^5.1.0, safe-buffer@^5.1.1, safe-buffer@^5.1.2, safe-buffer@^5.2.0, safe-buffer@~5.2.0:
   version "5.2.1"
@@ -13121,11 +13107,6 @@ tslib@^2.0.3, tslib@^2.3.1:
   version "2.3.1"
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.3.1.tgz#e8a335add5ceae51aa261d32a490158ef042ef01"
   integrity sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw==
-
-tslib@~2.1.0:
-  version "2.1.0"
-  resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.1.0.tgz#da60860f1c2ecaa5703ab7d39bc05b6bf988b97a"
-  integrity sha512-hcVC3wYEziELGGmEEXue7D75zbwIIVUMWAVbHItGPx0ziyXxrOMQx4rQEVEV45Ut/1IotuEvwqPopzIOkDMf0A==
 
 tsutils@^3.17.1:
   version "3.17.1"


### PR DESCRIPTION
Starting point for #224 

This PR adds the new code editor behind a feature flag. Right now the editor has no additional functionality (apart from syntax highlighting) but those can be added incrementally without affecting possible releases.

I have also added some basic tests and mocks.