### PR TITLE
Bump code-coverage workflow call to v0.1.2

### DIFF
--- a/.github/workflows/code-coverage.yml
+++ b/.github/workflows/code-coverage.yml
@@ -4,4 +4,4 @@ on:
     branches-ignore: [dependabot/**]
 jobs:
   workflow-call:
-    uses: grafana/code-coverage/.github/workflows/code-coverage.yml@v0.1.1
+    uses: grafana/code-coverage/.github/workflows/code-coverage.yml@v0.1.2


### PR DESCRIPTION
https://github.com/grafana/code-coverage/releases/tag/v0.1.2