### PR TITLE
Read AzureSettings from Grafana host via SDK

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,20 +3,19 @@ module github.com/grafana/azure-data-explorer-datasource
 go 1.17
 
 require (
-	github.com/AzureAD/microsoft-authentication-library-for-go v0.4.0
+	github.com/Azure/azure-sdk-for-go/sdk/azcore v0.22.0
 	github.com/Azure/azure-sdk-for-go/sdk/azidentity v0.13.2
+	github.com/AzureAD/microsoft-authentication-library-for-go v0.4.0
 	github.com/google/go-cmp v0.5.7
-	github.com/grafana/grafana-azure-sdk-go v1.1.0
+	github.com/grafana/grafana-azure-sdk-go v1.2.0
 	github.com/grafana/grafana-plugin-sdk-go v0.129.0
 	github.com/json-iterator/go v1.1.12
-	github.com/prometheus/client_golang v1.12.1
 	github.com/stretchr/testify v1.7.0
 	github.com/xorcare/pointer v1.1.0
 	golang.org/x/net v0.0.0-20211015210444-4f30a5c0130f
 )
 
 require (
-	github.com/Azure/azure-sdk-for-go/sdk/azcore v0.22.0 // indirect
 	github.com/Azure/azure-sdk-for-go/sdk/internal v0.9.1 // indirect
 	github.com/apache/arrow/go/arrow v0.0.0-20211112161151-bc219186db40 // indirect
 	github.com/beorn7/perks v1.0.1 // indirect
@@ -59,6 +58,7 @@ require (
 	github.com/pierrec/lz4/v4 v4.1.8 // indirect
 	github.com/pkg/browser v0.0.0-20210115035449-ce105d075bb4 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
+	github.com/prometheus/client_golang v1.12.1 // indirect
 	github.com/prometheus/client_model v0.2.0 // indirect
 	github.com/prometheus/common v0.32.1 // indirect
 	github.com/prometheus/procfs v0.7.3 // indirect

--- a/go.sum
+++ b/go.sum
@@ -194,8 +194,8 @@ github.com/googleapis/gax-go/v2 v2.0.4/go.mod h1:0Wqv26UfaUD9n4G6kQubkQ+KchISgw+
 github.com/googleapis/gax-go/v2 v2.0.5/go.mod h1:DWXyrwAJ9X0FpwwEdw+IPEYBICEFu5mhpdKc/us6bOk=
 github.com/gorilla/mux v1.8.0 h1:i40aqfkR1h2SlN9hojwV5ZA91wcXFOvkdNIeFDP5koI=
 github.com/gorilla/mux v1.8.0/go.mod h1:DVbg23sWSpFRCP0SfiEN6jmj59UnW/n46BH5rLB71So=
-github.com/grafana/grafana-azure-sdk-go v1.1.0 h1:Gh0fjs7jr4Lp5y+4cjn48U+MQaJeV8i9m1ds/1xszto=
-github.com/grafana/grafana-azure-sdk-go v1.1.0/go.mod h1:rgrnK9m6CgKlgx4rH3FFP/6dTdyRO6LYC2mVZov35yo=
+github.com/grafana/grafana-azure-sdk-go v1.2.0 h1:f/7BjCHGIU0JYOsLIt4oJztDy0fOPBRHB5R0Xe9++ew=
+github.com/grafana/grafana-azure-sdk-go v1.2.0/go.mod h1:rgrnK9m6CgKlgx4rH3FFP/6dTdyRO6LYC2mVZov35yo=
 github.com/grafana/grafana-plugin-sdk-go v0.129.0 h1:apmA8x59QvW5Wov+FhAfM0IiNGjMi8V2Ou7xyMk1leE=
 github.com/grafana/grafana-plugin-sdk-go v0.129.0/go.mod h1:4edtosZepfQF9jkQwRywJsNSJzXTHmzbmcVcAl8MEQc=
 github.com/grpc-ecosystem/go-grpc-middleware v1.3.0 h1:+9834+KizmvFV7pXQGSXQTsaWhq2GjuNUt0aUU0YBYw=

--- a/pkg/azuredx/datasource.go
+++ b/pkg/azuredx/datasource.go
@@ -43,10 +43,10 @@ func NewDatasource(instanceSettings backend.DataSourceInstanceSettings) (instanc
 	}
 	adx.settings = datasourceSettings
 
-	// TODO: #357 Azure settings should be received from the Grafana host
-	azureSettings := &azsettings.AzureSettings{
-		Cloud:                  azsettings.AzurePublic,
-		ManagedIdentityEnabled: false,
+	azureSettings, err := azsettings.ReadFromEnv()
+	if err != nil {
+		backend.Logger.Error("failed to read Azure settings from Grafana", "error", err.Error())
+		return nil, err
 	}
 
 	httpClientOptions, err := instanceSettings.HTTPClientOptions()


### PR DESCRIPTION
Use Grafana Azure SDK ([github.com/grafana/grafana-azure-sdk-go/azsettings/env.go](https://github.com/grafana/grafana-azure-sdk-go/blob/e8d4106df2fc474a8b7f55dd3b82f92868d9ed27/azsettings/env.go#L20)) to read `azsettings.AzureSettings` from environment variables passed by the Grafana host.

Fixes #357