### PR TITLE
Allow dynamic arrays when aggregating and grouping

### DIFF
--- a/src/KustoExpressionParser.test.ts
+++ b/src/KustoExpressionParser.test.ts
@@ -832,6 +832,34 @@ describe('KustoExpressionParser', () => {
       );
     });
 
+    it('should parse expression with summarize function in a nested array', () => {
+      const expression = createQueryExpression({
+        from: createProperty('StormEvents'),
+        reduce: createArray([
+          createReduceWithParameter('column["`indexer`"]["foo"]["`indexer`"]', 'percentile', [1, '2']),
+        ]),
+      });
+
+      const tableSchema: AdxColumnSchema[] = [
+        {
+          Name: 'column["`indexer`"]["foo"]["`indexer`"]',
+          CslType: 'string',
+        },
+        {
+          Name: 'StartTime',
+          CslType: 'datetime',
+        },
+      ];
+
+      expect(parser.toQuery(expression, tableSchema)).toEqual(
+        'StormEvents' +
+          '\n| where $__timeFilter(StartTime)' +
+          '\n| mv-expand array_1 = column' +
+          '\n| mv-expand array_2 = array_1["foo"]' +
+          `\n| summarize percentile(tostring(array_2), 1, '2')`
+      );
+    });
+
     it('should parse expression with timeshift', () => {
       const expression = createQueryExpression({
         from: createProperty('StormEvents'),
@@ -1015,6 +1043,32 @@ describe('KustoExpressionParser', () => {
       );
     });
 
+    it('should parse expression with a grouped nested array', () => {
+      const expression = createQueryExpression({
+        from: createProperty('StormEvents'),
+        groupBy: createArray([createGroupBy('column["`indexer`"]["foo"]["`indexer`"]')]),
+      });
+
+      const tableSchema: AdxColumnSchema[] = [
+        {
+          Name: 'column["`indexer`"]["foo"]["`indexer`"]',
+          CslType: 'string',
+        },
+        {
+          Name: 'StartTime',
+          CslType: 'datetime',
+        },
+      ];
+
+      expect(parser.toQuery(expression, tableSchema)).toEqual(
+        'StormEvents' +
+          '\n| where $__timeFilter(StartTime)' +
+          '\n| mv-expand array_1 = column' +
+          '\n| mv-expand array_2 = array_1["foo"]' +
+          '\n| summarize by tostring(array_2)'
+      );
+    });
+
     it('should parse expression with an array', () => {
       const expression = createQueryExpression({
         from: createProperty('StormEvents'),
@@ -1025,7 +1079,10 @@ describe('KustoExpressionParser', () => {
       });
 
       expect(parser.toQuery(expression)).toEqual(
-        'StormEvents' + "\n| mv-apply element = eventType on (where element == 'ThunderStorm')"
+        'StormEvents' +
+          '\n| mv-expand array_1 = eventType' +
+          "\n| where array_1 == 'ThunderStorm'" +
+          '\n| project-away array_1'
       );
     });
 
@@ -1042,7 +1099,59 @@ describe('KustoExpressionParser', () => {
       });
 
       expect(parser.toQuery(expression)).toEqual(
-        'StormEvents' + "\n| mv-apply element = eventType on (where element == 'ThunderStorm' or foo == 'bar')"
+        'StormEvents' +
+          '\n| mv-expand array_1 = eventType' +
+          "\n| where array_1 == 'ThunderStorm' or foo == 'bar'" +
+          '\n| project-away array_1'
+      );
+    });
+
+    it('should parse expression with nested arrays', () => {
+      const expression = createQueryExpression({
+        from: createProperty('StormEvents'),
+        where: createArray(
+          [
+            createOperator(
+              `eventType${DYNAMIC_TYPE_ARRAY_DELIMITER}["obj"]${DYNAMIC_TYPE_ARRAY_DELIMITER}`,
+              '==',
+              'ThunderStorm'
+            ),
+          ],
+          QueryEditorExpressionType.Or
+        ),
+      });
+
+      expect(parser.toQuery(expression)).toEqual(
+        'StormEvents' +
+          '\n| mv-expand array_1 = eventType' +
+          '\n| mv-expand array_2 = array_1["obj"]' +
+          "\n| where array_2 == 'ThunderStorm'" +
+          '\n| project-away array_1, array_2'
+      );
+    });
+
+    it('should parse expression with an array and other "or" operators', () => {
+      const expression = createQueryExpression({
+        from: createProperty('StormEvents'),
+        where: createArray(
+          [
+            createOperator(
+              `eventType${DYNAMIC_TYPE_ARRAY_DELIMITER}["obj"]${DYNAMIC_TYPE_ARRAY_DELIMITER}`,
+              '==',
+              'ThunderStorm'
+            ),
+            createOperator(`foo`, '==', 'bar'),
+          ],
+          QueryEditorExpressionType.Or
+        ),
+      });
+
+      expect(parser.toQuery(expression)).toEqual(
+        'StormEvents' +
+          '\n| mv-expand array_1 = eventType' +
+          '\n| mv-expand array_2 = array_1["obj"]' +
+          "\n| where array_2 == 'ThunderStorm' or foo == 'bar'" +
+          '\n| project-away array_1, array_2'
       );
     });
   });

--- a/src/components/VisualQueryEditor.tsx
+++ b/src/components/VisualQueryEditor.tsx
@@ -96,9 +96,6 @@ export const VisualQueryEditor: React.FC<Props> = (props) => {
   const groupable = useGroupableColumns(columns);
   const aggregable = useAggregableColumns(columns);
 
-  const columnTooltip =
-    "Some columns may not be visible for selection. The visual query editor does not currently support columns of type 'dynamic'";
-
   const onChangeTable = useCallback(
     (expression: QueryEditorExpression) => {
       if (!isFieldExpression(expression) || !table) {
@@ -274,7 +271,6 @@ export const VisualQueryEditor: React.FC<Props> = (props) => {
         fields={columns}
         onChange={onWhereChange}
         getSuggestions={onAutoComplete}
-        tooltip={columnTooltip}
       />
       <KustoValueColumnEditorSection
         templateVariableOptions={props.templateVariableOptions}
@@ -282,7 +278,6 @@ export const VisualQueryEditor: React.FC<Props> = (props) => {
         value={query.expression?.reduce ?? defaultQuery.expression?.reduce}
         fields={aggregable}
         onChange={onReduceChange}
-        tooltip={columnTooltip}
       />
       <KustoGroupByEditorSection
         templateVariableOptions={props.templateVariableOptions}
@@ -290,7 +285,6 @@ export const VisualQueryEditor: React.FC<Props> = (props) => {
         value={query.expression?.groupBy ?? defaultQuery.expression?.groupBy}
         fields={groupable}
         onChange={onGroupByChange}
-        tooltip={columnTooltip}
       />
       <hr />
       <KustoPropertyEditorSection

--- a/src/components/VisualQueryEditor.tsx
+++ b/src/components/VisualQueryEditor.tsx
@@ -9,7 +9,6 @@ import {
   QueryEditorOperatorExpression,
   QueryEditorPropertyExpression,
 } from 'editor/expressions';
-import { DYNAMIC_TYPE_ARRAY_DELIMITER } from 'KustoExpressionParser';
 import React, { useCallback, useMemo } from 'react';
 import { useAsync } from 'react-use';
 import { selectors } from 'test/selectors';
@@ -317,23 +316,13 @@ const getStyles = (theme: GrafanaTheme2) => ({
 
 const useGroupableColumns = (columns: QueryEditorPropertyDefinition[]): QueryEditorPropertyDefinition[] => {
   return useMemo(() => {
-    return columns.filter(
-      (c) =>
-        (c.type === QueryEditorPropertyType.DateTime || QueryEditorPropertyType.String) &&
-        // TODO: Add support dynamic arrays
-        !c.value.includes(DYNAMIC_TYPE_ARRAY_DELIMITER)
-    );
+    return columns.filter((c) => c.type === QueryEditorPropertyType.DateTime || QueryEditorPropertyType.String);
   }, [columns]);
 };
 
 const useAggregableColumns = (columns: QueryEditorPropertyDefinition[]): QueryEditorPropertyDefinition[] => {
   return useMemo(() => {
-    return columns.filter(
-      (c) =>
-        (c.type === QueryEditorPropertyType.DateTime || QueryEditorPropertyType.String) &&
-        // TODO: Add support dynamic arrays
-        !c.value.includes(DYNAMIC_TYPE_ARRAY_DELIMITER)
-    );
+    return columns.filter((c) => c.type === QueryEditorPropertyType.DateTime || QueryEditorPropertyType.String);
   }, [columns]);
 };
 

--- a/src/schema/AdxSchemaResolver.test.ts
+++ b/src/schema/AdxSchemaResolver.test.ts
@@ -1,4 +1,3 @@
-import { config } from '@grafana/runtime';
 import { mockDatasource } from 'components/__fixtures__/Datasource';
 import createMockSchema from 'components/__fixtures__/schema';
 
@@ -8,15 +7,10 @@ describe('Test schema resolution', () => {
   const datasource = mockDatasource();
   const schemaResolver = new AdxSchemaResolver(datasource);
   const schema = createMockSchema();
-  const originalFeatureToggles = config.featureToggles;
 
   beforeEach(() => {
     datasource.getSchema = jest.fn().mockResolvedValue(schema);
     datasource.getDynamicSchema = jest.fn().mockResolvedValue([{ Name: 'testprop', CslType: 'string' }]);
-    config.featureToggles = {
-      ...originalFeatureToggles,
-      adxQueryBuilderDynamicTypes: true,
-    };
   });
 
   it('Will correctly retrieve databases', async () => {
@@ -49,7 +43,7 @@ describe('Test schema resolution', () => {
     expect(columns).toEqual(schema.Databases['testdb'].Tables['testtable'].OrderedColumns);
   });
 
-  it('Will correctly filter include columns with type "dynamic" and containing arrays', async () => {
+  it('Will correctly include columns with type "dynamic" and containing arrays', async () => {
     const testColumns = [
       { Name: 'boolean', CslType: 'bool', Type: 'System.Boolean' },
       { Name: 'datetime', CslType: 'datetime', Type: 'System.DateTime' },
@@ -65,6 +59,39 @@ describe('Test schema resolution', () => {
     ];
     datasource.getDynamicSchema = jest.fn().mockResolvedValue({
       dynamic: [{ Name: 'Modes["`indexer`"]', CslType: 'string' }],
+    });
+    const schema = createMockSchema();
+    schema.Databases['testdb'].Tables = {
+      ...schema.Databases['testdb'].Tables,
+      ...{
+        testdynamictable: {
+          Name: 'testdynamictable',
+          OrderedColumns: testColumns,
+        },
+      },
+    };
+    datasource.getSchema = jest.fn().mockResolvedValue(schema);
+    const columns = await schemaResolver.getColumnsForTable('testdb', 'testdynamictable');
+    expect(columns).toHaveLength(testColumns.length);
+    expect(columns).toEqual(expect.arrayContaining([{ CslType: 'string', Name: 'Modes["`indexer`"]' }]));
+  });
+
+  it('Will correctly include columns with type "dynamic" and containing nested arrays', async () => {
+    const testColumns = [
+      { Name: 'boolean', CslType: 'bool', Type: 'System.Boolean' },
+      { Name: 'datetime', CslType: 'datetime', Type: 'System.DateTime' },
+      { Name: 'guid', CslType: 'guid', Type: 'System.Guid' },
+      { Name: 'int', CslType: 'int', Type: 'System.Int32' },
+      { Name: 'long', CslType: 'long', Type: 'System.Int64' },
+      { Name: 'real', CslType: 'real', Type: 'System.Double' },
+      { Name: 'string', CslType: 'string', Type: 'System.String' },
+      { Name: 'timespan', CslType: 'timespan', Type: 'System.TimeSpan' },
+      { Name: 'decimal', CslType: 'decimal', Type: 'System.Data.SqlTypes.SqlDecimal' },
+      // Dynamic column
+      { Name: 'dynamic', CslType: 'dynamic', Type: 'System.Object' },
+    ];
+    datasource.getDynamicSchema = jest.fn().mockResolvedValue({
+      dynamic: [{ Name: 'Modes["`indexer`"]["`indexer`"]', CslType: 'string' }],
     });
     const schema = createMockSchema();
     schema.Databases['testdb'].Tables = {

--- a/src/schema/AdxSchemaResolver.ts
+++ b/src/schema/AdxSchemaResolver.ts
@@ -8,8 +8,6 @@ import {
 } from '../types';
 import { AdxDataSource } from '../datasource';
 import { cache } from './cache';
-import { config } from '@grafana/runtime';
-import { DYNAMIC_TYPE_ARRAY_DELIMITER } from 'KustoExpressionParser';
 
 const schemaKey = 'AdxSchemaResolver';
 
@@ -90,19 +88,7 @@ export class AdxSchemaResolver {
         }
 
         // Handling dynamic columns
-
-        // Adding a feature flag while we polish things up
-        if (!config.featureToggles.adxQueryBuilderDynamicTypes) {
-          return columns;
-        }
-
-        // TODO: Ignoring arrays with multiple nested arrays
-        const schemaForDynamicColumnWithoutMultipleArrays = schemaForDynamicColumn.filter(
-          (c) => c.Name.split(DYNAMIC_TYPE_ARRAY_DELIMITER).length <= 2
-        );
-
-        // Plain objects
-        Array.prototype.push.apply(columns, schemaForDynamicColumnWithoutMultipleArrays);
+        Array.prototype.push.apply(columns, schemaForDynamicColumn);
         return columns;
       }, []);
     });

--- a/src/schema/mapper.ts
+++ b/src/schema/mapper.ts
@@ -1,5 +1,6 @@
 import { SelectableValue } from '@grafana/data';
 import { DYNAMIC_TYPE_ARRAY_DELIMITER } from 'KustoExpressionParser';
+import { escapeRegExp } from 'lodash';
 
 import { QueryEditorPropertyDefinition, QueryEditorPropertyType } from '../editor/types';
 import { AdxColumnSchema, AdxDatabaseSchema, AdxTableSchema } from '../types';
@@ -54,7 +55,7 @@ export const columnsToDefinition = (columns: AdxColumnSchema[]): QueryEditorProp
   return columns.map((column) => {
     return {
       value: column.Name,
-      label: column.Name.replace(DYNAMIC_TYPE_ARRAY_DELIMITER, '[ ]'),
+      label: column.Name.replace(new RegExp(escapeRegExp(DYNAMIC_TYPE_ARRAY_DELIMITER), 'g'), '[ ]'),
       type: toPropertyType(column.CslType),
     };
   });


### PR DESCRIPTION
Using the [`mv-expand` operator](https://docs.microsoft.com/en-us/azure/data-explorer/kusto/query/mvexpandoperator), it is possible to convert a dynamic array to a set of rows. After doing that, we can `summarize` the result as any other field.

In this example, we are returning the sum of all the players score, grouped by the time played:

![Screenshot from 2022-06-02 17-40-53](https://user-images.githubusercontent.com/4025665/171667542-2aff7f09-95f4-483a-a610-2bc4cbf86708.png)
