### PR TITLE
Finish new editor set up

### DIFF
--- a/src/components/RawQueryEditor.test.tsx
+++ b/src/components/RawQueryEditor.test.tsx
@@ -16,7 +16,12 @@ jest.mock('../monaco/KustoMonacoEditor', () => {
 let mockedRuntime;
 jest.mock('@grafana/runtime', () => {
   const original = jest.requireActual('@grafana/runtime');
-  mockedRuntime = { ...original };
+  mockedRuntime = {
+    ...original,
+    getTemplateSrv: () => ({
+      getVariables: () => [],
+    }),
+  };
   mockedRuntime.config.buildInfo.version = '8.1.0';
 
   return mockedRuntime;

--- a/src/components/RawQueryEditor.test.tsx
+++ b/src/components/RawQueryEditor.test.tsx
@@ -1,4 +1,3 @@
-import { config } from '@grafana/runtime';
 import { render, screen } from '@testing-library/react';
 import React from 'react';
 import { selectors } from 'test/selectors';
@@ -14,6 +13,15 @@ jest.mock('../monaco/KustoMonacoEditor', () => {
   };
 });
 
+let mockedRuntime;
+jest.mock('@grafana/runtime', () => {
+  const original = jest.requireActual('@grafana/runtime');
+  mockedRuntime = { ...original };
+  mockedRuntime.config.buildInfo.version = '8.1.0';
+
+  return mockedRuntime;
+});
+
 const defaultProps = {
   database: 'default',
   templateVariableOptions: {},
@@ -25,21 +33,21 @@ const defaultProps = {
 };
 
 describe('RawQueryEditor', () => {
-  const featureToggles = { ...config.featureToggles };
-
-  afterEach(() => {
-    config.featureToggles = featureToggles;
+  describe('when the Grafana version is <8.5', () => {
+    it('should render legacy editor', () => {
+      render(<RawQueryEditor {...defaultProps} />);
+      expect(screen.getByTestId(selectors.components.queryEditor.codeEditorLegacy.container)).toBeInTheDocument();
+    });
   });
 
-  it('should render legacy editor', () => {
-    render(<RawQueryEditor {...defaultProps} />);
-    expect(screen.getByTestId(selectors.components.queryEditor.codeEditorLegacy.container)).toBeInTheDocument();
-  });
-
-  it('should render the new code editor', async () => {
-    config.featureToggles.adxNewCodeEditor = true;
-    render(<RawQueryEditor {...defaultProps} />);
-    expect(screen.getByTestId(selectors.components.queryEditor.codeEditor.container)).toBeInTheDocument();
-    await screen.findByText('Loading...');
+  describe('when the Grafana version is >=8.5', () => {
+    beforeEach(() => {
+      mockedRuntime.config.buildInfo.version = '8.5.0';
+    });
+    it('should render the new code editor', async () => {
+      render(<RawQueryEditor {...defaultProps} />);
+      expect(screen.getByTestId(selectors.components.queryEditor.codeEditor.container)).toBeInTheDocument();
+      await screen.findByText('Loading...');
+    });
   });
 });

--- a/src/components/RawQueryEditor.tsx
+++ b/src/components/RawQueryEditor.tsx
@@ -5,7 +5,8 @@ import { CodeEditor, Icon, Monaco, MonacoEditor, useStyles2 } from '@grafana/ui'
 import { QueryEditorResultFormat, selectResultFormat } from 'components/QueryEditorResultFormat';
 import { AdxDataSource } from 'datasource';
 import { KustoMonacoEditor } from 'monaco/KustoMonacoEditor';
-import React, { useState } from 'react';
+import React, { useEffect, useState } from 'react';
+import { gte, valid } from 'semver';
 import { selectors } from 'test/selectors';
 import { AdxDataSourceOptions, AdxSchema, KustoQuery } from 'types';
 
@@ -32,9 +33,21 @@ const defaultQuery = [
   '// | order by Timestamp asc',
 ].join('\n');
 
+interface Worker {
+  setSchemaFromShowSchema: (schema: AdxSchema, url: string, database: string) => void;
+}
+
+// Since Grafana 8.5, the query editor includes a version of the Monaco editor for Kusto
+// that includes fixes required for auto-completion to work.
+// Remove this code once Grafana 8.5 is the minimal version supported
+function gtGrafana8_5() {
+  return valid(config.buildInfo.version) && gte(config.buildInfo.version, '8.5.0');
+}
+
 export const RawQueryEditor: React.FC<RawQueryEditorProps> = (props) => {
   const [showLastQuery, setShowLastQuery] = useState(false);
   const [showHelp, setShowHelp] = useState(false);
+  const [worker, setWorker] = useState<Worker>();
   const templateSrv = getTemplateSrv();
 
   const onRawQueryChange = (kql: string) => {
@@ -73,15 +86,19 @@ export const RawQueryEditor: React.FC<RawQueryEditorProps> = (props) => {
         return model && kusto(model.uri);
       })
       .then((worker) => {
-        if (schema) {
-          // Populate Database schema with macros
-          Object.keys(schema.Databases).forEach((db) =>
-            Object.assign(schema.Databases[db].Functions, getFunctions(templateSrv.getVariables()))
-          );
-          worker?.setSchemaFromShowSchema(schema, 'https://help.kusto.windows.net', props.database);
-        }
+        setWorker(worker);
       });
   };
+
+  useEffect(() => {
+    if (worker && schema) {
+      // Populate Database schema with macros
+      Object.keys(schema.Databases).forEach((db) =>
+        Object.assign(schema.Databases[db].Functions, getFunctions(templateSrv.getVariables()))
+      );
+      worker.setSchemaFromShowSchema(schema, 'https://help.kusto.windows.net', props.database);
+    }
+  }, [worker, schema, props.database]);
 
   if (!schema) {
     return null;
@@ -89,7 +106,7 @@ export const RawQueryEditor: React.FC<RawQueryEditorProps> = (props) => {
 
   return (
     <div>
-      {config.featureToggles.adxNewCodeEditor ? (
+      {gtGrafana8_5() ? (
         <div data-testid={selectors.components.queryEditor.codeEditor.container}>
           <CodeEditor
             language="kusto"

--- a/src/components/RawQueryEditor.tsx
+++ b/src/components/RawQueryEditor.tsx
@@ -48,7 +48,7 @@ export const RawQueryEditor: React.FC<RawQueryEditorProps> = (props) => {
   const [showLastQuery, setShowLastQuery] = useState(false);
   const [showHelp, setShowHelp] = useState(false);
   const [worker, setWorker] = useState<Worker>();
-  const templateSrv = getTemplateSrv();
+  const [variables] = useState(getTemplateSrv().getVariables());
 
   const onRawQueryChange = (kql: string) => {
     const resultFormat = selectResultFormat(props.query.resultFormat, true);
@@ -94,7 +94,7 @@ export const RawQueryEditor: React.FC<RawQueryEditorProps> = (props) => {
     if (worker && schema) {
       // Populate Database schema with macros
       Object.keys(schema.Databases).forEach((db) =>
-        Object.assign(schema.Databases[db].Functions, getFunctions(templateSrv.getVariables()))
+        Object.assign(schema.Databases[db].Functions, getFunctions(variables))
       );
       worker.setSchemaFromShowSchema(schema, 'https://help.kusto.windows.net', props.database);
     }

--- a/src/components/RawQueryEditor.tsx
+++ b/src/components/RawQueryEditor.tsx
@@ -98,7 +98,7 @@ export const RawQueryEditor: React.FC<RawQueryEditorProps> = (props) => {
       );
       worker.setSchemaFromShowSchema(schema, 'https://help.kusto.windows.net', props.database);
     }
-  }, [worker, schema, props.database]);
+  }, [worker, schema, variables, props.database]);
 
   if (!schema) {
     return null;


### PR DESCRIPTION
Closes #224 

Two last changes here for the new query editor:

 - Added some logic to reload the schema when the database changes. This allows to suggest new tables / columns in the editor.
 - I removed the feature flag, since this is now ready to be used ... but only works for Grafana >= 8.5. I replaced the feature flag with a version gate. Only people running the latest versions of Grafana will get the new editor.