### PR TITLE
Avoid unnecessary todynamic

### DIFF
--- a/src/components/QueryEditor.test.tsx
+++ b/src/components/QueryEditor.test.tsx
@@ -25,7 +25,7 @@ jest.mock('@grafana/runtime', () => {
 const defaultProps = {
   onChange: jest.fn(),
   onRunQuery: jest.fn(),
-  datasource: mockDatasource,
+  datasource: mockDatasource(),
   query: mockQuery,
 };
 
@@ -38,13 +38,13 @@ describe('QueryEditor', () => {
   });
 
   describe('there is a schema error', () => {
-    const getSchema = mockDatasource.getSchema;
+    const getSchema = defaultProps.datasource.getSchema;
     beforeEach(() => {
-      mockDatasource.getSchema = getSchema;
+      defaultProps.datasource.getSchema = getSchema;
     });
 
     it('should render the encoded message', async () => {
-      mockDatasource.getSchema = jest.fn().mockRejectedValue({
+      defaultProps.datasource.getSchema = jest.fn().mockRejectedValue({
         data: {
           Message: 'Boom!',
         },
@@ -54,7 +54,7 @@ describe('QueryEditor', () => {
     });
 
     it('should render the error', async () => {
-      mockDatasource.getSchema = jest.fn().mockRejectedValue('Boom!');
+      defaultProps.datasource.getSchema = jest.fn().mockRejectedValue('Boom!');
       render(<QueryEditor {...defaultProps} />);
       await waitFor(() => screen.getByText('Could not load datasource schema: Boom!'));
     });
@@ -62,13 +62,13 @@ describe('QueryEditor', () => {
 
   describe('when there is a schema', () => {
     it('should render a no databases warning', async () => {
-      mockDatasource.getSchema = jest.fn().mockResolvedValue({});
+      defaultProps.datasource.getSchema = jest.fn().mockResolvedValue({});
       render(<QueryEditor {...defaultProps} />);
       await waitFor(() => screen.getByText(/Datasource schema loaded but without any databases/i));
     });
 
     it('should render a visual editor', async () => {
-      mockDatasource.getSchema = jest.fn().mockResolvedValue({
+      defaultProps.datasource.getSchema = jest.fn().mockResolvedValue({
         Databases: {
           foo: {},
         },
@@ -78,7 +78,7 @@ describe('QueryEditor', () => {
     });
 
     it('should render a raw editor', async () => {
-      mockDatasource.getSchema = jest.fn().mockResolvedValue({
+      defaultProps.datasource.getSchema = jest.fn().mockResolvedValue({
         Databases: {
           foo: {},
         },

--- a/src/components/RawQueryEditor.test.tsx
+++ b/src/components/RawQueryEditor.test.tsx
@@ -36,7 +36,7 @@ const defaultProps = {
   templateVariableOptions: {},
   onChange: jest.fn(),
   onRunQuery: jest.fn(),
-  datasource: mockDatasource,
+  datasource: mockDatasource(),
   query: mockQuery,
   schema: { Databases: {} },
 };

--- a/src/components/VisualQueryEditor.test.tsx
+++ b/src/components/VisualQueryEditor.test.tsx
@@ -18,7 +18,7 @@ const defaultProps = {
   database: '',
   query: mockQuery,
   onChangeQuery: jest.fn(),
-  datasource: mockDatasource,
+  datasource: mockDatasource(),
   templateVariableOptions: {},
 };
 
@@ -51,7 +51,7 @@ describe('VisualQueryEditor', () => {
   });
 
   it('should render the VisualQueryEditor with a schema', async () => {
-    const datasource = mockDatasource;
+    const datasource = mockDatasource();
     datasource.getSchema = jest.fn().mockResolvedValue(schema);
     render(<VisualQueryEditor {...defaultProps} datasource={datasource} database="foo" schema={schema} />);
     await waitFor(() => screen.getByText('bar'));

--- a/src/components/VisualQueryEditor.tsx
+++ b/src/components/VisualQueryEditor.tsx
@@ -320,6 +320,7 @@ const useGroupableColumns = (columns: QueryEditorPropertyDefinition[]): QueryEdi
       .filter((c) => c.type === QueryEditorPropertyType.DateTime || QueryEditorPropertyType.String)
       .map((c) => ({
         ...c,
+        // Transform dynamic values to string so they can be grouped
         value: c.dynamic ? `tostring(${c.value})` : c.value,
       }));
   }, [columns]);
@@ -331,7 +332,8 @@ const useAggregableColumns = (columns: QueryEditorPropertyDefinition[]): QueryEd
       .filter((c) => c.type === QueryEditorPropertyType.DateTime || QueryEditorPropertyType.String)
       .map((c) => ({
         ...c,
-        value: c.dynamic ? `tolong(${c.value})` : c.value,
+        // Transform dynamic values to long so they can be used by math functions
+        value: c.value.includes('[') ? `tolong(${c.value})` : c.value,
       }));
   }, [columns]);
 };

--- a/src/components/__fixtures__/Datasource.ts
+++ b/src/components/__fixtures__/Datasource.ts
@@ -48,35 +48,36 @@ export const mockDatasourceOptions: DataSourcePluginOptionsEditorProps<
   onOptionsChange: jest.fn(),
 };
 
-export const mockDatasource = new AdxDataSource({
-  id: 1,
-  uid: 'adx-id',
-  type: 'adx-datasource',
-  name: 'ADX Data Source',
-  access: 'proxy',
-  jsonData: mockDatasourceOptions.options.jsonData,
-  meta: {
-    id: 'adx-datasource',
+export const mockDatasource = () =>
+  new AdxDataSource({
+    id: 1,
+    uid: 'adx-id',
+    type: 'adx-datasource',
     name: 'ADX Data Source',
-    type: PluginType.datasource,
-    module: '',
-    baseUrl: '',
-    info: {
-      description: '',
-      screenshots: [],
-      updated: '',
-      version: '',
-      logos: {
-        small: '',
-        large: '',
+    access: 'proxy',
+    jsonData: mockDatasourceOptions.options.jsonData,
+    meta: {
+      id: 'adx-datasource',
+      name: 'ADX Data Source',
+      type: PluginType.datasource,
+      module: '',
+      baseUrl: '',
+      info: {
+        description: '',
+        screenshots: [],
+        updated: '',
+        version: '',
+        logos: {
+          small: '',
+          large: '',
+        },
+        author: {
+          name: '',
+        },
+        links: [],
       },
-      author: {
-        name: '',
-      },
-      links: [],
     },
-  },
-});
+  });
 
 export const mockQuery: KustoQuery = {
   refId: 'A',

--- a/src/datasource.ts
+++ b/src/datasource.ts
@@ -381,9 +381,9 @@ const recordSchema = (columnName: string, schema: any, result: AdxColumnSchema[]
   }
 
   for (const name of Object.keys(schema)) {
-    // Using > as a key separator since it's not a valid character for an identifier
-    // https://docs.microsoft.com/en-us/azure/data-explorer/kusto/query/schema-entities/entity-names#identifier-naming-rules
-    const key = `${columnName}>${name}`;
+    // Generate a valid accessor for a dynamic type
+    // https://docs.microsoft.com/en-us/azure/data-explorer/kusto/query/scalar-data-types/dynamic#dynamic-object-accessors
+    const key = `${columnName}["${name}"]`;
 
     if (typeof schema[name] === 'string') {
       result.push({

--- a/src/schema/AdxSchemaResolver.test.ts
+++ b/src/schema/AdxSchemaResolver.test.ts
@@ -5,7 +5,7 @@ import createMockSchema from 'components/__fixtures__/schema';
 import { AdxSchemaResolver } from './AdxSchemaResolver';
 
 describe('Test schema resolution', () => {
-  const datasource = mockDatasource;
+  const datasource = mockDatasource();
   const schemaResolver = new AdxSchemaResolver(datasource);
   const schema = createMockSchema();
   const originalFeatureToggles = config.featureToggles;

--- a/src/schema/mapper.test.ts
+++ b/src/schema/mapper.test.ts
@@ -10,15 +10,4 @@ describe('columnsToDefinition', () => {
       },
     ]);
   });
-
-  it('should parse a dynamic column', () => {
-    expect(columnsToDefinition([{ Name: 'foo>bar', CslType: 'string' }])).toEqual([
-      {
-        label: 'foo > bar',
-        type: 'string',
-        value: 'foo["bar"]',
-        dynamic: true,
-      },
-    ]);
-  });
 });

--- a/src/schema/mapper.test.ts
+++ b/src/schema/mapper.test.ts
@@ -16,7 +16,7 @@ describe('columnsToDefinition', () => {
       {
         label: 'foo > bar',
         type: 'string',
-        value: 'todynamic(foo)["bar"]',
+        value: 'foo["bar"]',
         dynamic: true,
       },
     ]);

--- a/src/schema/mapper.ts
+++ b/src/schema/mapper.ts
@@ -57,7 +57,7 @@ export const columnsToDefinition = (columns: AdxColumnSchema[]): QueryEditorProp
       const nestedProps = groups.splice(1).map((p) => `["${p}"]`);
       return {
         label: column.Name.replace(/>/g, ' > '),
-        value: `todynamic(${colName})${nestedProps.join('')}`,
+        value: `${colName}${nestedProps.join('')}`,
         type: toPropertyType(column.CslType),
         dynamic: true,
       };

--- a/src/schema/mapper.ts
+++ b/src/schema/mapper.ts
@@ -51,18 +51,6 @@ export const columnsToDefinition = (columns: AdxColumnSchema[]): QueryEditorProp
   }
 
   return columns.map((column) => {
-    if (column.Name.includes('>')) {
-      const groups = column.Name.split('>');
-      const colName = groups[0];
-      const nestedProps = groups.splice(1).map((p) => `["${p}"]`);
-      return {
-        label: column.Name.replace(/>/g, ' > '),
-        value: `${colName}${nestedProps.join('')}`,
-        type: toPropertyType(column.CslType),
-        dynamic: true,
-      };
-    }
-
     return {
       value: column.Name,
       label: column.Name,


### PR DESCRIPTION
There is really no need to cast a dynamic value when you get it because the result is already a `dynamic` type. From:

https://docs.microsoft.com/en-us/azure/data-explorer/kusto/query/scalar-data-types/dynamic#dynamic-object-accessors

> Accessing a sub-object of a dynamic value yields another dynamic value, even if the sub-object has a different underlying type

Since there is no need to use `todynamic`, I can remove the logic I added #389 to use `>` in `dynamic` types and simply return a valid accessor when parsing the dynamic schema.

Note for the reviewer: There are a bunch of test changes in this PR but the functional changes are few, mostly removing extra handling:

[src/datasource.ts](https://github.com/grafana/azure-data-explorer-datasource/pull/392/files#diff-804a5756e358074cb0ba27b1932cca77d39b90694fc1d4d122f46348c8653259)
[src/schema/mapper.ts](https://github.com/grafana/azure-data-explorer-datasource/pull/392/files#diff-b5407913a74a840627ce3902427cb64abc474c938069ef2dfffd08123fafd448)
[src/components/VisualQueryEditor.tsx](https://github.com/grafana/azure-data-explorer-datasource/pull/392/files#diff-e4544781782f9bfb36cc56593b96635368f89bdc69811bcb009f9979bbe7a6d6)
