### PR TITLE
Add macro suggestions

### DIFF
--- a/src/components/RawQueryEditor.tsx
+++ b/src/components/RawQueryEditor.tsx
@@ -59,16 +59,16 @@ export const RawQueryEditor: React.FC<RawQueryEditorProps> = (props) => {
 
   const styles = useStyles2(getStyles);
 
-  if (!schema) {
-    return null;
-  }
-
   const handleEditorMount = useCallback((editor: MonacoEditor, monaco: Monaco) => {
     monaco.languages.registerCompletionItemProvider('kusto', {
       triggerCharacters: ['.', ' '],
       provideCompletionItems: getSuggestions,
     });
   }, []);
+
+  if (!schema) {
+    return null;
+  }
 
   return (
     <div>

--- a/src/components/RawQueryEditor.tsx
+++ b/src/components/RawQueryEditor.tsx
@@ -1,13 +1,14 @@
 import { css } from '@emotion/css';
 import { GrafanaTheme2, QueryEditorProps, SelectableValue } from '@grafana/data';
 import { config } from '@grafana/runtime';
-import { CodeEditor, Icon, useStyles2 } from '@grafana/ui';
+import { CodeEditor, Icon, Monaco, MonacoEditor, useStyles2 } from '@grafana/ui';
 import { QueryEditorResultFormat, selectResultFormat } from 'components/QueryEditorResultFormat';
 import { AdxDataSource } from 'datasource';
-import React, { useState } from 'react';
+import React, { useCallback, useState } from 'react';
 import { AdxDataSourceOptions, AdxSchema, KustoQuery } from 'types';
 
 import { KustoMonacoEditor } from '../monaco/KustoMonacoEditor';
+import { getSuggestions } from './Suggestions';
 
 type Props = QueryEditorProps<AdxDataSource, KustoQuery, AdxDataSourceOptions>;
 
@@ -62,6 +63,13 @@ export const RawQueryEditor: React.FC<RawQueryEditorProps> = (props) => {
     return null;
   }
 
+  const handleEditorMount = useCallback((editor: MonacoEditor, monaco: Monaco) => {
+    monaco.languages.registerCompletionItemProvider('kusto', {
+      triggerCharacters: ['.', ' '],
+      provideCompletionItems: getSuggestions,
+    });
+  }, []);
+
   return (
     <div>
       {config.featureToggles.adxNewCodeEditor ? (
@@ -72,8 +80,8 @@ export const RawQueryEditor: React.FC<RawQueryEditorProps> = (props) => {
             onBlur={onRawQueryChange}
             showMiniMap={false}
             showLineNumbers={true}
-            // getSuggestions={() => TBD}
             height="240px"
+            onEditorDidMount={handleEditorMount}
           />
         </div>
       ) : (

--- a/src/components/Suggestions.test.ts
+++ b/src/components/Suggestions.test.ts
@@ -1,0 +1,76 @@
+import { monacoTypes } from '@grafana/ui';
+
+import { getSuggestions } from './Suggestions';
+
+describe('getCompletionItems', () => {
+  let completionItems;
+  let lineContent;
+  let model;
+
+  beforeEach(() => {
+    (window as any).monaco = {
+      languages: {
+        CompletionItemKind: {
+          Keyword: '',
+        },
+      },
+    };
+    model = {
+      getLineCount: () => 3,
+      getValueInRange: () => 'atable/n' + lineContent,
+      getLineContent: () => lineContent,
+      getWordUntilPosition: () => ({ startColumn: 1, endColumn: 2 }),
+    };
+  });
+
+  describe('when no where clause and no | in model text', () => {
+    beforeEach(() => {
+      lineContent = ' ';
+      const position = { lineNumber: 2, column: 2 } as monacoTypes.Position;
+      completionItems = getSuggestions(model, position);
+    });
+
+    it('should not return any grafana macros', () => {
+      expect(completionItems.suggestions.length).toBe(0);
+    });
+  });
+
+  describe('when no where clause in model text', () => {
+    beforeEach(() => {
+      lineContent = '| ';
+      const position = { lineNumber: 2, column: 3 } as monacoTypes.Position;
+      completionItems = getSuggestions(model, position);
+    });
+
+    it('should return grafana macros for where and timefilter', () => {
+      expect(completionItems.suggestions.length).toBe(1);
+
+      expect(completionItems.suggestions[0].label).toBe('where $__timeFilter(timeColumn)');
+      expect(completionItems.suggestions[0].insertText).toBe('where $__timeFilter(Timestamp)');
+    });
+  });
+
+  describe('when on line with where clause', () => {
+    beforeEach(() => {
+      lineContent = '| where Test == 2 and ';
+      const position = { lineNumber: 2, column: 23 } as monacoTypes.Position;
+      completionItems = getSuggestions(model, position);
+    });
+
+    it('should return grafana macros and variables', () => {
+      expect(completionItems.suggestions.length).toBe(4);
+
+      expect(completionItems.suggestions[0].label).toBe('$__timeFilter(timeColumn)');
+      expect(completionItems.suggestions[0].insertText).toBe('$__timeFilter(Timestamp)');
+
+      expect(completionItems.suggestions[1].label).toBe('$__from');
+      expect(completionItems.suggestions[1].insertText).toBe('$__from');
+
+      expect(completionItems.suggestions[2].label).toBe('$__to');
+      expect(completionItems.suggestions[2].insertText).toBe('$__to');
+
+      expect(completionItems.suggestions[3].label).toBe('$__timeInterval');
+      expect(completionItems.suggestions[3].insertText).toBe('$__timeInterval');
+    });
+  });
+});

--- a/src/components/Suggestions.test.ts
+++ b/src/components/Suggestions.test.ts
@@ -6,6 +6,7 @@ describe('getCompletionItems', () => {
   let completionItems;
   let lineContent;
   let model;
+  const wordPosition = { startColumn: 1, endColumn: 2 };
 
   beforeEach(() => {
     (window as any).monaco = {
@@ -19,7 +20,7 @@ describe('getCompletionItems', () => {
       getLineCount: () => 3,
       getValueInRange: () => 'atable/n' + lineContent,
       getLineContent: () => lineContent,
-      getWordUntilPosition: () => ({ startColumn: 1, endColumn: 2 }),
+      getWordUntilPosition: () => wordPosition,
     };
   });
 
@@ -71,6 +72,25 @@ describe('getCompletionItems', () => {
 
       expect(completionItems.suggestions[3].label).toBe('$__timeInterval');
       expect(completionItems.suggestions[3].insertText).toBe('$__timeInterval');
+    });
+  });
+
+  describe('when half a macro is already written', () => {
+    beforeEach(() => {
+      lineContent = '| where $__time';
+      const position = { lineNumber: 2, column: 3 } as monacoTypes.Position;
+      model.getValueInRange = jest
+        .fn()
+        // First return the previous letter
+        .mockReturnValueOnce('$')
+        // Then return the whole content
+        .mockReturnValueOnce('atable/n' + lineContent);
+      completionItems = getSuggestions(model, position);
+    });
+
+    it('should return the position of the previous character', () => {
+      expect(completionItems.suggestions.length).toBe(4);
+      expect(completionItems.suggestions[0].range.startColumn).toBe(wordPosition.startColumn - 1);
     });
   });
 });

--- a/src/components/Suggestions.ts
+++ b/src/components/Suggestions.ts
@@ -5,10 +5,16 @@ const defaultTimeField = 'Timestamp';
 
 export function getSuggestions(model: monacoTypes.editor.ITextModel, position: monacoTypes.Position) {
   const word = model.getWordUntilPosition(position);
-  const range: monaco.IRange = {
+  const prevChar = model.getValueInRange({
     startLineNumber: position.lineNumber,
     endLineNumber: position.lineNumber,
-    startColumn: word.startColumn,
+    startColumn: word.startColumn - 1,
+    endColumn: word.startColumn,
+  });
+  const replaceRange: monaco.IRange = {
+    startLineNumber: position.lineNumber,
+    endLineNumber: position.lineNumber,
+    startColumn: prevChar === '$' ? word.startColumn - 1 : word.startColumn,
     endColumn: word.endColumn,
   };
   const textUntilPosition = model.getValueInRange({
@@ -30,7 +36,7 @@ export function getSuggestions(model: monacoTypes.editor.ITextModel, position: m
         ' column\n\n' +
         '- `$__timeFilter(datetimeColumn)` ->  Uses the specified datetime column to build the query.',
     },
-    range,
+    range: replaceRange,
   };
 
   if (!includes(textUntilPosition, '|')) {
@@ -62,7 +68,7 @@ export function getSuggestions(model: monacoTypes.editor.ITextModel, position: m
               defaultTimeField +
               ' > $__from` ',
           },
-          range,
+          range: replaceRange,
         },
         {
           label: '$__to',
@@ -75,7 +81,7 @@ export function getSuggestions(model: monacoTypes.editor.ITextModel, position: m
               defaultTimeField +
               ' < $__to` ',
           },
-          range,
+          range: replaceRange,
         },
         {
           label: '$__timeInterval',
@@ -89,7 +95,7 @@ export function getSuggestions(model: monacoTypes.editor.ITextModel, position: m
               ', $__timeInterval)` \n\n' +
               '[Grafana docs](http://docs.grafana.org/reference/templating/#the-interval-variable)',
           },
-          range,
+          range: replaceRange,
         },
       ],
     };

--- a/src/components/Suggestions.ts
+++ b/src/components/Suggestions.ts
@@ -1,0 +1,101 @@
+import { monacoTypes } from '@grafana/ui';
+import { includes } from 'lodash';
+
+const defaultTimeField = 'Timestamp';
+
+export function getSuggestions(model: monacoTypes.editor.ITextModel, position: monacoTypes.Position) {
+  const word = model.getWordUntilPosition(position);
+  const range: monaco.IRange = {
+    startLineNumber: position.lineNumber,
+    endLineNumber: position.lineNumber,
+    startColumn: word.startColumn,
+    endColumn: word.endColumn,
+  };
+  const textUntilPosition = model.getValueInRange({
+    startLineNumber: 1,
+    startColumn: 1,
+    endLineNumber: position.lineNumber,
+    endColumn: position.column,
+  });
+
+  const timeFilterSuggestion = {
+    label: 'where $__timeFilter(timeColumn)',
+    kind: monaco.languages.CompletionItemKind.Keyword,
+    insertText: 'where $__timeFilter(' + defaultTimeField + ')',
+    documentation: {
+      value:
+        '##### Macro that uses the selected timerange in Grafana to filter the query.\n\n' +
+        '- `$__timeFilter()` -> Uses the ' +
+        defaultTimeField +
+        ' column\n\n' +
+        '- `$__timeFilter(datetimeColumn)` ->  Uses the specified datetime column to build the query.',
+    },
+    range,
+  };
+
+  if (!includes(textUntilPosition, '|')) {
+    return { suggestions: [] };
+  }
+
+  if (!includes(textUntilPosition.toLowerCase(), 'where')) {
+    return {
+      suggestions: [timeFilterSuggestion],
+    };
+  }
+
+  if (includes(model.getLineContent(position.lineNumber).toLowerCase(), 'where')) {
+    return {
+      suggestions: [
+        {
+          ...timeFilterSuggestion,
+          label: '$__timeFilter(timeColumn)',
+          insertText: '$__timeFilter(' + defaultTimeField + ')',
+        },
+        {
+          label: '$__from',
+          kind: monaco.languages.CompletionItemKind.Keyword,
+          insertText: `$__from`,
+          documentation: {
+            value:
+              'Built-in variable that returns the from value of the selected timerange in Grafana.\n\n' +
+              'Example: `where ' +
+              defaultTimeField +
+              ' > $__from` ',
+          },
+          range,
+        },
+        {
+          label: '$__to',
+          kind: monaco.languages.CompletionItemKind.Keyword,
+          insertText: `$__to`,
+          documentation: {
+            value:
+              'Built-in variable that returns the to value of the selected timerange in Grafana.\n\n' +
+              'Example: `where ' +
+              defaultTimeField +
+              ' < $__to` ',
+          },
+          range,
+        },
+        {
+          label: '$__timeInterval',
+          kind: monaco.languages.CompletionItemKind.Keyword,
+          insertText: `$__timeInterval`,
+          documentation: {
+            value:
+              '##### Built-in variable that returns an automatic time grain suitable for the current timerange.\n\n' +
+              'Used with the bin() function - `bin(' +
+              defaultTimeField +
+              ', $__timeInterval)` \n\n' +
+              '[Grafana docs](http://docs.grafana.org/reference/templating/#the-interval-variable)',
+          },
+          range,
+        },
+      ],
+    };
+  }
+
+  return {
+    suggestions: [],
+  };
+}


### PR DESCRIPTION
Another incremental change towards #224

In this PR, I am adding the data source macros as suggestions. The legacy implementation was smart enough to suggest different macros depending on the line content so this PR does the same. It's not possible to use `getSuggestions` from the `CodeEditor` since that return "dumb" suggestions (always the same ones). Because of that, we need to access the underlying Monaco editor in the `onEditorDidMount` function.

The legacy code for this can be found here: https://github.com/grafana/azure-data-explorer-datasource/blob/main/src/monaco/kusto_code_editor.ts#L167

And the tests are the same than for the legacy editor, which can be found here: https://github.com/grafana/azure-data-explorer-datasource/blob/main/src/monaco/kusto_code_editor.test.ts#L7

![Peek 2022-04-06 17-59](https://user-images.githubusercontent.com/4025665/162018806-3c7e7608-3c8f-4550-ab01-6ec35431f9b1.gif)
