### PR TITLE
Support for dynamic nested arrays

### DIFF
--- a/src/KustoExpressionParser.test.ts
+++ b/src/KustoExpressionParser.test.ts
@@ -832,6 +832,34 @@ describe('KustoExpressionParser', () => {
       );
     });
 
+    it('should parse expression with summarize function in a nested array', () => {
+      const expression = createQueryExpression({
+        from: createProperty('StormEvents'),
+        reduce: createArray([
+          createReduceWithParameter('column["`indexer`"]["foo"]["`indexer`"]', 'percentile', [1, '2']),
+        ]),
+      });
+
+      const tableSchema: AdxColumnSchema[] = [
+        {
+          Name: 'column["`indexer`"]["foo"]["`indexer`"]',
+          CslType: 'string',
+        },
+        {
+          Name: 'StartTime',
+          CslType: 'datetime',
+        },
+      ];
+
+      expect(parser.toQuery(expression, tableSchema)).toEqual(
+        'StormEvents' +
+          '\n| where $__timeFilter(StartTime)' +
+          '\n| mv-expand array_1 = column' +
+          '\n| mv-expand array_2 = array_1["foo"]' +
+          `\n| summarize percentile(tostring(array_2), 1, '2')`
+      );
+    });
+
     it('should parse expression with timeshift', () => {
       const expression = createQueryExpression({
         from: createProperty('StormEvents'),
@@ -1015,6 +1043,32 @@ describe('KustoExpressionParser', () => {
       );
     });
 
+    it('should parse expression with a grouped nested array', () => {
+      const expression = createQueryExpression({
+        from: createProperty('StormEvents'),
+        groupBy: createArray([createGroupBy('column["`indexer`"]["foo"]["`indexer`"]')]),
+      });
+
+      const tableSchema: AdxColumnSchema[] = [
+        {
+          Name: 'column["`indexer`"]["foo"]["`indexer`"]',
+          CslType: 'string',
+        },
+        {
+          Name: 'StartTime',
+          CslType: 'datetime',
+        },
+      ];
+
+      expect(parser.toQuery(expression, tableSchema)).toEqual(
+        'StormEvents' +
+          '\n| where $__timeFilter(StartTime)' +
+          '\n| mv-expand array_1 = column' +
+          '\n| mv-expand array_2 = array_1["foo"]' +
+          '\n| summarize by tostring(array_2)'
+      );
+    });
+
     it('should parse expression with an array', () => {
       const expression = createQueryExpression({
         from: createProperty('StormEvents'),
@@ -1025,7 +1079,10 @@ describe('KustoExpressionParser', () => {
       });
 
       expect(parser.toQuery(expression)).toEqual(
-        'StormEvents' + "\n| mv-apply element = eventType on (where element == 'ThunderStorm')"
+        'StormEvents' +
+          '\n| mv-expand array_1 = eventType' +
+          "\n| where array_1 == 'ThunderStorm'" +
+          '\n| project-away array_1'
       );
     });
 
@@ -1042,7 +1099,59 @@ describe('KustoExpressionParser', () => {
       });
 
       expect(parser.toQuery(expression)).toEqual(
-        'StormEvents' + "\n| mv-apply element = eventType on (where element == 'ThunderStorm' or foo == 'bar')"
+        'StormEvents' +
+          '\n| mv-expand array_1 = eventType' +
+          "\n| where array_1 == 'ThunderStorm' or foo == 'bar'" +
+          '\n| project-away array_1'
+      );
+    });
+
+    it('should parse expression with nested arrays', () => {
+      const expression = createQueryExpression({
+        from: createProperty('StormEvents'),
+        where: createArray(
+          [
+            createOperator(
+              `eventType${DYNAMIC_TYPE_ARRAY_DELIMITER}["obj"]${DYNAMIC_TYPE_ARRAY_DELIMITER}`,
+              '==',
+              'ThunderStorm'
+            ),
+          ],
+          QueryEditorExpressionType.Or
+        ),
+      });
+
+      expect(parser.toQuery(expression)).toEqual(
+        'StormEvents' +
+          '\n| mv-expand array_1 = eventType' +
+          '\n| mv-expand array_2 = array_1["obj"]' +
+          "\n| where array_2 == 'ThunderStorm'" +
+          '\n| project-away array_1, array_2'
+      );
+    });
+
+    it('should parse expression with an array and other "or" operators', () => {
+      const expression = createQueryExpression({
+        from: createProperty('StormEvents'),
+        where: createArray(
+          [
+            createOperator(
+              `eventType${DYNAMIC_TYPE_ARRAY_DELIMITER}["obj"]${DYNAMIC_TYPE_ARRAY_DELIMITER}`,
+              '==',
+              'ThunderStorm'
+            ),
+            createOperator(`foo`, '==', 'bar'),
+          ],
+          QueryEditorExpressionType.Or
+        ),
+      });
+
+      expect(parser.toQuery(expression)).toEqual(
+        'StormEvents' +
+          '\n| mv-expand array_1 = eventType' +
+          '\n| mv-expand array_2 = array_1["obj"]' +
+          "\n| where array_2 == 'ThunderStorm' or foo == 'bar'" +
+          '\n| project-away array_1, array_2'
       );
     });
   });

--- a/src/components/VisualQueryEditor.tsx
+++ b/src/components/VisualQueryEditor.tsx
@@ -96,9 +96,6 @@ export const VisualQueryEditor: React.FC<Props> = (props) => {
   const groupable = useGroupableColumns(columns);
   const aggregable = useAggregableColumns(columns);
 
-  const columnTooltip =
-    "Some columns may not be visible for selection. The visual query editor does not currently support columns of type 'dynamic'";
-
   const onChangeTable = useCallback(
     (expression: QueryEditorExpression) => {
       if (!isFieldExpression(expression) || !table) {
@@ -274,7 +271,6 @@ export const VisualQueryEditor: React.FC<Props> = (props) => {
         fields={columns}
         onChange={onWhereChange}
         getSuggestions={onAutoComplete}
-        tooltip={columnTooltip}
       />
       <KustoValueColumnEditorSection
         templateVariableOptions={props.templateVariableOptions}
@@ -282,7 +278,6 @@ export const VisualQueryEditor: React.FC<Props> = (props) => {
         value={query.expression?.reduce ?? defaultQuery.expression?.reduce}
         fields={aggregable}
         onChange={onReduceChange}
-        tooltip={columnTooltip}
       />
       <KustoGroupByEditorSection
         templateVariableOptions={props.templateVariableOptions}
@@ -290,7 +285,6 @@ export const VisualQueryEditor: React.FC<Props> = (props) => {
         value={query.expression?.groupBy ?? defaultQuery.expression?.groupBy}
         fields={groupable}
         onChange={onGroupByChange}
-        tooltip={columnTooltip}
       />
       <hr />
       <KustoPropertyEditorSection

--- a/src/schema/AdxSchemaResolver.test.ts
+++ b/src/schema/AdxSchemaResolver.test.ts
@@ -1,4 +1,3 @@
-import { config } from '@grafana/runtime';
 import { mockDatasource } from 'components/__fixtures__/Datasource';
 import createMockSchema from 'components/__fixtures__/schema';
 
@@ -8,15 +7,10 @@ describe('Test schema resolution', () => {
   const datasource = mockDatasource();
   const schemaResolver = new AdxSchemaResolver(datasource);
   const schema = createMockSchema();
-  const originalFeatureToggles = config.featureToggles;
 
   beforeEach(() => {
     datasource.getSchema = jest.fn().mockResolvedValue(schema);
     datasource.getDynamicSchema = jest.fn().mockResolvedValue([{ Name: 'testprop', CslType: 'string' }]);
-    config.featureToggles = {
-      ...originalFeatureToggles,
-      adxQueryBuilderDynamicTypes: true,
-    };
   });
 
   it('Will correctly retrieve databases', async () => {
@@ -49,7 +43,7 @@ describe('Test schema resolution', () => {
     expect(columns).toEqual(schema.Databases['testdb'].Tables['testtable'].OrderedColumns);
   });
 
-  it('Will correctly filter include columns with type "dynamic" and containing arrays', async () => {
+  it('Will correctly include columns with type "dynamic" and containing arrays', async () => {
     const testColumns = [
       { Name: 'boolean', CslType: 'bool', Type: 'System.Boolean' },
       { Name: 'datetime', CslType: 'datetime', Type: 'System.DateTime' },
@@ -65,6 +59,39 @@ describe('Test schema resolution', () => {
     ];
     datasource.getDynamicSchema = jest.fn().mockResolvedValue({
       dynamic: [{ Name: 'Modes["`indexer`"]', CslType: 'string' }],
+    });
+    const schema = createMockSchema();
+    schema.Databases['testdb'].Tables = {
+      ...schema.Databases['testdb'].Tables,
+      ...{
+        testdynamictable: {
+          Name: 'testdynamictable',
+          OrderedColumns: testColumns,
+        },
+      },
+    };
+    datasource.getSchema = jest.fn().mockResolvedValue(schema);
+    const columns = await schemaResolver.getColumnsForTable('testdb', 'testdynamictable');
+    expect(columns).toHaveLength(testColumns.length);
+    expect(columns).toEqual(expect.arrayContaining([{ CslType: 'string', Name: 'Modes["`indexer`"]' }]));
+  });
+
+  it('Will correctly include columns with type "dynamic" and containing nested arrays', async () => {
+    const testColumns = [
+      { Name: 'boolean', CslType: 'bool', Type: 'System.Boolean' },
+      { Name: 'datetime', CslType: 'datetime', Type: 'System.DateTime' },
+      { Name: 'guid', CslType: 'guid', Type: 'System.Guid' },
+      { Name: 'int', CslType: 'int', Type: 'System.Int32' },
+      { Name: 'long', CslType: 'long', Type: 'System.Int64' },
+      { Name: 'real', CslType: 'real', Type: 'System.Double' },
+      { Name: 'string', CslType: 'string', Type: 'System.String' },
+      { Name: 'timespan', CslType: 'timespan', Type: 'System.TimeSpan' },
+      { Name: 'decimal', CslType: 'decimal', Type: 'System.Data.SqlTypes.SqlDecimal' },
+      // Dynamic column
+      { Name: 'dynamic', CslType: 'dynamic', Type: 'System.Object' },
+    ];
+    datasource.getDynamicSchema = jest.fn().mockResolvedValue({
+      dynamic: [{ Name: 'Modes["`indexer`"]["`indexer`"]', CslType: 'string' }],
     });
     const schema = createMockSchema();
     schema.Databases['testdb'].Tables = {

--- a/src/schema/AdxSchemaResolver.ts
+++ b/src/schema/AdxSchemaResolver.ts
@@ -8,8 +8,6 @@ import {
 } from '../types';
 import { AdxDataSource } from '../datasource';
 import { cache } from './cache';
-import { config } from '@grafana/runtime';
-import { DYNAMIC_TYPE_ARRAY_DELIMITER } from 'KustoExpressionParser';
 
 const schemaKey = 'AdxSchemaResolver';
 
@@ -90,19 +88,7 @@ export class AdxSchemaResolver {
         }
 
         // Handling dynamic columns
-
-        // Adding a feature flag while we polish things up
-        if (!config.featureToggles.adxQueryBuilderDynamicTypes) {
-          return columns;
-        }
-
-        // TODO: Ignoring arrays with multiple nested arrays
-        const schemaForDynamicColumnWithoutMultipleArrays = schemaForDynamicColumn.filter(
-          (c) => c.Name.split(DYNAMIC_TYPE_ARRAY_DELIMITER).length <= 2
-        );
-
-        // Plain objects
-        Array.prototype.push.apply(columns, schemaForDynamicColumnWithoutMultipleArrays);
+        Array.prototype.push.apply(columns, schemaForDynamicColumn);
         return columns;
       }, []);
     });

--- a/src/schema/mapper.ts
+++ b/src/schema/mapper.ts
@@ -1,5 +1,6 @@
 import { SelectableValue } from '@grafana/data';
 import { DYNAMIC_TYPE_ARRAY_DELIMITER } from 'KustoExpressionParser';
+import { escapeRegExp } from 'lodash';
 
 import { QueryEditorPropertyDefinition, QueryEditorPropertyType } from '../editor/types';
 import { AdxColumnSchema, AdxDatabaseSchema, AdxTableSchema } from '../types';
@@ -54,7 +55,7 @@ export const columnsToDefinition = (columns: AdxColumnSchema[]): QueryEditorProp
   return columns.map((column) => {
     return {
       value: column.Name,
-      label: column.Name.replace(DYNAMIC_TYPE_ARRAY_DELIMITER, '[ ]'),
+      label: column.Name.replace(new RegExp(escapeRegExp(DYNAMIC_TYPE_ARRAY_DELIMITER), 'g'), '[ ]'),
       type: toPropertyType(column.CslType),
     };
   });


### PR DESCRIPTION
This is the last PR to fully add support for dynamic objects in the query builder :tada: 

The main goal of this PR is to add support for dynamic objects containing nested arrays.

The list of changes are:

 - I have replaced the apperances of `mv-apply` with `mv-expand`. Both functions are similar and just using `mv-expand` allows me to define nested arrays. For example: 

```kusto
| mv-apply e = Players on (where e.Score  == 1)
```

is the same than:

```kusto
| mv-expand e = Players
| where e.Score == 1
```

 - I noticed that `mv-expand` (and `mv-apply`) generated a new column that was returned to the user. Since this is supposed to be a temporary calculation, I have added the logic to remove those (with [`project-away`](https://docs.microsoft.com/en-us/azure/data-explorer/kusto/query/projectawayoperator))
 - I have refactored the logic that calls `mv-expand` so it's reused both when using `where` and `summarize`
 - Added support for nested arrays. This is done calling recursively to `addExpanPartsdIfNeeded` and thanks to the above.
 - Removed the tooltips that warned about missing dynamic types and the feature flag since this should be completed :tada:

![Screenshot from 2022-06-03 17-31-32](https://user-images.githubusercontent.com/4025665/171901212-b497ec26-e0f5-4b12-88d5-f57f06307d9c.png)
 

Closes #353 