### PR TITLE
Avoid crash when loading legacy kusto editor

### DIFF
--- a/src/monaco/KustoMonacoEditor.tsx
+++ b/src/monaco/KustoMonacoEditor.tsx
@@ -5,7 +5,7 @@
 /* eslint-enable */
 import { css } from '@emotion/css';
 import { config } from '@grafana/runtime';
-import { stylesFactory } from '@grafana/ui';
+import { Alert, stylesFactory } from '@grafana/ui';
 import React from 'react';
 
 import { AdxSchema } from '../types';
@@ -20,7 +20,9 @@ interface Props {
   onExecute: () => void;
 }
 
-interface MonacoState {}
+interface MonacoState {
+  error?: Error;
+}
 
 export class KustoMonacoEditor extends React.Component<Props, MonacoState> {
   monacoRef: React.RefObject<HTMLDivElement>;
@@ -31,9 +33,7 @@ export class KustoMonacoEditor extends React.Component<Props, MonacoState> {
     super(props);
     this.styles = this.getStyles();
     this.monacoRef = React.createRef<HTMLDivElement>();
-    this.state = {
-      content: props.content,
-    };
+    this.state = {};
 
     if (!window.hasOwnProperty('monaco')) {
       // using the standard import() here causes issues with webpack/babel/typescript because monaco is just so large
@@ -57,7 +57,10 @@ export class KustoMonacoEditor extends React.Component<Props, MonacoState> {
       config
     );
 
-    this.kustoCodeEditor.initMonaco(this.props.content);
+    const error = this.kustoCodeEditor.initMonaco(this.props.content);
+    if (error) {
+      this.setState({ error });
+    }
 
     /* tslint:disable:no-bitwise */
     this.kustoCodeEditor.addCommand(monaco.KeyMod.Shift | monaco.KeyCode.Enter, () => {
@@ -91,6 +94,15 @@ export class KustoMonacoEditor extends React.Component<Props, MonacoState> {
   }));
 
   render() {
-    return <div id="content" tabIndex={0} className={this.styles.editor} ref={this.monacoRef}></div>;
+    return (
+      <>
+        {this.state.error && (
+          <Alert title="Error loading editor" severity="warning">
+            {this.state.error.message}
+          </Alert>
+        )}
+        <div id="content" tabIndex={0} className={this.styles.editor} ref={this.monacoRef}></div>
+      </>
+    );
   }
 }

--- a/src/monaco/kusto_code_editor.ts
+++ b/src/monaco/kusto_code_editor.ts
@@ -22,6 +22,7 @@ export default class KustoCodeEditor {
   ) {}
 
   initMonaco(content: string) {
+    let error: Error | undefined;
     const themeName = this.config.bootData.user.lightTheme ? 'grafana-light' : 'vs-dark';
 
     monaco.editor.defineTheme('grafana-light', {
@@ -57,10 +58,10 @@ export default class KustoCodeEditor {
         useIntellisenseV2: false,
       });
     } catch (e) {
-      console.error(
-        'Unable to load Kusto language. Try refreshing the page or upgrade to the latest version of Grafana and the ADX plugin.',
-        e
+      error = new Error(
+        'Unable to load Kusto language. Try refreshing the page or upgrading to Grafana +8.5 and ADX plugin +4.0'
       );
+      console.error(error, e);
     }
 
     this.codeEditor = monaco.editor.create(this.containerDiv, {
@@ -121,6 +122,8 @@ export default class KustoCodeEditor {
         });
       });
     });
+
+    return error;
   }
 
   resize() {

--- a/src/monaco/kusto_code_editor.ts
+++ b/src/monaco/kusto_code_editor.ts
@@ -50,11 +50,18 @@ export default class KustoCodeEditor {
       },
     });
 
-    monaco.languages['kusto'].kustoDefaults.setLanguageSettings({
-      includeControlCommands: true,
-      newlineAfterPipe: true,
-      useIntellisenseV2: false,
-    });
+    try {
+      monaco.languages['kusto'].kustoDefaults.setLanguageSettings({
+        includeControlCommands: true,
+        newlineAfterPipe: true,
+        useIntellisenseV2: false,
+      });
+    } catch (e) {
+      console.error(
+        'Unable to load Kusto language. Try refreshing the page or upgrade to the latest version of Grafana and the ADX plugin.',
+        e
+      );
+    }
 
     this.codeEditor = monaco.editor.create(this.containerDiv, {
       value: content || 'Write your query here',


### PR DESCRIPTION
Ref: #325

There is already a new code editor for the plugin that avoids the issue of #325 but since people running Grafana <8.5 won't get the fix, this PR helps a bit with the UX. Rather than crashing and not rendering the editor we can catch the exception and render the editor with no Kusto functionality. I have also added a message to urge users to upgrade to newer versions:

![Screenshot from 2022-04-28 13-22-47](https://user-images.githubusercontent.com/4025665/165742498-73da8c4d-361a-4e72-a56a-ffb433095b4a.png)

Note that this only helps with the flow Grafana editor -> ADX editor. The other way around still hard-crash.