### PR TITLE
Add basic objects as options in the query builder

### DIFF
--- a/README.md
+++ b/README.md
@@ -291,7 +291,11 @@ MyLogs
 
 ## Query Builder - Data Types
 
-The query builder provides an easy to use interface to query Azure Data Explorer. However, there are limitations on the supported data types that a column can possess. Currently, if a column is typed as `dynamic` it is not included as an option for the following operations: `Where`, `Aggregate`, `Group by`. The reason for this is that columns of type `dynamic` can potentially contain values that have any of the primitive data types, but also arrays (where the array can then have values of any type) and JSON objects. The query builder does not currently support querying values that are either arrays or JSON objects.
+<!-- TODO: Update the paragraph below once #353 is fixed -->
+
+The query builder provides an easy to use interface to query Azure Data Explorer. However, there are limitations on the supported data types that a column can possess. Currently, if a column is typed as `dynamic` it is fully not included as an option for the following operations: `Where`, `Aggregate`, `Group by`. The reason for this is that columns of type `dynamic` can potentially contain values that have any of the primitive data types, but also arrays (where the array can then have values of any type) and JSON objects. The query builder does not currently support querying values that are either arrays or JSON objects.
+
+Note that only the 50.000 first rows of a table are evaluated in order to obtain possible values to show as options in the query builder. Additional values can be manually written in the different selectors if they don't appear by default.
 
 See the below documentation for further details on how to handle dynamic columns appropriately via the KQL editor.
 

--- a/src/datasource.ts
+++ b/src/datasource.ts
@@ -381,7 +381,9 @@ const recordSchema = (columnName: string, schema: any, result: AdxColumnSchema[]
   }
 
   for (const name of Object.keys(schema)) {
-    const key = `${columnName}.${name}`;
+    // Using > as a key separator since it's not a valid character for an identifier
+    // https://docs.microsoft.com/en-us/azure/data-explorer/kusto/query/schema-entities/entity-names#identifier-naming-rules
+    const key = `${columnName}>${name}`;
 
     if (typeof schema[name] === 'string') {
       result.push({

--- a/src/schema/mapper.test.ts
+++ b/src/schema/mapper.test.ts
@@ -1,0 +1,23 @@
+import { columnsToDefinition } from './mapper';
+
+describe('columnsToDefinition', () => {
+  it('should convert a column to a definition', () => {
+    expect(columnsToDefinition([{ Name: 'foo', CslType: 'string' }])).toEqual([
+      {
+        label: 'foo',
+        type: 'string',
+        value: 'foo',
+      },
+    ]);
+  });
+
+  it('should parse a dynamic column', () => {
+    expect(columnsToDefinition([{ Name: 'foo>bar', CslType: 'string' }])).toEqual([
+      {
+        label: 'foo > bar',
+        type: 'string',
+        value: 'todynamic(foo)["bar"]',
+      },
+    ]);
+  });
+});

--- a/src/schema/mapper.ts
+++ b/src/schema/mapper.ts
@@ -50,11 +50,24 @@ export const columnsToDefinition = (columns: AdxColumnSchema[]): QueryEditorProp
     return [];
   }
 
-  return columns.map((column) => ({
-    value: column.Name,
-    label: column.Name,
-    type: toPropertyType(column.CslType),
-  }));
+  return columns.map((column) => {
+    if (column.Name.includes('>')) {
+      const groups = column.Name.split('>');
+      const colName = groups[0];
+      const nestedProps = groups.splice(1).map((p) => `["${p}"]`);
+      return {
+        label: column.Name.replace(/>/g, ' > '),
+        value: `todynamic(${colName})${nestedProps.join('')}`,
+        type: toPropertyType(column.CslType),
+      };
+    }
+
+    return {
+      value: column.Name,
+      label: column.Name,
+      type: toPropertyType(column.CslType),
+    };
+  });
 };
 
 const toPropertyType = (kustoType: string): QueryEditorPropertyType => {


### PR DESCRIPTION
I have split #353 in different subtasks, in this PR, I am adding support for dynamic columns that doesn't contain any array within them.

I noticed that there is some code already that generates a query that inspect tables in order to get dynamic columns information so we already can get the structure of a dynamic column. If a column contains an array, it contains the identifier ``indexer``, rather than a name so we can filter those out for the moment.

I have also put this behind a feature flag so it doesn't interfere with release until this is released.

![Screenshot from 2022-05-26 15-59-03](https://user-images.githubusercontent.com/4025665/170513190-91305128-54b4-4c59-b214-b80970ed9b2c.png)
