### PR TITLE
Add support for dynamic objects in Aggregate and Group by fields

### DIFF
--- a/src/components/VisualQueryEditor.test.tsx
+++ b/src/components/VisualQueryEditor.test.tsx
@@ -45,7 +45,7 @@ const schema = {
 };
 
 describe('VisualQueryEditor', () => {
-  xit('should render the VisualQueryEditor', async () => {
+  it('should render the VisualQueryEditor', async () => {
     render(<VisualQueryEditor {...defaultProps} />);
     await waitFor(() => screen.getByText('Table schema loaded successfully but without any columns'));
   });

--- a/src/components/VisualQueryEditor.test.tsx
+++ b/src/components/VisualQueryEditor.test.tsx
@@ -1,0 +1,59 @@
+import { render, screen, waitFor } from '@testing-library/react';
+import React from 'react';
+import { VisualQueryEditor } from './VisualQueryEditor';
+import { mockDatasource, mockQuery } from './__fixtures__/Datasource';
+
+jest.mock('@grafana/runtime', () => {
+  const original = jest.requireActual('@grafana/runtime');
+  return {
+    ...original,
+    getTemplateSrv: () => ({
+      getVariables: () => [],
+      replace: (s: string) => s,
+    }),
+  };
+});
+
+const defaultProps = {
+  database: '',
+  query: mockQuery,
+  onChangeQuery: jest.fn(),
+  datasource: mockDatasource,
+  templateVariableOptions: {},
+};
+
+const schema = {
+  Databases: {
+    foo: {
+      Name: 'foo',
+      Tables: {
+        bar: {
+          Name: 'bar',
+          OrderedColumns: [
+            {
+              Name: 'foobar',
+              CslType: 'string',
+            },
+          ],
+        },
+      },
+      ExternalTables: {},
+      Functions: {},
+      MaterializedViews: {},
+    },
+  },
+};
+
+describe('VisualQueryEditor', () => {
+  xit('should render the VisualQueryEditor', async () => {
+    render(<VisualQueryEditor {...defaultProps} />);
+    await waitFor(() => screen.getByText('Table schema loaded successfully but without any columns'));
+  });
+
+  it('should render the VisualQueryEditor with a schema', async () => {
+    const datasource = mockDatasource;
+    datasource.getSchema = jest.fn().mockResolvedValue(schema);
+    render(<VisualQueryEditor {...defaultProps} datasource={datasource} database="foo" schema={schema} />);
+    await waitFor(() => screen.getByText('bar'));
+  });
+});

--- a/src/components/VisualQueryEditor.tsx
+++ b/src/components/VisualQueryEditor.tsx
@@ -94,6 +94,7 @@ export const VisualQueryEditor: React.FC<Props> = (props) => {
 
   const columns = useColumnOptions(tableSchema.value);
   const groupable = useGroupableColumns(columns);
+  const aggregable = useAggregableColumns(columns);
 
   const columnTooltip =
     "Some columns may not be visible for selection. The visual query editor does not currently support columns of type 'dynamic'";
@@ -279,7 +280,7 @@ export const VisualQueryEditor: React.FC<Props> = (props) => {
         templateVariableOptions={props.templateVariableOptions}
         label="Aggregate"
         value={query.expression?.reduce ?? defaultQuery.expression?.reduce}
-        fields={columns}
+        fields={aggregable}
         onChange={onReduceChange}
         tooltip={columnTooltip}
       />
@@ -315,7 +316,23 @@ const getStyles = (theme: GrafanaTheme2) => ({
 
 const useGroupableColumns = (columns: QueryEditorPropertyDefinition[]): QueryEditorPropertyDefinition[] => {
   return useMemo(() => {
-    return columns.filter((c) => c.type === QueryEditorPropertyType.DateTime || QueryEditorPropertyType.String);
+    return columns
+      .filter((c) => c.type === QueryEditorPropertyType.DateTime || QueryEditorPropertyType.String)
+      .map((c) => ({
+        ...c,
+        value: c.dynamic ? `tostring(${c.value})` : c.value,
+      }));
+  }, [columns]);
+};
+
+const useAggregableColumns = (columns: QueryEditorPropertyDefinition[]): QueryEditorPropertyDefinition[] => {
+  return useMemo(() => {
+    return columns
+      .filter((c) => c.type === QueryEditorPropertyType.DateTime || QueryEditorPropertyType.String)
+      .map((c) => ({
+        ...c,
+        value: c.dynamic ? `tolong(${c.value})` : c.value,
+      }));
   }, [columns]);
 };
 

--- a/src/editor/types.ts
+++ b/src/editor/types.ts
@@ -34,6 +34,7 @@ export interface QueryEditorPropertyDefinition {
   value: string;
   type: QueryEditorPropertyType;
   label?: string;
+  dynamic?: boolean;
 }
 
 export interface QueryEditorFunctionDefinition extends QueryEditorPropertyDefinition {

--- a/src/schema/mapper.test.ts
+++ b/src/schema/mapper.test.ts
@@ -17,6 +17,7 @@ describe('columnsToDefinition', () => {
         label: 'foo > bar',
         type: 'string',
         value: 'todynamic(foo)["bar"]',
+        dynamic: true,
       },
     ]);
   });

--- a/src/schema/mapper.ts
+++ b/src/schema/mapper.ts
@@ -59,6 +59,7 @@ export const columnsToDefinition = (columns: AdxColumnSchema[]): QueryEditorProp
         label: column.Name.replace(/>/g, ' > '),
         value: `todynamic(${colName})${nestedProps.join('')}`,
         type: toPropertyType(column.CslType),
+        dynamic: true,
       };
     }
 


### PR DESCRIPTION
I noticed that `dynamic` values cannot be used for the summarize function (used for the Aggregate and Group by fields). For aggregating, I am converting the value to a `long` since its goal is to be used with a mathematical function. For grouping I am converting the value to a string. Note that the goal of this is not to support all the possible use cases but to at least give valid syntax:

Aggregate example:
![Screenshot from 2022-06-01 11-18-41](https://user-images.githubusercontent.com/4025665/171372105-5edc7b6c-8194-4015-b5ab-899c81895785.png)

Group by example:
![Screenshot from 2022-06-01 11-19-07](https://user-images.githubusercontent.com/4025665/171372085-49e99460-c679-4772-b8d0-69315dc0b2b8.png)

I tried to do some unit test for this but it seems that the current components are not working with the react testing library (clicking on the "+" button didn't render the selector). I could do some e2e test for covering this functionality but it doesn't seem worth it. Let me know what you think.