### PR TITLE
Load database schema

### DIFF
--- a/cypress/integration/smoke.spec.ts
+++ b/cypress/integration/smoke.spec.ts
@@ -35,7 +35,7 @@ function addCommonProvisioningADXDatasource(ADXProvisions: ADXProvision[]) {
     },
     expectedAlertMessage: 'Success',
   });
-};
+}
 
 e2e.scenario({
   describeName: 'Add ADX datasource Import Dashoard',
@@ -72,7 +72,7 @@ e2e.scenario({
           visitDashboardAtStart: false,
           queriesForm: () => {
             e2eSelectors.queryEditor.database.input().click({ force: true });
-            cy.contains('PerfTest').click();
+            cy.contains('PerfTest').click({ force: true });
             e2eSelectors.queryEditor.editKQL.button().click({ force: true });
             e2eSelectors.queryEditor.codeEditorLegacy
               .textarea()
@@ -110,10 +110,10 @@ e2e.scenario({
           visitDashboardAtStart: false,
           queriesForm: () => {
             e2eSelectors.queryEditor.database.input().click({ force: true });
-            cy.contains('PerfTest').click();
+            cy.contains('PerfTest').click({ force: true });
 
             e2eSelectors.queryEditor.tableFrom.input().click({ force: true });
-            cy.contains('events.all').click();
+            cy.contains('events.all').click({ force: true });
 
             e2eSelectors.queryEditor.runQuery.button().click({ force: true });
             cy.contains('No graphable fields').should('exist');

--- a/src/components/RawQueryEditor.tsx
+++ b/src/components/RawQueryEditor.tsx
@@ -4,11 +4,11 @@ import { config } from '@grafana/runtime';
 import { CodeEditor, Icon, Monaco, MonacoEditor, useStyles2 } from '@grafana/ui';
 import { QueryEditorResultFormat, selectResultFormat } from 'components/QueryEditorResultFormat';
 import { AdxDataSource } from 'datasource';
+import { KustoMonacoEditor } from 'monaco/KustoMonacoEditor';
 import React, { useCallback, useState } from 'react';
 import { selectors } from 'test/selectors';
 import { AdxDataSourceOptions, AdxSchema, KustoQuery } from 'types';
 
-import { KustoMonacoEditor } from '../monaco/KustoMonacoEditor';
 import { getSignatureHelp, getSuggestions } from './Suggestions';
 
 type Props = QueryEditorProps<AdxDataSource, KustoQuery, AdxDataSourceOptions>;
@@ -60,7 +60,7 @@ export const RawQueryEditor: React.FC<RawQueryEditorProps> = (props) => {
 
   const styles = useStyles2(getStyles);
 
-  const handleEditorMount = useCallback((editor: MonacoEditor, monaco: Monaco) => {
+  const handleEditorMount = useCallback(async (editor: MonacoEditor, monaco: Monaco) => {
     monaco.languages.registerCompletionItemProvider('kusto', {
       triggerCharacters: ['.', ' '],
       provideCompletionItems: getSuggestions,
@@ -69,6 +69,17 @@ export const RawQueryEditor: React.FC<RawQueryEditorProps> = (props) => {
       signatureHelpTriggerCharacters: ['(', ')'],
       provideSignatureHelp: getSignatureHelp,
     });
+    monaco.languages['kusto']
+      .getKustoWorker()
+      .then((kusto) => {
+        const model = editor.getModel();
+        return model && kusto(model.uri);
+      })
+      .then((worker) => {
+        if (schema) {
+          worker?.setSchemaFromShowSchema(schema, 'https://help.kusto.windows.net', props.database);
+        }
+      });
   }, []);
 
   if (!schema) {

--- a/src/components/RawQueryEditor.tsx
+++ b/src/components/RawQueryEditor.tsx
@@ -60,7 +60,7 @@ export const RawQueryEditor: React.FC<RawQueryEditorProps> = (props) => {
 
   const styles = useStyles2(getStyles);
 
-  const handleEditorMount = useCallback(async (editor: MonacoEditor, monaco: Monaco) => {
+  const handleEditorMount = useCallback((editor: MonacoEditor, monaco: Monaco) => {
     monaco.languages.registerCompletionItemProvider('kusto', {
       triggerCharacters: ['.', ' '],
       provideCompletionItems: getSuggestions,

--- a/src/datasource.ts
+++ b/src/datasource.ts
@@ -1,33 +1,34 @@
 import {
-  MetricFindValue,
-  DataSourceInstanceSettings,
-  DataQueryRequest,
-  ScopedVar,
-  TimeRange,
   DataFrame,
+  DataQueryRequest,
+  DataSourceInstanceSettings,
+  MetricFindValue,
+  ScopedVar,
   ScopedVars,
+  TimeRange,
 } from '@grafana/data';
-import { map } from 'lodash';
-import { getBackendSrv, BackendSrv, getTemplateSrv, TemplateSrv, DataSourceWithBackend } from '@grafana/runtime';
-import { ResponseParser, DatabaseItem, KustoDatabaseList } from './response_parser';
-import {
-  AdxDataSourceOptions,
-  KustoQuery,
-  AdxSchema,
-  AdxColumnSchema,
-  defaultQuery,
-  QueryExpression,
-  EditorMode,
-  AutoCompleteQuery,
-} from './types';
-import interpolateKustoQuery from './query_builder';
-import { migrateAnnotation } from './migrations/annotation';
+import { BackendSrv, DataSourceWithBackend, getBackendSrv, getTemplateSrv, TemplateSrv } from '@grafana/runtime';
 import { firstStringFieldToMetricFindValue } from 'common/responseHelpers';
 import { QueryEditorPropertyExpression } from 'editor/expressions';
 import { QueryEditorOperator } from 'editor/types';
-import { cache } from 'schema/cache';
 import { KustoExpressionParser } from 'KustoExpressionParser';
+import { map } from 'lodash';
 import { AdxSchemaMapper } from 'schema/AdxSchemaMapper';
+import { cache } from 'schema/cache';
+
+import { migrateAnnotation } from './migrations/annotation';
+import interpolateKustoQuery from './query_builder';
+import { DatabaseItem, KustoDatabaseList, ResponseParser } from './response_parser';
+import {
+  AdxColumnSchema,
+  AdxDataSourceOptions,
+  AdxSchema,
+  AutoCompleteQuery,
+  defaultQuery,
+  EditorMode,
+  KustoQuery,
+  QueryExpression,
+} from './types';
 
 export class AdxDataSource extends DataSourceWithBackend<KustoQuery, AdxDataSourceOptions> {
   private backendSrv: BackendSrv;

--- a/src/response_parser.ts
+++ b/src/response_parser.ts
@@ -1,4 +1,3 @@
-import _ from 'lodash';
 import { AdxSchema } from 'types';
 
 export interface DataTarget {

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,12 +1,13 @@
-const packageJson = require('../package.json');
-
 import { DataQuery, DataSourceJsonData } from '@grafana/data';
+
 import {
-  QueryEditorPropertyExpression,
   QueryEditorArrayExpression,
   QueryEditorExpressionType,
   QueryEditorOperatorExpression,
+  QueryEditorPropertyExpression,
 } from './editor/expressions';
+
+const packageJson = require('../package.json');
 
 export interface QueryExpression {
   from?: QueryEditorPropertyExpression;
@@ -125,6 +126,8 @@ export interface AdxTableSchema {
 export interface AdxColumnSchema {
   Name: string;
   CslType: string;
+  Type?: string;
+  CslDefaultValue?: string;
 }
 
 export interface AdxFunctionSchema {
@@ -133,6 +136,7 @@ export interface AdxFunctionSchema {
   Name: string;
   InputParameters: AdxFunctionInputParameterSchema[];
   OutputColumns: AdxColumnSchema[];
+  DocString?: string;
 }
 
 export interface AdxFunctionInputParameterSchema extends AdxColumnSchema {}

--- a/src/types.ts
+++ b/src/types.ts
@@ -126,8 +126,6 @@ export interface AdxTableSchema {
 export interface AdxColumnSchema {
   Name: string;
   CslType: string;
-  Type?: string;
-  CslDefaultValue?: string;
 }
 
 export interface AdxFunctionSchema {
@@ -136,7 +134,6 @@ export interface AdxFunctionSchema {
   Name: string;
   InputParameters: AdxFunctionInputParameterSchema[];
   OutputColumns: AdxColumnSchema[];
-  DocString?: string;
 }
 
 export interface AdxFunctionInputParameterSchema extends AdxColumnSchema {}


### PR DESCRIPTION
Cont #224 

Load the database schema so we get more suggestions like table names and columns:

![Screenshot from 2022-04-13 16-59-46](https://user-images.githubusercontent.com/4025665/163209993-41043453-9057-42bc-a184-f817965fab18.png)

Next step would be to add macros and templates variables as done for [Azure Monitor Logs](https://github.com/grafana/grafana/pull/47689).

Unfortunately, this will only work with the latest version of Grafana (>=8.5.0). This is because only that version includes the latest version of `@kusto/monaco-kusto`, which is needed to successfully load the schema. Once the editor is ready and we remove the feature flag, we can substitute it for a version check and only load the new editor if the Grafana version is bigger than 8.5.0 (:unamused:)

Note: It's not possible to test this with unit tests (it's not possible to load languages with jest). My plan is to add a check in the e2e test to verify this but will do that in a different PR.