### PR TITLE
Add materialized views as tables in the query builder

### DIFF
--- a/src/schema/AdxSchemaMapper.test.ts
+++ b/src/schema/AdxSchemaMapper.test.ts
@@ -1,0 +1,14 @@
+import createMockSchema from 'components/__fixtures__/schema';
+
+import { AdxSchemaMapper } from './AdxSchemaMapper';
+
+describe('getTableOptions', () => {
+  const schema = createMockSchema();
+
+  it('will correctly return tables and materialized views', () => {
+    const adxSchemaMapper = new AdxSchemaMapper(false, []);
+    const opts = adxSchemaMapper.getTableOptions(schema, 'testdb');
+    expect(opts).toHaveLength(2);
+    expect(opts.map((op) => op.value)).toEqual(['testtable', 'testMaterializedView']);
+  });
+});

--- a/src/schema/AdxSchemaMapper.ts
+++ b/src/schema/AdxSchemaMapper.ts
@@ -52,10 +52,15 @@ export class AdxSchemaMapper {
     }
 
     if (!this.enabled) {
-      return Object.keys(database.Tables).map((key) => {
+      const tables = Object.keys(database.Tables).map((key) => {
         const table = database.Tables[key];
         return tableToDefinition(table);
       });
+      const materializedViews = Object.keys(database.MaterializedViews).map((key) => {
+        const table = database.MaterializedViews[key];
+        return tableToDefinition(table);
+      });
+      return tables.concat(materializedViews);
     }
 
     const mappings = this.mappingsByDatabase[databaseName];


### PR DESCRIPTION
Fixes #399

Materialized views are valid tables.

![Screenshot from 2022-06-16 14-43-35](https://user-images.githubusercontent.com/4025665/174072344-de7a46aa-292c-41ed-bc53-6004732b647f.png)
