### PR TITLE
Plugin.json : Removed deprecated `grafanaVersion`

### DIFF
--- a/src/plugin.json
+++ b/src/plugin.json
@@ -29,7 +29,6 @@
   },
   "dependencies": {
     "grafanaDependency": ">=8.0.0",
-    "grafanaVersion": "8.0.x",
     "plugins": []
   },
   "metrics": true,


### PR DESCRIPTION
`grafanaVersion` is deprecated, removing it to avoid confusion 😃 

https://grafana.com/docs/grafana/latest/developers/plugins/metadata/#properties-1 and https://grafana.com/docs/grafana/latest/developers/plugins/migration-guide/#update-the-pluginjson