### PR TITLE
Give signature suggestions

### DIFF
--- a/src/components/RawQueryEditor.tsx
+++ b/src/components/RawQueryEditor.tsx
@@ -8,7 +8,7 @@ import React, { useCallback, useState } from 'react';
 import { AdxDataSourceOptions, AdxSchema, KustoQuery } from 'types';
 
 import { KustoMonacoEditor } from '../monaco/KustoMonacoEditor';
-import { getSuggestions } from './Suggestions';
+import { getSignatureHelp, getSuggestions } from './Suggestions';
 
 type Props = QueryEditorProps<AdxDataSource, KustoQuery, AdxDataSourceOptions>;
 
@@ -63,6 +63,10 @@ export const RawQueryEditor: React.FC<RawQueryEditorProps> = (props) => {
     monaco.languages.registerCompletionItemProvider('kusto', {
       triggerCharacters: ['.', ' '],
       provideCompletionItems: getSuggestions,
+    });
+    monaco.languages.registerSignatureHelpProvider('kusto', {
+      signatureHelpTriggerCharacters: ['(', ')'],
+      provideSignatureHelp: getSignatureHelp,
     });
   }, []);
 

--- a/src/components/Suggestions.test.ts
+++ b/src/components/Suggestions.test.ts
@@ -1,11 +1,12 @@
 import { monacoTypes } from '@grafana/ui';
 
-import { getSuggestions } from './Suggestions';
+import { getSignatureHelp, getSuggestions } from './Suggestions';
 
-describe('getCompletionItems', () => {
+describe('Suggestions', () => {
   let completionItems;
   let lineContent;
   let model;
+  let signatureHelp;
   const wordPosition = { startColumn: 1, endColumn: 2 };
 
   beforeEach(() => {
@@ -23,74 +24,105 @@ describe('getCompletionItems', () => {
       getWordUntilPosition: () => wordPosition,
     };
   });
+  describe('getCompletionItems', () => {
+    describe('when no where clause and no | in model text', () => {
+      beforeEach(() => {
+        lineContent = ' ';
+        const position = { lineNumber: 2, column: 2 } as monacoTypes.Position;
+        completionItems = getSuggestions(model, position);
+      });
 
-  describe('when no where clause and no | in model text', () => {
-    beforeEach(() => {
-      lineContent = ' ';
-      const position = { lineNumber: 2, column: 2 } as monacoTypes.Position;
-      completionItems = getSuggestions(model, position);
+      it('should not return any grafana macros', () => {
+        expect(completionItems.suggestions.length).toBe(0);
+      });
     });
 
-    it('should not return any grafana macros', () => {
-      expect(completionItems.suggestions.length).toBe(0);
+    describe('when no where clause in model text', () => {
+      beforeEach(() => {
+        lineContent = '| ';
+        const position = { lineNumber: 2, column: 3 } as monacoTypes.Position;
+        completionItems = getSuggestions(model, position);
+      });
+
+      it('should return grafana macros for where and timefilter', () => {
+        expect(completionItems.suggestions.length).toBe(1);
+
+        expect(completionItems.suggestions[0].label).toBe('where $__timeFilter(timeColumn)');
+        expect(completionItems.suggestions[0].insertText).toBe('where $__timeFilter(Timestamp)');
+      });
+    });
+
+    describe('when on line with where clause', () => {
+      beforeEach(() => {
+        lineContent = '| where Test == 2 and ';
+        const position = { lineNumber: 2, column: 23 } as monacoTypes.Position;
+        completionItems = getSuggestions(model, position);
+      });
+
+      it('should return grafana macros and variables', () => {
+        expect(completionItems.suggestions.length).toBe(4);
+
+        expect(completionItems.suggestions[0].label).toBe('$__timeFilter(timeColumn)');
+        expect(completionItems.suggestions[0].insertText).toBe('$__timeFilter(Timestamp)');
+
+        expect(completionItems.suggestions[1].label).toBe('$__from');
+        expect(completionItems.suggestions[1].insertText).toBe('$__from');
+
+        expect(completionItems.suggestions[2].label).toBe('$__to');
+        expect(completionItems.suggestions[2].insertText).toBe('$__to');
+
+        expect(completionItems.suggestions[3].label).toBe('$__timeInterval');
+        expect(completionItems.suggestions[3].insertText).toBe('$__timeInterval');
+      });
+    });
+
+    describe('when half a macro is already written', () => {
+      beforeEach(() => {
+        lineContent = '| where $__time';
+        const position = { lineNumber: 2, column: 3 } as monacoTypes.Position;
+        model.getValueInRange = jest
+          .fn()
+          // First return the previous letter
+          .mockReturnValueOnce('$')
+          // Then return the whole content
+          .mockReturnValueOnce('atable/n' + lineContent);
+        completionItems = getSuggestions(model, position);
+      });
+
+      it('should return the position of the previous character', () => {
+        expect(completionItems.suggestions.length).toBe(4);
+        expect(completionItems.suggestions[0].range.startColumn).toBe(wordPosition.startColumn - 1);
+      });
     });
   });
 
-  describe('when no where clause in model text', () => {
-    beforeEach(() => {
-      lineContent = '| ';
-      const position = { lineNumber: 2, column: 3 } as monacoTypes.Position;
-      completionItems = getSuggestions(model, position);
+  describe('getSignatureHelp', () => {
+    describe('when the function is not a time filter', () => {
+      beforeEach(() => {
+        lineContent = '$__foo(';
+        model.getValueInRange = () => lineContent;
+        const position = { lineNumber: 2, column: 2 } as monacoTypes.Position;
+        position.delta = jest.fn().mockReturnValue(position);
+        signatureHelp = getSignatureHelp(model, position);
+      });
+
+      it('should not return any signature', () => {
+        expect(signatureHelp.value.signatures).toBe(undefined);
+      });
     });
 
-    it('should return grafana macros for where and timefilter', () => {
-      expect(completionItems.suggestions.length).toBe(1);
+    describe('when the function is a time filter', () => {
+      beforeEach(() => {
+        lineContent = '$__timeFilter(';
+        model.getValueInRange = () => lineContent;
+        const position = { lineNumber: 2, column: 2 } as monacoTypes.Position;
+        position.delta = jest.fn().mockReturnValue(position);
+        signatureHelp = getSignatureHelp(model, position);
+      });
 
-      expect(completionItems.suggestions[0].label).toBe('where $__timeFilter(timeColumn)');
-      expect(completionItems.suggestions[0].insertText).toBe('where $__timeFilter(Timestamp)');
-    });
-  });
-
-  describe('when on line with where clause', () => {
-    beforeEach(() => {
-      lineContent = '| where Test == 2 and ';
-      const position = { lineNumber: 2, column: 23 } as monacoTypes.Position;
-      completionItems = getSuggestions(model, position);
-    });
-
-    it('should return grafana macros and variables', () => {
-      expect(completionItems.suggestions.length).toBe(4);
-
-      expect(completionItems.suggestions[0].label).toBe('$__timeFilter(timeColumn)');
-      expect(completionItems.suggestions[0].insertText).toBe('$__timeFilter(Timestamp)');
-
-      expect(completionItems.suggestions[1].label).toBe('$__from');
-      expect(completionItems.suggestions[1].insertText).toBe('$__from');
-
-      expect(completionItems.suggestions[2].label).toBe('$__to');
-      expect(completionItems.suggestions[2].insertText).toBe('$__to');
-
-      expect(completionItems.suggestions[3].label).toBe('$__timeInterval');
-      expect(completionItems.suggestions[3].insertText).toBe('$__timeInterval');
-    });
-  });
-
-  describe('when half a macro is already written', () => {
-    beforeEach(() => {
-      lineContent = '| where $__time';
-      const position = { lineNumber: 2, column: 3 } as monacoTypes.Position;
-      model.getValueInRange = jest
-        .fn()
-        // First return the previous letter
-        .mockReturnValueOnce('$')
-        // Then return the whole content
-        .mockReturnValueOnce('atable/n' + lineContent);
-      completionItems = getSuggestions(model, position);
-    });
-
-    it('should return the position of the previous character', () => {
-      expect(completionItems.suggestions.length).toBe(4);
-      expect(completionItems.suggestions[0].range.startColumn).toBe(wordPosition.startColumn - 1);
+      it('should not return any signature', () => {
+        expect(signatureHelp.value.signatures.length).toBe(1);
+      });
     });
   });
 });

--- a/src/components/Suggestions.test.ts
+++ b/src/components/Suggestions.test.ts
@@ -99,22 +99,20 @@ describe('Suggestions', () => {
   describe('getSignatureHelp', () => {
     describe('when the function is not a time filter', () => {
       beforeEach(() => {
-        lineContent = '$__foo(';
-        model.getValueInRange = () => lineContent;
+        model.getWordUntilPosition = () => ({ word: '__foo' });
         const position = { lineNumber: 2, column: 2 } as monacoTypes.Position;
         position.delta = jest.fn().mockReturnValue(position);
         signatureHelp = getSignatureHelp(model, position);
       });
 
       it('should not return any signature', () => {
-        expect(signatureHelp.value.signatures).toBe(undefined);
+        expect(signatureHelp.value.signatures.length).toBe(0);
       });
     });
 
     describe('when the function is a time filter', () => {
       beforeEach(() => {
-        lineContent = '$__timeFilter(';
-        model.getValueInRange = () => lineContent;
+        model.getWordUntilPosition = () => ({ word: '__timeFilter' });
         const position = { lineNumber: 2, column: 2 } as monacoTypes.Position;
         position.delta = jest.fn().mockReturnValue(position);
         signatureHelp = getSignatureHelp(model, position);

--- a/src/components/Suggestions.ts
+++ b/src/components/Suggestions.ts
@@ -105,3 +105,41 @@ export function getSuggestions(model: monacoTypes.editor.ITextModel, position: m
     suggestions: [],
   };
 }
+
+export function getSignatureHelp(
+  model: monacoTypes.editor.ITextModel,
+  position: monacoTypes.Position
+): monacoTypes.languages.ProviderResult<monacoTypes.languages.SignatureHelpResult> {
+  const word = model.getWordUntilPosition(position.delta(0, -1));
+  const textUntilPosition = model.getValueInRange({
+    startLineNumber: position.lineNumber,
+    startColumn: word.startColumn - 1,
+    endLineNumber: position.lineNumber,
+    endColumn: position.column,
+  });
+
+  if (textUntilPosition !== '$__timeFilter(') {
+    return { value: {} as monaco.languages.SignatureHelp, dispose: () => {} };
+  }
+
+  const signature: monaco.languages.SignatureHelp = {
+    activeParameter: 0,
+    activeSignature: 0,
+    signatures: [
+      {
+        label: '$__timeFilter(timeColumn)',
+        parameters: [
+          {
+            label: 'timeColumn',
+            documentation:
+              'Default is ' +
+              defaultTimeField +
+              ' column. Datetime column to filter data using the selected date range. ',
+          },
+        ],
+      },
+    ],
+  };
+
+  return { value: signature, dispose: () => {} };
+}


### PR DESCRIPTION
The signature suggestions are given when some function parameters need to be specified (it's only triggered when opening parenthesis). In this case, to maintain previous behavior, we are giving some information when the user tries to use the `$__timeFilter` macro:

![Screenshot from 2022-04-07 17-50-54](https://user-images.githubusercontent.com/4025665/162244926-34879f6f-22dc-461f-8df2-2b053ce814d3.png)
