### PR TITLE
Filter dynamic columns from query builder

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 _Not released yet_
 
 - Breaking Change: Azure Data Explorer plugin now requires Grafana 8.0+ to run.
+- Bugfix: Filter dynamic columns from Where/Aggregate/Group by clauses to prevent syntax errors.
 
 ## [3.7.1]
 

--- a/README.md
+++ b/README.md
@@ -294,6 +294,16 @@ MyLogs
 | project Timestamp, Text=Message , Tags="tag1,tag2"
 ```
 
+## Query Builder - Data Types
+
+The query builder provides an easy to use interface to query Azure Data Explorer. However, there are limitations on the supported data types that a column can possess. Currently, if a column is typed as `dynamic` it is filtered as an option for the following operations: `Where`, `Aggregate`, `Group by`. The reason for this is that columns of type `dynamic` can potentially contain values that have any of the primitive data types, but also arrays (where the array can then have values of any type) and JSON objects. The query builder does not currently support querying values that are either arrays or JSON objects.
+
+See the below documentation for further details on how to handle dynamic columns appropriately via the KQL editor.
+
+[Kusto Data Types](https://docs.microsoft.com/en-us/azure/data-explorer/kusto/query/scalar-data-types/) - Documentation on data types supported by Kusto.
+
+[Dynamic Data Type](https://docs.microsoft.com/en-us/azure/data-explorer/kusto/query/scalar-data-types/dynamic) - Detailed documentation on the dynamic data type.
+
 ## CHANGELOG
 
 See the [Changelog](https://github.com/grafana/azure-data-explorer-datasource/blob/master/CHANGELOG.md).

--- a/README.md
+++ b/README.md
@@ -296,7 +296,7 @@ MyLogs
 
 ## Query Builder - Data Types
 
-The query builder provides an easy to use interface to query Azure Data Explorer. However, there are limitations on the supported data types that a column can possess. Currently, if a column is typed as `dynamic` it is filtered as an option for the following operations: `Where`, `Aggregate`, `Group by`. The reason for this is that columns of type `dynamic` can potentially contain values that have any of the primitive data types, but also arrays (where the array can then have values of any type) and JSON objects. The query builder does not currently support querying values that are either arrays or JSON objects.
+The query builder provides an easy to use interface to query Azure Data Explorer. However, there are limitations on the supported data types that a column can possess. Currently, if a column is typed as `dynamic` it is not included as an option for the following operations: `Where`, `Aggregate`, `Group by`. The reason for this is that columns of type `dynamic` can potentially contain values that have any of the primitive data types, but also arrays (where the array can then have values of any type) and JSON objects. The query builder does not currently support querying values that are either arrays or JSON objects.
 
 See the below documentation for further details on how to handle dynamic columns appropriately via the KQL editor.
 

--- a/src/components/VisualQueryEditor.tsx
+++ b/src/components/VisualQueryEditor.tsx
@@ -96,7 +96,7 @@ export const VisualQueryEditor: React.FC<Props> = (props) => {
   const groupable = useGroupableColumns(columns);
 
   const columnTooltip =
-    "Some columns may not be visible for selection. This is due to the type of the column. The visual query editor does not currently support columns of type 'dynamic'";
+    "Some columns may not be visible for selection. The visual query editor does not currently support columns of type 'dynamic'";
 
   const onChangeTable = useCallback(
     (expression: QueryEditorExpression) => {

--- a/src/components/VisualQueryEditor.tsx
+++ b/src/components/VisualQueryEditor.tsx
@@ -95,6 +95,9 @@ export const VisualQueryEditor: React.FC<Props> = (props) => {
   const columns = useColumnOptions(tableSchema.value);
   const groupable = useGroupableColumns(columns);
 
+  const columnTooltip =
+    "Some columns may not be visible for selection. This is due to the type of the column. The visual query editor does not currently support columns of type 'dynamic'";
+
   const onChangeTable = useCallback(
     (expression: QueryEditorExpression) => {
       if (!isFieldExpression(expression) || !table) {
@@ -270,6 +273,7 @@ export const VisualQueryEditor: React.FC<Props> = (props) => {
         fields={columns}
         onChange={onWhereChange}
         getSuggestions={onAutoComplete}
+        tooltip={columnTooltip}
       />
       <KustoValueColumnEditorSection
         templateVariableOptions={props.templateVariableOptions}
@@ -277,6 +281,7 @@ export const VisualQueryEditor: React.FC<Props> = (props) => {
         value={query.expression?.reduce ?? defaultQuery.expression?.reduce}
         fields={columns}
         onChange={onReduceChange}
+        tooltip={columnTooltip}
       />
       <KustoGroupByEditorSection
         templateVariableOptions={props.templateVariableOptions}
@@ -284,6 +289,7 @@ export const VisualQueryEditor: React.FC<Props> = (props) => {
         value={query.expression?.groupBy ?? defaultQuery.expression?.groupBy}
         fields={groupable}
         onChange={onGroupByChange}
+        tooltip={columnTooltip}
       />
       <hr />
       <KustoPropertyEditorSection

--- a/src/components/__fixtures__/schema.ts
+++ b/src/components/__fixtures__/schema.ts
@@ -1,0 +1,38 @@
+import { DeepPartial } from '@grafana/data/themes/types';
+import { AdxSchema } from 'types';
+
+export default function createMockSchema(overrides?: DeepPartial<AdxSchema>) {
+  const _mockSchema: DeepPartial<AdxSchema> = {
+    Databases: {
+      testdb: {
+        Name: 'testdb',
+        Tables: {
+          testtable: {
+            Name: 'testtable',
+            OrderedColumns: [{ Name: 'column', CslType: 'string', Type: 'System.String' }],
+          },
+        },
+        ExternalTables: {},
+        Functions: {
+          testfunction: {
+            Body: 'Body',
+            DocString: 'Doc String',
+            FunctionKind: 'scalar',
+            InputParameters: [],
+            OutputColumns: [],
+          },
+        },
+        MaterializedViews: {
+          testMaterializedView: {
+            Name: 'testMaterializedView',
+            OrderedColumns: [],
+          },
+        },
+      },
+    },
+    ...overrides,
+  };
+
+  const mockSchema = _mockSchema as AdxSchema;
+  return mockSchema;
+}

--- a/src/editor/components/QueryEditorSection.tsx
+++ b/src/editor/components/QueryEditorSection.tsx
@@ -3,12 +3,13 @@ import { InlineFormLabel } from '@grafana/ui';
 
 export interface QueryEditorSectionProps {
   label: string;
+  tooltip?: string;
 }
 
 export const QueryEditorSection: React.FC<PropsWithChildren<QueryEditorSectionProps>> = (props) => {
   return (
     <div className="gf-form">
-      <InlineFormLabel className="query-keyword" width={12}>
+      <InlineFormLabel className="query-keyword" width={12} tooltip={props.tooltip ?? ''}>
         {props.label}
       </InlineFormLabel>
       {props.children}

--- a/src/editor/components/QueryEditorSection.tsx
+++ b/src/editor/components/QueryEditorSection.tsx
@@ -9,7 +9,7 @@ export interface QueryEditorSectionProps {
 export const QueryEditorSection: React.FC<PropsWithChildren<QueryEditorSectionProps>> = (props) => {
   return (
     <div className="gf-form">
-      <InlineFormLabel className="query-keyword" width={12} tooltip={props.tooltip ?? ''}>
+      <InlineFormLabel className="query-keyword" width={12} tooltip={props.tooltip}>
         {props.label}
       </InlineFormLabel>
       {props.children}

--- a/src/editor/components/filter/QueryEditorFilterSection.tsx
+++ b/src/editor/components/filter/QueryEditorFilterSection.tsx
@@ -40,7 +40,7 @@ export const QueryEditorFilterSection = (
 
     if (props.value?.expressions?.length === 0) {
       return (
-        <QueryEditorSection label={props.label}>
+        <QueryEditorSection label={props.label} tooltip={props.tooltip}>
           <Button
             variant="secondary"
             onClick={() => {
@@ -75,7 +75,7 @@ export const QueryEditorFilterSection = (
             }
 
             return (
-              <QueryEditorSection label={props.label}>
+              <QueryEditorSection label={props.label} tooltip={props.tooltip}>
                 <Button
                   variant="secondary"
                   onClick={() => {
@@ -93,7 +93,7 @@ export const QueryEditorFilterSection = (
           }
 
           return (
-            <QueryEditorSection label={props.label}>
+            <QueryEditorSection label={props.label} tooltip={props.tooltip}>
               <div className={styles.container}>
                 <QueryEditorRepeater id="filter-or" value={filterProps.value} onChange={filterProps.onChange}>
                   {(operatorProps) => {

--- a/src/editor/components/groupBy/QueryEditorGroupBySection.tsx
+++ b/src/editor/components/groupBy/QueryEditorGroupBySection.tsx
@@ -30,7 +30,7 @@ export const QueryEditorGroupBySection = (
 
     if (props.value.expressions.length === 0) {
       return (
-        <QueryEditorSection label={props.label}>
+        <QueryEditorSection label={props.label} tooltip={props.tooltip}>
           <Button
             variant="secondary"
             onClick={() => {
@@ -47,7 +47,7 @@ export const QueryEditorGroupBySection = (
     }
 
     return (
-      <QueryEditorSection label={props.label}>
+      <QueryEditorSection label={props.label} tooltip={props.tooltip}>
         <div className={styles.container}>
           <QueryEditorRepeater id="group-by" onChange={props.onChange} value={props.value}>
             {(childProps) => {

--- a/src/editor/components/reduce/QueryEditorReduceSection.tsx
+++ b/src/editor/components/reduce/QueryEditorReduceSection.tsx
@@ -30,7 +30,7 @@ export const QueryEditorReduceSection = (
 
     if (props.value.expressions.length === 0) {
       return (
-        <QueryEditorSection label={props.label}>
+        <QueryEditorSection label={props.label} tooltip={props.tooltip}>
           <Button
             variant="secondary"
             onClick={() => {
@@ -47,7 +47,7 @@ export const QueryEditorReduceSection = (
     }
 
     return (
-      <QueryEditorSection label={props.label}>
+      <QueryEditorSection label={props.label} tooltip={props.tooltip}>
         <div className={styles.container}>
           <QueryEditorRepeater id="reduce" onChange={props.onChange} value={props.value}>
             {(childProps) => {

--- a/src/schema/AdxSchemaResolver.test.ts
+++ b/src/schema/AdxSchemaResolver.test.ts
@@ -53,6 +53,8 @@ describe('Test schema resolution', () => {
       { Name: 'timespan', CslType: 'timespan', Type: 'System.TimeSpan' },
       { Name: 'decimal', CslType: 'decimal', Type: 'System.Data.SqlTypes.SqlDecimal' },
     ];
+    const schema = createMockSchema();
+    datasource.getSchema = jest.fn().mockResolvedValue(schema);
     schema.Databases['testdb'].Tables = {
       ...schema.Databases['testdb'].Tables,
       ...{

--- a/src/schema/AdxSchemaResolver.test.ts
+++ b/src/schema/AdxSchemaResolver.test.ts
@@ -1,0 +1,69 @@
+import { mockDatasource } from 'components/__fixtures__/Datasource';
+import createMockSchema from 'components/__fixtures__/schema';
+
+import { AdxSchemaResolver } from './AdxSchemaResolver';
+
+describe('Test schema resolution', () => {
+  const datasource = mockDatasource;
+  const schemaResolver = new AdxSchemaResolver(datasource);
+  const schema = createMockSchema();
+  datasource.getSchema = jest.fn().mockResolvedValue(schema);
+  datasource.getDynamicSchema = jest.fn().mockResolvedValue([{ Name: 'testprop', CslType: 'string' }]);
+
+  it('Will correctly retrieve databases', async () => {
+    const databases = await schemaResolver.getDatabases();
+    expect(databases).toHaveLength(1);
+    expect(databases[0]).toEqual(schema.Databases['testdb']);
+  });
+
+  it('Will correctly retrieve database tables', async () => {
+    const tables = await schemaResolver.getTablesForDatabase('testdb');
+    expect(tables).toHaveLength(1);
+    expect(tables[0]).toEqual(schema.Databases['testdb'].Tables['testtable']);
+  });
+
+  it('Will correctly retrieve materialized views', async () => {
+    const views = await schemaResolver.getViewsForDatabase('testdb');
+    expect(views).toHaveLength(1);
+    expect(views[0]).toEqual(schema.Databases['testdb'].MaterializedViews['testMaterializedView']);
+  });
+
+  it('Will correctly retrieve functions', async () => {
+    const functions = await schemaResolver.getFunctionsForDatabase('testdb');
+    expect(functions).toHaveLength(1);
+    expect(functions[0]).toEqual(schema.Databases['testdb'].Functions['testfunction']);
+  });
+
+  it('Will correctly retrieve table columns', async () => {
+    const columns = await schemaResolver.getColumnsForTable('testdb', 'testtable');
+    expect(columns).toHaveLength(1);
+    expect(columns).toEqual(schema.Databases['testdb'].Tables['testtable'].OrderedColumns);
+  });
+
+  it('Will correctly filter out columns with type "dynamic"', async () => {
+    const testColumns = [
+      { Name: 'boolean', CslType: 'bool', Type: 'System.Boolean' },
+      { Name: 'datetime', CslType: 'datetime', Type: 'System.DateTime' },
+      { Name: 'dynamic', CslType: 'dynamic', Type: 'System.Object' },
+      { Name: 'guid', CslType: 'guid', Type: 'System.Guid' },
+      { Name: 'int', CslType: 'int', Type: 'System.Int32' },
+      { Name: 'long', CslType: 'long', Type: 'System.Int64' },
+      { Name: 'real', CslType: 'real', Type: 'System.Double' },
+      { Name: 'string', CslType: 'string', Type: 'System.String' },
+      { Name: 'timespan', CslType: 'timespan', Type: 'System.TimeSpan' },
+      { Name: 'decimal', CslType: 'decimal', Type: 'System.Data.SqlTypes.SqlDecimal' },
+    ];
+    schema.Databases['testdb'].Tables = {
+      ...schema.Databases['testdb'].Tables,
+      ...{
+        testdynamictable: {
+          Name: 'testdynamictable',
+          OrderedColumns: testColumns,
+        },
+      },
+    };
+    const columns = await schemaResolver.getColumnsForTable('testdb', 'testdynamictable');
+    expect(columns).toHaveLength(testColumns.length - 1);
+    expect(columns).not.toContain({ Name: 'dynamic', CslType: 'dynamic', Type: 'System.Object' });
+  });
+});

--- a/src/schema/AdxSchemaResolver.ts
+++ b/src/schema/AdxSchemaResolver.ts
@@ -80,14 +80,17 @@ export class AdxSchemaResolver {
       );
 
       return schema.OrderedColumns.reduce((columns: AdxColumnSchema[], column) => {
-        const schemaForDynamicColumn = schemaByColumn[column.Name];
+        if (column.CslType !== 'dynamic') {
+          const schemaForDynamicColumn = schemaByColumn[column.Name];
 
-        if (!Array.isArray(schemaForDynamicColumn)) {
-          columns.push(column);
+          if (!Array.isArray(schemaForDynamicColumn)) {
+            columns.push(column);
+            return columns;
+          }
+
+          Array.prototype.push.apply(columns, schemaForDynamicColumn);
           return columns;
         }
-
-        Array.prototype.push.apply(columns, schemaForDynamicColumn);
         return columns;
       }, []);
     });


### PR DESCRIPTION
This PR tackles #353 by not displaying columns with type `dynamic` as options in the Where/Aggregate/Group by clauses to prevent malformed queries being generated. 

Further discussion is then needed on how we handle these columns. 