### PR TITLE
Adapt KustoExpressionParser to new dynamic notation

### DIFF
--- a/src/KustoExpressionParser.test.ts
+++ b/src/KustoExpressionParser.test.ts
@@ -99,7 +99,7 @@ describe('KustoExpressionParser', () => {
         where: createArray([
           createOperator('eventType', '==', 'ThunderStorm'),
           createArray(
-            [createOperator('column.type', '==', ''), createOperator('eventType', '==', 'Ligthning')],
+            [createOperator('column["type"]', '==', ''), createOperator('eventType', '==', 'Ligthning')],
             QueryEditorExpressionType.Or
           ),
         ]),
@@ -107,14 +107,14 @@ describe('KustoExpressionParser', () => {
 
       const acQuery: AutoCompleteQuery = {
         expression,
-        search: createOperator('column.type', 'contains', 'TEXAS'),
+        search: createOperator('column["type"]', 'contains', 'TEXAS'),
         index: '1-0',
         database: 'Samples',
       };
 
       const tableSchema: AdxColumnSchema[] = [
         {
-          Name: 'column.type',
+          Name: 'column["type"]',
           CslType: 'string',
         },
       ];
@@ -122,9 +122,9 @@ describe('KustoExpressionParser', () => {
       expect(parser.toAutoCompleteQuery(acQuery, tableSchema)).toEqual(
         'StormEvents' +
           "\n| where eventType == 'ThunderStorm'" +
-          "\n| where column.type contains 'TEXAS' or eventType == 'Ligthning'" +
+          "\n| where column[\"type\"] contains 'TEXAS' or eventType == 'Ligthning'" +
           '\n| take 50000' +
-          '\n| distinct tostring(todynamic(column).type)' +
+          '\n| distinct tostring(column["type"])' +
           '\n| take 251'
       );
     });
@@ -135,7 +135,7 @@ describe('KustoExpressionParser', () => {
         where: createArray([
           createOperator('eventType', '==', 'ThunderStorm'),
           createArray(
-            [createOperator('column.type', '==', ''), createOperator('eventType', '==', 'Ligthning')],
+            [createOperator('column["type"]', '==', ''), createOperator('eventType', '==', 'Ligthning')],
             QueryEditorExpressionType.Or
           ),
         ]),
@@ -143,14 +143,14 @@ describe('KustoExpressionParser', () => {
 
       const acQuery: AutoCompleteQuery = {
         expression,
-        search: createOperator('column.type', 'contains', 'TEXAS'),
+        search: createOperator('column["type"]', 'contains', 'TEXAS'),
         index: '1-0',
         database: 'Samples',
       };
 
       const tableSchema: AdxColumnSchema[] = [
         {
-          Name: 'column.type',
+          Name: 'column["type"]',
           CslType: 'string',
         },
         {
@@ -163,9 +163,9 @@ describe('KustoExpressionParser', () => {
         'StormEvents' +
           '\n| where $__timeFilter(StartTime)' +
           "\n| where eventType == 'ThunderStorm'" +
-          "\n| where column.type contains 'TEXAS' or eventType == 'Ligthning'" +
+          "\n| where column[\"type\"] contains 'TEXAS' or eventType == 'Ligthning'" +
           '\n| take 50000' +
-          '\n| distinct tostring(todynamic(column).type)' +
+          '\n| distinct tostring(column["type"])' +
           '\n| take 251'
       );
     });
@@ -323,16 +323,16 @@ describe('KustoExpressionParser', () => {
 
       const tableSchema: AdxColumnSchema[] = [
         {
-          Name: 'Column.StartTime',
+          Name: 'Column["StartTime"]',
           CslType: 'datetime',
         },
       ];
 
       expect(parser.toQuery(expression, tableSchema)).toEqual(
         'StormEvents' +
-          '\n| where todatetime(todynamic(Column).StartTime) between ($__timeFrom .. $__timeTo)' +
+          '\n| where todatetime(Column["StartTime"]) between ($__timeFrom .. $__timeTo)' +
           '\n| where isActive == true' +
-          `\n| order by todatetime(todynamic(Column).StartTime) asc`
+          `\n| order by todatetime(Column["StartTime"]) asc`
       );
     });
 
@@ -344,7 +344,7 @@ describe('KustoExpressionParser', () => {
 
       const tableSchema: AdxColumnSchema[] = [
         {
-          Name: 'Column.StartTime',
+          Name: 'Column["StartTime"]',
           CslType: 'datetime',
         },
         {
@@ -364,91 +364,89 @@ describe('KustoExpressionParser', () => {
     it('should parse expression with when filter on dynamic column', () => {
       const expression = createQueryExpression({
         from: createProperty('StormEvents'),
-        where: createArray([createOperator('column.isActive', '==', true)]),
+        where: createArray([createOperator('column["isActive"]', '==', true)]),
       });
 
-      expect(parser.toQuery(expression)).toEqual('StormEvents' + '\n| where column.isActive == true');
+      expect(parser.toQuery(expression)).toEqual('StormEvents' + '\n| where column["isActive"] == true');
     });
 
     it('should parse expression with summarize of sum(active)', () => {
       const expression = createQueryExpression({
         from: createProperty('StormEvents'),
-        where: createArray([createOperator('column.isActive', '==', true)]),
+        where: createArray([createOperator('column["isActive"]', '==', true)]),
         reduce: createArray([createReduce('active', 'sum')]),
       });
 
       expect(parser.toQuery(expression)).toEqual(
-        'StormEvents' + '\n| where column.isActive == true' + `\n| summarize sum(active)`
+        'StormEvents' + '\n| where column["isActive"] == true' + `\n| summarize sum(active)`
       );
     });
 
     it('should parse expression with summarize of count', () => {
       const expression = createQueryExpression({
         from: createProperty('StormEvents'),
-        where: createArray([createOperator('column.isActive', '==', true)]),
+        where: createArray([createOperator('column["isActive"]', '==', true)]),
         reduce: createArray([createReduce('active', 'count')]),
       });
 
       expect(parser.toQuery(expression)).toEqual(
-        'StormEvents' + '\n| where column.isActive == true' + `\n| summarize count()`
+        'StormEvents' + '\n| where column["isActive"] == true' + `\n| summarize count()`
       );
     });
 
     it('should parse expression with summarize of count', () => {
       const expression = createQueryExpression({
         from: createProperty('StormEvents'),
-        where: createArray([createOperator('column.isActive', '==', true)]),
+        where: createArray([createOperator('column["isActive"]', '==', true)]),
         reduce: createArray([createReduce('', 'count')]),
       });
 
       expect(parser.toQuery(expression)).toEqual(
-        'StormEvents' + '\n| where column.isActive == true' + `\n| summarize count()`
+        'StormEvents' + '\n| where column["isActive"] == true' + `\n| summarize count()`
       );
     });
 
     it('should parse expression with summarize of multiple count', () => {
       const expression = createQueryExpression({
         from: createProperty('StormEvents'),
-        where: createArray([createOperator('column.isActive', '==', true)]),
+        where: createArray([createOperator('column["isActive"]', '==', true)]),
         reduce: createArray([createReduce('active', 'count'), createReduce('total', 'count')]),
       });
 
       expect(parser.toQuery(expression)).toEqual(
-        'StormEvents' + '\n| where column.isActive == true' + `\n| summarize count()`
+        'StormEvents' + '\n| where column["isActive"] == true' + `\n| summarize count()`
       );
     });
 
     it('should parse expression with summarize of sum on dynamic column', () => {
       const expression = createQueryExpression({
         from: createProperty('StormEvents'),
-        where: createArray([createOperator('column.isActive', '==', true)]),
-        reduce: createArray([createReduce('column.level.active', 'sum')]),
+        where: createArray([createOperator('column["isActive"]', '==', true)]),
+        reduce: createArray([createReduce('column["level"]["active"]', 'sum')]),
       });
 
       const tableSchema: AdxColumnSchema[] = [
         {
-          Name: 'column.level.active',
+          Name: 'column["level"]["active"]',
           CslType: 'int',
         },
       ];
 
       expect(parser.toQuery(expression, tableSchema)).toEqual(
-        'StormEvents' +
-          '\n| where column.isActive == true' +
-          `\n| summarize sum(toint(todynamic(todynamic(column).level).active))`
+        'StormEvents' + '\n| where column["isActive"] == true' + `\n| summarize sum(toint(column["level"]["active"]))`
       );
     });
 
     it('should parse expression with project when no group by and no reduce functions', () => {
       const expression = createQueryExpression({
         from: createProperty('StormEvents'),
-        where: createArray([createOperator('column.isActive', '==', true)]),
-        reduce: createArray([createReduce('column.level.active', 'none'), createReduce('active', 'none')]),
+        where: createArray([createOperator('column["isActive"]', '==', true)]),
+        reduce: createArray([createReduce('column["level"]["active"]', 'none'), createReduce('active', 'none')]),
       });
 
       const tableSchema: AdxColumnSchema[] = [
         {
-          Name: 'column.level.active',
+          Name: 'column["level"]["active"]',
           CslType: 'int',
         },
         {
@@ -460,21 +458,21 @@ describe('KustoExpressionParser', () => {
       expect(parser.toQuery(expression, tableSchema)).toEqual(
         'StormEvents' +
           '\n| where $__timeFilter(StartTime)' +
-          '\n| where column.isActive == true' +
-          `\n| project toint(todynamic(todynamic(column).level).active), active`
+          '\n| where column["isActive"] == true' +
+          `\n| project toint(column["level"]["active"]), active`
       );
     });
 
     it('should parse expression with summarize when no group by and mixed none and reduce functions', () => {
       const expression = createQueryExpression({
         from: createProperty('StormEvents'),
-        where: createArray([createOperator('column.isActive', '==', true)]),
-        reduce: createArray([createReduce('column.level.active', 'sum'), createReduce('active', 'none')]),
+        where: createArray([createOperator('column["isActive"]', '==', true)]),
+        reduce: createArray([createReduce('column["level"]["active"]', 'sum'), createReduce('active', 'none')]),
       });
 
       const tableSchema: AdxColumnSchema[] = [
         {
-          Name: 'column.level.active',
+          Name: 'column["level"]["active"]',
           CslType: 'int',
         },
         {
@@ -486,22 +484,22 @@ describe('KustoExpressionParser', () => {
       expect(parser.toQuery(expression, tableSchema)).toEqual(
         'StormEvents' +
           '\n| where $__timeFilter(StartTime)' +
-          '\n| where column.isActive == true' +
-          `\n| summarize sum(toint(todynamic(todynamic(column).level).active))`
+          '\n| where column["isActive"] == true' +
+          `\n| summarize sum(toint(column["level"]["active"]))`
       );
     });
 
     it('should parse expression to summarize and bin size when it has group by and reduce functions', () => {
       const expression = createQueryExpression({
         from: createProperty('StormEvents'),
-        where: createArray([createOperator('column.isActive', '==', true)]),
-        reduce: createArray([createReduce('column.level.active', 'sum')]),
+        where: createArray([createOperator('column["isActive"]', '==', true)]),
+        reduce: createArray([createReduce('column["level"]["active"]', 'sum')]),
         groupBy: createArray([createGroupBy('StartTime', '1h')]),
       });
 
       const tableSchema: AdxColumnSchema[] = [
         {
-          Name: 'column.level.active',
+          Name: 'column["level"]["active"]',
           CslType: 'int',
         },
         {
@@ -513,8 +511,8 @@ describe('KustoExpressionParser', () => {
       expect(parser.toQuery(expression, tableSchema)).toEqual(
         'StormEvents' +
           '\n| where $__timeFilter(StartTime)' +
-          '\n| where column.isActive == true' +
-          `\n| summarize sum(toint(todynamic(todynamic(column).level).active)) by bin(StartTime, 1h)` +
+          '\n| where column["isActive"] == true' +
+          `\n| summarize sum(toint(column["level"]["active"])) by bin(StartTime, 1h)` +
           `\n| order by StartTime asc`
       );
     });
@@ -522,13 +520,13 @@ describe('KustoExpressionParser', () => {
     it('should parse expression to summarize and bin size when it has group by', () => {
       const expression = createQueryExpression({
         from: createProperty('StormEvents'),
-        where: createArray([createOperator('column.isActive', '==', true)]),
+        where: createArray([createOperator('column["isActive"]', '==', true)]),
         groupBy: createArray([createGroupBy('StartTime', '1h')]),
       });
 
       const tableSchema: AdxColumnSchema[] = [
         {
-          Name: 'column.level.active',
+          Name: 'column["level"]["active"]',
           CslType: 'int',
         },
         {
@@ -540,7 +538,7 @@ describe('KustoExpressionParser', () => {
       expect(parser.toQuery(expression, tableSchema)).toEqual(
         'StormEvents' +
           '\n| where $__timeFilter(StartTime)' +
-          '\n| where column.isActive == true' +
+          '\n| where column["isActive"] == true' +
           `\n| summarize by bin(StartTime, 1h)` +
           `\n| order by StartTime asc`
       );
@@ -549,13 +547,13 @@ describe('KustoExpressionParser', () => {
     it('should parse expression to summarize and bin size when it has group by multiple fields', () => {
       const expression = createQueryExpression({
         from: createProperty('StormEvents'),
-        where: createArray([createOperator('column.isActive', '==', true)]),
+        where: createArray([createOperator('column["isActive"]', '==', true)]),
         groupBy: createArray([createGroupBy('StartTime', '1h'), createGroupBy('type')]),
       });
 
       const tableSchema: AdxColumnSchema[] = [
         {
-          Name: 'column.level.active',
+          Name: 'column["level"]["active"]',
           CslType: 'int',
         },
         {
@@ -567,7 +565,7 @@ describe('KustoExpressionParser', () => {
       expect(parser.toQuery(expression, tableSchema)).toEqual(
         'StormEvents' +
           '\n| where $__timeFilter(StartTime)' +
-          '\n| where column.isActive == true' +
+          '\n| where column["isActive"] == true' +
           `\n| summarize by bin(StartTime, 1h), type` +
           `\n| order by StartTime asc`
       );
@@ -576,13 +574,13 @@ describe('KustoExpressionParser', () => {
     it('should parse expression and replace default time column with group by time if available', () => {
       const expression = createQueryExpression({
         from: createProperty('StormEvents'),
-        where: createArray([createOperator('column.isActive', '==', true)]),
+        where: createArray([createOperator('column["isActive"]', '==', true)]),
         groupBy: createArray([createGroupBy('EndTime', '1h'), createGroupBy('type')]),
       });
 
       const tableSchema: AdxColumnSchema[] = [
         {
-          Name: 'column.level.active',
+          Name: 'column["level"]["active"]',
           CslType: 'int',
         },
         {
@@ -598,7 +596,7 @@ describe('KustoExpressionParser', () => {
       expect(parser.toQuery(expression, tableSchema)).toEqual(
         'StormEvents' +
           '\n| where $__timeFilter(EndTime)' +
-          '\n| where column.isActive == true' +
+          '\n| where column["isActive"] == true' +
           `\n| summarize by bin(EndTime, 1h), type` +
           `\n| order by EndTime asc`
       );
@@ -607,13 +605,13 @@ describe('KustoExpressionParser', () => {
     it('should parse expression and replace default time column with group by as dynamic column', () => {
       const expression = createQueryExpression({
         from: createProperty('StormEvents'),
-        where: createArray([createOperator('column.isActive', '==', true)]),
-        groupBy: createArray([createGroupBy('column.EndTime', '1h'), createGroupBy('type')]),
+        where: createArray([createOperator('column["isActive"]', '==', true)]),
+        groupBy: createArray([createGroupBy('column["EndTime"]', '1h'), createGroupBy('type')]),
       });
 
       const tableSchema: AdxColumnSchema[] = [
         {
-          Name: 'column.level.active',
+          Name: 'column["level"]["active"]',
           CslType: 'int',
         },
         {
@@ -621,30 +619,30 @@ describe('KustoExpressionParser', () => {
           CslType: 'datetime',
         },
         {
-          Name: 'column.EndTime',
+          Name: 'column["EndTime"]',
           CslType: 'datetime',
         },
       ];
 
       expect(parser.toQuery(expression, tableSchema)).toEqual(
         'StormEvents' +
-          '\n| where todatetime(todynamic(column).EndTime) between ($__timeFrom .. $__timeTo)' +
-          '\n| where column.isActive == true' +
-          `\n| summarize by bin(todatetime(todynamic(column).EndTime), 1h), type` +
-          `\n| order by todatetime(todynamic(column).EndTime) asc`
+          '\n| where todatetime(column["EndTime"]) between ($__timeFrom .. $__timeTo)' +
+          '\n| where column["isActive"] == true' +
+          `\n| summarize by bin(todatetime(column["EndTime"]), 1h), type` +
+          `\n| order by todatetime(column["EndTime"]) asc`
       );
     });
 
     it('should parse expression and summarize by dynamic column', () => {
       const expression = createQueryExpression({
         from: createProperty('StormEvents'),
-        where: createArray([createOperator('column.isActive', '==', true)]),
-        groupBy: createArray([createGroupBy('column.type')]),
+        where: createArray([createOperator('column["isActive"]', '==', true)]),
+        groupBy: createArray([createGroupBy('column["type"]')]),
       });
 
       const tableSchema: AdxColumnSchema[] = [
         {
-          Name: 'column.type',
+          Name: 'column["type"]',
           CslType: 'string',
         },
         {
@@ -656,8 +654,8 @@ describe('KustoExpressionParser', () => {
       expect(parser.toQuery(expression, tableSchema)).toEqual(
         'StormEvents' +
           '\n| where $__timeFilter(StartTime)' +
-          '\n| where column.isActive == true' +
-          `\n| summarize by tostring(todynamic(column).type)`
+          '\n| where column["isActive"] == true' +
+          `\n| summarize by tostring(column["type"])`
       );
     });
 
@@ -682,13 +680,13 @@ describe('KustoExpressionParser', () => {
 
       const expression = createQueryExpression({
         from: createProperty('StormEvents'),
-        where: createArray([createOperator('column.country', '==', '$country')]),
-        groupBy: createArray([createGroupBy('column.type')]),
+        where: createArray([createOperator('column["country"]', '==', '$country')]),
+        groupBy: createArray([createGroupBy('column["type"]')]),
       });
 
       const tableSchema: AdxColumnSchema[] = [
         {
-          Name: 'column.type',
+          Name: 'column["type"]',
           CslType: 'string',
         },
         {
@@ -700,21 +698,21 @@ describe('KustoExpressionParser', () => {
       expect(parser.toQuery(expression, tableSchema)).toEqual(
         'StormEvents' +
           '\n| where $__timeFilter(StartTime)' +
-          '\n| where column.country == $country' +
-          `\n| summarize by tostring(todynamic(column).type)`
+          '\n| where column["country"] == $country' +
+          `\n| summarize by tostring(column["type"])`
       );
     });
 
     it('should parse expression with summarize function that takes a parameter', () => {
       const expression = createQueryExpression({
         from: createProperty('StormEvents'),
-        where: createArray([createOperator('column.country', '==', 'sweden')]),
+        where: createArray([createOperator('column["country"]', '==', 'sweden')]),
         reduce: createArray([createReduceWithParameter('amount', 'percentile', [1])]),
       });
 
       const tableSchema: AdxColumnSchema[] = [
         {
-          Name: 'column.type',
+          Name: 'column["type"]',
           CslType: 'string',
         },
         {
@@ -726,7 +724,7 @@ describe('KustoExpressionParser', () => {
       expect(parser.toQuery(expression, tableSchema)).toEqual(
         'StormEvents' +
           '\n| where $__timeFilter(StartTime)' +
-          "\n| where column.country == 'sweden'" +
+          '\n| where column["country"] == \'sweden\'' +
           `\n| summarize percentile(amount, 1)`
       );
     });
@@ -734,13 +732,13 @@ describe('KustoExpressionParser', () => {
     it('should parse expression with summarize function that takes multiple parameter', () => {
       const expression = createQueryExpression({
         from: createProperty('StormEvents'),
-        where: createArray([createOperator('column.country', '==', 'sweden')]),
+        where: createArray([createOperator('column["country"]', '==', 'sweden')]),
         reduce: createArray([createReduceWithParameter('amount', 'percentile', [1, 2])]),
       });
 
       const tableSchema: AdxColumnSchema[] = [
         {
-          Name: 'column.type',
+          Name: 'column["type"]',
           CslType: 'string',
         },
         {
@@ -752,7 +750,7 @@ describe('KustoExpressionParser', () => {
       expect(parser.toQuery(expression, tableSchema)).toEqual(
         'StormEvents' +
           '\n| where $__timeFilter(StartTime)' +
-          "\n| where column.country == 'sweden'" +
+          '\n| where column["country"] == \'sweden\'' +
           `\n| summarize percentile(amount, 1, 2)`
       );
     });
@@ -760,13 +758,13 @@ describe('KustoExpressionParser', () => {
     it('should parse expression with summarize function that takes a parameter', () => {
       const expression = createQueryExpression({
         from: createProperty('StormEvents'),
-        where: createArray([createOperator('column.country', '==', 'sweden')]),
+        where: createArray([createOperator('column["country"]', '==', 'sweden')]),
         reduce: createArray([createReduceWithParameter('amount', 'percentile', [1])]),
       });
 
       const tableSchema: AdxColumnSchema[] = [
         {
-          Name: 'column.type',
+          Name: 'column["type"]',
           CslType: 'string',
         },
         {
@@ -778,7 +776,7 @@ describe('KustoExpressionParser', () => {
       expect(parser.toQuery(expression, tableSchema)).toEqual(
         'StormEvents' +
           '\n| where $__timeFilter(StartTime)' +
-          "\n| where column.country == 'sweden'" +
+          '\n| where column["country"] == \'sweden\'' +
           `\n| summarize percentile(amount, 1)`
       );
     });
@@ -786,13 +784,13 @@ describe('KustoExpressionParser', () => {
     it('should parse expression with summarize function that takes multiple parameter of different types', () => {
       const expression = createQueryExpression({
         from: createProperty('StormEvents'),
-        where: createArray([createOperator('column.country', '==', 'sweden')]),
+        where: createArray([createOperator('column["country"]', '==', 'sweden')]),
         reduce: createArray([createReduceWithParameter('amount', 'percentile', [1, '2'])]),
       });
 
       const tableSchema: AdxColumnSchema[] = [
         {
-          Name: 'column.type',
+          Name: 'column["type"]',
           CslType: 'string',
         },
         {
@@ -804,7 +802,7 @@ describe('KustoExpressionParser', () => {
       expect(parser.toQuery(expression, tableSchema)).toEqual(
         'StormEvents' +
           '\n| where $__timeFilter(StartTime)' +
-          "\n| where column.country == 'sweden'" +
+          '\n| where column["country"] == \'sweden\'' +
           `\n| summarize percentile(amount, 1, '2')`
       );
     });

--- a/src/KustoExpressionParser.ts
+++ b/src/KustoExpressionParser.ts
@@ -19,7 +19,7 @@ import { cloneDeep } from 'lodash';
 
 interface ParseContext {
   timeColumn?: string;
-  castIfDynamic: (column: string) => string;
+  castIfDynamic: (column: string, schemaName?: string) => string;
 }
 
 export const DYNAMIC_TYPE_ARRAY_DELIMITER = '["`indexer`"]';
@@ -34,7 +34,7 @@ export class KustoExpressionParser {
 
     const context: ParseContext = {
       timeColumn: defaultTimeColumn(tableSchema, query?.expression),
-      castIfDynamic: (column: string) => castIfDynamic(column, tableSchema),
+      castIfDynamic: (column: string, schemaName?: string) => castIfDynamic(column, tableSchema, schemaName),
     };
 
     const parts: string[] = [];
@@ -59,7 +59,7 @@ export class KustoExpressionParser {
 
     const context: ParseContext = {
       timeColumn: defaultTimeColumn(tableSchema, expression),
-      castIfDynamic: (column: string) => castIfDynamic(column, tableSchema),
+      castIfDynamic: (column: string, schemaName?: string) => castIfDynamic(column, tableSchema, schemaName),
     };
 
     const parts: string[] = [];
@@ -149,30 +149,35 @@ export class KustoExpressionParser {
     context: ParseContext,
     expression: QueryEditorExpression | undefined,
     parts: string[],
-    prefix?: string
+    prefix?: string,
+    expandParts?: string[]
   ) {
     if (!expression) {
       return;
     }
+    const eParts = expandParts ? expandParts : [];
 
     if (isAndExpression(expression)) {
-      return expression.expressions.forEach((exp) => this.appendWhere(context, exp, parts, prefix));
+      return expression.expressions.forEach((exp) => this.appendWhere(context, exp, parts, prefix, eParts));
     }
 
     if (isOrExpression(expression)) {
       const orParts: string[] = [];
-      expression.expressions.map((exp) => this.appendWhere(context, exp, orParts));
+      expression.expressions.map((exp) => this.appendWhere(context, exp, orParts, undefined, eParts));
       if (orParts.length === 0) {
         return;
       }
-      if (this.filtersContainArray(orParts)) {
-        return parts.push(this.formatArrayFilter(orParts));
+      eParts.forEach((p, i) => parts.push(`mv-expand array_${i + 1} = ${p}`));
+      parts.push(`where ${orParts.join(' or ')}`);
+      if (eParts.length) {
+        // mv-expand creates a new column that we need to delete from the result
+        const arrayCols = eParts.map((p, i) => `array_${i + 1}`);
+        parts.push(`project-away ${arrayCols.join(', ')}`);
       }
-      return parts.push(`where ${orParts.join(' or ')}`);
     }
 
     if (isFieldAndOperator(expression)) {
-      return this.appendOperator(context, expression, parts, prefix);
+      return this.appendOperator(expression, parts, eParts, prefix);
     }
   }
 
@@ -185,6 +190,7 @@ export class KustoExpressionParser {
     let countAddedInReduce = false;
     const reduceParts: string[] = [];
     const groupByParts: string[] = [];
+    const expandParts: string[] = [];
     const columns: string[] = [];
 
     for (const expression of reduce?.expressions ?? []) {
@@ -194,7 +200,8 @@ export class KustoExpressionParser {
 
       const func = expression.reduce.name;
       const parameters = expression.parameters;
-      const column = context.castIfDynamic(expression.property.name);
+      const name = this.appendMvExpandIfNeeded(expression.property.name, expandParts);
+      const column = context.castIfDynamic(name, expression.property.name);
       columns.push(column);
 
       if (Array.isArray(parameters)) {
@@ -222,7 +229,8 @@ export class KustoExpressionParser {
         continue;
       }
 
-      const column = context.castIfDynamic(expression.property.name);
+      const name = this.appendMvExpandIfNeeded(expression.property.name, expandParts);
+      const column = context.castIfDynamic(name, expression.property.name);
 
       if (expression.interval) {
         const interval = expression.interval.name;
@@ -231,6 +239,10 @@ export class KustoExpressionParser {
       }
 
       groupByParts.push(column);
+    }
+
+    if (expandParts.length > 0) {
+      expandParts.forEach((p, i) => parts.push(`mv-expand array_${i + 1} = ${p}`));
     }
 
     if (reduceParts.length > 0) {
@@ -254,9 +266,9 @@ export class KustoExpressionParser {
   }
 
   private appendOperator(
-    context: ParseContext,
     expression: QueryEditorOperatorExpression,
     parts: string[],
+    expandParts: string[],
     prefix?: string
   ) {
     const { property, operator } = expression;
@@ -272,7 +284,8 @@ export class KustoExpressionParser {
 
       default:
         const value = this.formatValue(operator.value, property.type);
-        parts.push(withPrefix(`${property.name} ${operator.name} ${value}`, prefix));
+        const name = this.appendMvExpandIfNeeded(property.name, expandParts);
+        parts.push(withPrefix(`${name} ${operator.name} ${value}`, prefix));
         break;
     }
   }
@@ -295,15 +308,17 @@ export class KustoExpressionParser {
     }
   }
 
-  private filtersContainArray(orParts: string[]) {
-    return orParts.some((p) => p.includes(DYNAMIC_TYPE_ARRAY_DELIMITER));
-  }
-
-  private formatArrayFilter(orParts: string[]) {
-    const arrayElemIndex = orParts.findIndex((p) => p.includes(DYNAMIC_TYPE_ARRAY_DELIMITER));
-    const arrayElemParts = orParts[arrayElemIndex].split(DYNAMIC_TYPE_ARRAY_DELIMITER);
-    orParts[arrayElemIndex] = `element${arrayElemParts[1]}`;
-    return `mv-apply element = ${arrayElemParts[0]} on (where ${orParts.join(' or ')})`;
+  private appendMvExpandIfNeeded(name: string, parts: string[]) {
+    if (name.includes(DYNAMIC_TYPE_ARRAY_DELIMITER)) {
+      const arrayElemParts = name.split(DYNAMIC_TYPE_ARRAY_DELIMITER);
+      const arrayLength = parts.push(arrayElemParts[0]);
+      const res = name.replace(`${parts[arrayLength - 1]}${DYNAMIC_TYPE_ARRAY_DELIMITER}`, `array_${arrayLength}`);
+      if (res.includes(DYNAMIC_TYPE_ARRAY_DELIMITER)) {
+        return this.appendMvExpandIfNeeded(res, parts);
+      }
+      return res;
+    }
+    return name;
   }
 
   private appendProperty(context: ParseContext, expression: QueryEditorPropertyExpression, parts: string[]) {
@@ -371,29 +386,29 @@ const defaultTimeColumn = (columns?: AdxColumnSchema[], expression?: QueryExpres
     return column;
   }
 
-  return toType(column);
+  return toType(column.CslType, column.Name);
 };
 
 const isDynamic = (column: string): boolean => {
   return !!(column && column.indexOf('[') > -1) || !!(column && column.indexOf('todynamic') > -1);
 };
 
-const castIfDynamic = (column: string, tableSchema?: AdxColumnSchema[]): string => {
-  if (!isDynamic(column) || !Array.isArray(tableSchema)) {
+const castIfDynamic = (column: string, tableSchema?: AdxColumnSchema[], schemaName?: string): string => {
+  if (!isDynamic(schemaName || column) || !Array.isArray(tableSchema)) {
     return column;
   }
 
-  const columnSchema = tableSchema.find((c) => c.Name === column);
+  const columnSchema = tableSchema.find((c) => c.Name === (schemaName || column));
 
   if (!columnSchema) {
     return column;
   }
 
-  return toType(columnSchema);
+  return toType(columnSchema.CslType, column);
 };
 
-const toType = (column: AdxColumnSchema): string => {
-  return `to${column.CslType}(${column.Name})`;
+const toType = (type: string, name: string): string => {
+  return `to${type}(${name})`;
 };
 
 const replaceByIndex = (

--- a/src/KustoExpressionParser.ts
+++ b/src/KustoExpressionParser.ts
@@ -195,7 +195,6 @@ export class KustoExpressionParser {
       const func = expression.reduce.name;
       const parameters = expression.parameters;
       const column = context.castIfDynamic(expression.property.name);
-      // column = column.includes('[') ? `tolong(${column})` : column;
       columns.push(column);
 
       if (Array.isArray(parameters)) {

--- a/src/KustoExpressionParser.ts
+++ b/src/KustoExpressionParser.ts
@@ -235,11 +235,7 @@ export class KustoExpressionParser {
 
     if (reduceParts.length > 0) {
       if (groupByParts.length > 0) {
-        parts.push(
-          `summarize ${reduceParts.join(', ')} by ${groupByParts
-            .map((c) => (c.includes('[') ? `tostring(${c})` : c))
-            .join(', ')}`
-        );
+        parts.push(`summarize ${reduceParts.join(', ')} by ${groupByParts.join(', ')}`);
         return;
       }
       parts.push(`summarize ${reduceParts.join(', ')}`);

--- a/src/components/VisualQueryEditor.tsx
+++ b/src/components/VisualQueryEditor.tsx
@@ -9,7 +9,6 @@ import {
   QueryEditorOperatorExpression,
   QueryEditorPropertyExpression,
 } from 'editor/expressions';
-import { DYNAMIC_TYPE_ARRAY_DELIMITER } from 'KustoExpressionParser';
 import React, { useCallback, useMemo } from 'react';
 import { useAsync } from 'react-use';
 import { selectors } from 'test/selectors';
@@ -96,9 +95,6 @@ export const VisualQueryEditor: React.FC<Props> = (props) => {
   const columns = useColumnOptions(tableSchema.value);
   const groupable = useGroupableColumns(columns);
   const aggregable = useAggregableColumns(columns);
-
-  const columnTooltip =
-    "Some columns may not be visible for selection. The visual query editor does not currently support columns of type 'dynamic'";
 
   const onChangeTable = useCallback(
     (expression: QueryEditorExpression) => {
@@ -275,7 +271,6 @@ export const VisualQueryEditor: React.FC<Props> = (props) => {
         fields={columns}
         onChange={onWhereChange}
         getSuggestions={onAutoComplete}
-        tooltip={columnTooltip}
       />
       <KustoValueColumnEditorSection
         templateVariableOptions={props.templateVariableOptions}
@@ -283,7 +278,6 @@ export const VisualQueryEditor: React.FC<Props> = (props) => {
         value={query.expression?.reduce ?? defaultQuery.expression?.reduce}
         fields={aggregable}
         onChange={onReduceChange}
-        tooltip={columnTooltip}
       />
       <KustoGroupByEditorSection
         templateVariableOptions={props.templateVariableOptions}
@@ -291,7 +285,6 @@ export const VisualQueryEditor: React.FC<Props> = (props) => {
         value={query.expression?.groupBy ?? defaultQuery.expression?.groupBy}
         fields={groupable}
         onChange={onGroupByChange}
-        tooltip={columnTooltip}
       />
       <hr />
       <KustoPropertyEditorSection
@@ -317,23 +310,13 @@ const getStyles = (theme: GrafanaTheme2) => ({
 
 const useGroupableColumns = (columns: QueryEditorPropertyDefinition[]): QueryEditorPropertyDefinition[] => {
   return useMemo(() => {
-    return columns.filter(
-      (c) =>
-        (c.type === QueryEditorPropertyType.DateTime || QueryEditorPropertyType.String) &&
-        // TODO: Add support dynamic arrays
-        !c.value.includes(DYNAMIC_TYPE_ARRAY_DELIMITER)
-    );
+    return columns.filter((c) => c.type === QueryEditorPropertyType.DateTime || QueryEditorPropertyType.String);
   }, [columns]);
 };
 
 const useAggregableColumns = (columns: QueryEditorPropertyDefinition[]): QueryEditorPropertyDefinition[] => {
   return useMemo(() => {
-    return columns.filter(
-      (c) =>
-        (c.type === QueryEditorPropertyType.DateTime || QueryEditorPropertyType.String) &&
-        // TODO: Add support dynamic arrays
-        !c.value.includes(DYNAMIC_TYPE_ARRAY_DELIMITER)
-    );
+    return columns.filter((c) => c.type === QueryEditorPropertyType.DateTime || QueryEditorPropertyType.String);
   }, [columns]);
 };
 

--- a/src/components/VisualQueryEditor.tsx
+++ b/src/components/VisualQueryEditor.tsx
@@ -317,35 +317,23 @@ const getStyles = (theme: GrafanaTheme2) => ({
 
 const useGroupableColumns = (columns: QueryEditorPropertyDefinition[]): QueryEditorPropertyDefinition[] => {
   return useMemo(() => {
-    return columns
-      .filter(
-        (c) =>
-          (c.type === QueryEditorPropertyType.DateTime || QueryEditorPropertyType.String) &&
-          // TODO: Add support dynamic arrays
-          !c.value.includes(DYNAMIC_TYPE_ARRAY_DELIMITER)
-      )
-      .map((c) => ({
-        ...c,
-        // Transform dynamic values to string so they can be grouped
-        value: c.dynamic ? `tostring(${c.value})` : c.value,
-      }));
+    return columns.filter(
+      (c) =>
+        (c.type === QueryEditorPropertyType.DateTime || QueryEditorPropertyType.String) &&
+        // TODO: Add support dynamic arrays
+        !c.value.includes(DYNAMIC_TYPE_ARRAY_DELIMITER)
+    );
   }, [columns]);
 };
 
 const useAggregableColumns = (columns: QueryEditorPropertyDefinition[]): QueryEditorPropertyDefinition[] => {
   return useMemo(() => {
-    return columns
-      .filter(
-        (c) =>
-          (c.type === QueryEditorPropertyType.DateTime || QueryEditorPropertyType.String) &&
-          // TODO: Add support dynamic arrays
-          !c.value.includes(DYNAMIC_TYPE_ARRAY_DELIMITER)
-      )
-      .map((c) => ({
-        ...c,
-        // Transform dynamic values to long so they can be used by math functions
-        value: c.value.includes('[') ? `tolong(${c.value})` : c.value,
-      }));
+    return columns.filter(
+      (c) =>
+        (c.type === QueryEditorPropertyType.DateTime || QueryEditorPropertyType.String) &&
+        // TODO: Add support dynamic arrays
+        !c.value.includes(DYNAMIC_TYPE_ARRAY_DELIMITER)
+    );
   }, [columns]);
 };
 

--- a/src/schema/AdxSchemaResolver.test.ts
+++ b/src/schema/AdxSchemaResolver.test.ts
@@ -1,4 +1,3 @@
-import { config } from '@grafana/runtime';
 import { mockDatasource } from 'components/__fixtures__/Datasource';
 import createMockSchema from 'components/__fixtures__/schema';
 
@@ -8,15 +7,10 @@ describe('Test schema resolution', () => {
   const datasource = mockDatasource();
   const schemaResolver = new AdxSchemaResolver(datasource);
   const schema = createMockSchema();
-  const originalFeatureToggles = config.featureToggles;
 
   beforeEach(() => {
     datasource.getSchema = jest.fn().mockResolvedValue(schema);
     datasource.getDynamicSchema = jest.fn().mockResolvedValue([{ Name: 'testprop', CslType: 'string' }]);
-    config.featureToggles = {
-      ...originalFeatureToggles,
-      adxQueryBuilderDynamicTypes: true,
-    };
   });
 
   it('Will correctly retrieve databases', async () => {
@@ -49,7 +43,7 @@ describe('Test schema resolution', () => {
     expect(columns).toEqual(schema.Databases['testdb'].Tables['testtable'].OrderedColumns);
   });
 
-  it('Will correctly filter include columns with type "dynamic" and containing arrays', async () => {
+  it('Will correctly include columns with type "dynamic" and containing arrays', async () => {
     const testColumns = [
       { Name: 'boolean', CslType: 'bool', Type: 'System.Boolean' },
       { Name: 'datetime', CslType: 'datetime', Type: 'System.DateTime' },
@@ -65,6 +59,39 @@ describe('Test schema resolution', () => {
     ];
     datasource.getDynamicSchema = jest.fn().mockResolvedValue({
       dynamic: [{ Name: 'Modes["`indexer`"]', CslType: 'string' }],
+    });
+    const schema = createMockSchema();
+    schema.Databases['testdb'].Tables = {
+      ...schema.Databases['testdb'].Tables,
+      ...{
+        testdynamictable: {
+          Name: 'testdynamictable',
+          OrderedColumns: testColumns,
+        },
+      },
+    };
+    datasource.getSchema = jest.fn().mockResolvedValue(schema);
+    const columns = await schemaResolver.getColumnsForTable('testdb', 'testdynamictable');
+    expect(columns).toHaveLength(testColumns.length);
+    expect(columns).toEqual(expect.arrayContaining([{ CslType: 'string', Name: 'Modes["`indexer`"]' }]));
+  });
+
+  it('Will correctly include columns with type "dynamic" and containing nested arrays', async () => {
+    const testColumns = [
+      { Name: 'boolean', CslType: 'bool', Type: 'System.Boolean' },
+      { Name: 'datetime', CslType: 'datetime', Type: 'System.DateTime' },
+      { Name: 'guid', CslType: 'guid', Type: 'System.Guid' },
+      { Name: 'int', CslType: 'int', Type: 'System.Int32' },
+      { Name: 'long', CslType: 'long', Type: 'System.Int64' },
+      { Name: 'real', CslType: 'real', Type: 'System.Double' },
+      { Name: 'string', CslType: 'string', Type: 'System.String' },
+      { Name: 'timespan', CslType: 'timespan', Type: 'System.TimeSpan' },
+      { Name: 'decimal', CslType: 'decimal', Type: 'System.Data.SqlTypes.SqlDecimal' },
+      // Dynamic column
+      { Name: 'dynamic', CslType: 'dynamic', Type: 'System.Object' },
+    ];
+    datasource.getDynamicSchema = jest.fn().mockResolvedValue({
+      dynamic: [{ Name: 'Modes["`indexer`"]["`indexer`"]', CslType: 'string' }],
     });
     const schema = createMockSchema();
     schema.Databases['testdb'].Tables = {

--- a/src/schema/AdxSchemaResolver.ts
+++ b/src/schema/AdxSchemaResolver.ts
@@ -8,8 +8,6 @@ import {
 } from '../types';
 import { AdxDataSource } from '../datasource';
 import { cache } from './cache';
-import { config } from '@grafana/runtime';
-import { DYNAMIC_TYPE_ARRAY_DELIMITER } from 'KustoExpressionParser';
 
 const schemaKey = 'AdxSchemaResolver';
 
@@ -90,19 +88,7 @@ export class AdxSchemaResolver {
         }
 
         // Handling dynamic columns
-
-        // Adding a feature flag while we polish things up
-        if (!config.featureToggles.adxQueryBuilderDynamicTypes) {
-          return columns;
-        }
-
-        // TODO: Ignoring arrays with multiple nested arrays
-        const schemaForDynamicColumnWithoutMultipleArrays = schemaForDynamicColumn.filter(
-          (c) => c.Name.split(DYNAMIC_TYPE_ARRAY_DELIMITER).length <= 2
-        );
-
-        // Plain objects
-        Array.prototype.push.apply(columns, schemaForDynamicColumnWithoutMultipleArrays);
+        Array.prototype.push.apply(columns, schemaForDynamicColumn);
         return columns;
       }, []);
     });

--- a/src/schema/mapper.ts
+++ b/src/schema/mapper.ts
@@ -1,5 +1,6 @@
 import { SelectableValue } from '@grafana/data';
 import { DYNAMIC_TYPE_ARRAY_DELIMITER } from 'KustoExpressionParser';
+import { escapeRegExp } from 'lodash';
 
 import { QueryEditorPropertyDefinition, QueryEditorPropertyType } from '../editor/types';
 import { AdxColumnSchema, AdxDatabaseSchema, AdxTableSchema } from '../types';
@@ -54,7 +55,7 @@ export const columnsToDefinition = (columns: AdxColumnSchema[]): QueryEditorProp
   return columns.map((column) => {
     return {
       value: column.Name,
-      label: column.Name.replace(DYNAMIC_TYPE_ARRAY_DELIMITER, '[ ]'),
+      label: column.Name.replace(new RegExp(escapeRegExp(DYNAMIC_TYPE_ARRAY_DELIMITER), 'g'), '[ ]'),
       type: toPropertyType(column.CslType),
     };
   });


### PR DESCRIPTION
I just noticed that KustoExpressionParser already have the logic to handle dynamic types but it was relying on the `obj.property` notation (rather than `obj["property"]`).

I have adapted that and luckily the functionality was really well covered with unit tests so I was able to verify that the new output is correct.

With that, I was also able to remove some related code from the VisualQueryEditor since the logic was duplicated.