### PR TITLE
Fix template variable quoting

### DIFF
--- a/src/KustoExpressionParser.test.ts
+++ b/src/KustoExpressionParser.test.ts
@@ -703,7 +703,7 @@ describe('KustoExpressionParser', () => {
       );
     });
 
-    it('should parse expression with a template variable with custom format', () => {
+    it('should parse expression with template variable as an object', () => {
       const templateSrv: TemplateSrv = {
         getVariables: jest.fn().mockReturnValue([
           {
@@ -724,7 +724,7 @@ describe('KustoExpressionParser', () => {
 
       const expression = createQueryExpression({
         from: createProperty('StormEvents'),
-        where: createArray([createOperator('column["country"]', '==', '${country:singlequote}')]),
+        where: createArray([createOperator('column["country"]', '==', { label: '$country', value: `'$country'` })]),
         groupBy: createArray([createGroupBy('column["type"]')]),
       });
 
@@ -742,7 +742,7 @@ describe('KustoExpressionParser', () => {
       expect(parser.toQuery(expression, tableSchema)).toEqual(
         'StormEvents' +
           '\n| where $__timeFilter(StartTime)' +
-          '\n| where column["country"] == ${country:singlequote}' +
+          '\n| where column["country"] == \'$country\'' +
           `\n| summarize by tostring(column["type"])`
       );
     });

--- a/src/KustoExpressionParser.test.ts
+++ b/src/KustoExpressionParser.test.ts
@@ -703,6 +703,50 @@ describe('KustoExpressionParser', () => {
       );
     });
 
+    it('should parse expression with a template variable with custom format', () => {
+      const templateSrv: TemplateSrv = {
+        getVariables: jest.fn().mockReturnValue([
+          {
+            id: 'country',
+            current: {
+              text: 'usa',
+              value: 'USA',
+            },
+            multi: false,
+          },
+        ]),
+        replace: jest.fn(),
+        containsTemplate: jest.fn(),
+        updateTimeRange: jest.fn(),
+      };
+
+      const parser = new KustoExpressionParser(templateSrv);
+
+      const expression = createQueryExpression({
+        from: createProperty('StormEvents'),
+        where: createArray([createOperator('column["country"]', '==', '${country:singlequote}')]),
+        groupBy: createArray([createGroupBy('column["type"]')]),
+      });
+
+      const tableSchema: AdxColumnSchema[] = [
+        {
+          Name: 'column["type"]',
+          CslType: 'string',
+        },
+        {
+          Name: 'StartTime',
+          CslType: 'datetime',
+        },
+      ];
+
+      expect(parser.toQuery(expression, tableSchema)).toEqual(
+        'StormEvents' +
+          '\n| where $__timeFilter(StartTime)' +
+          '\n| where column["country"] == ${country:singlequote}' +
+          `\n| summarize by tostring(column["type"])`
+      );
+    });
+
     it('should parse expression with summarize function that takes a parameter', () => {
       const expression = createQueryExpression({
         from: createProperty('StormEvents'),

--- a/src/KustoExpressionParser.ts
+++ b/src/KustoExpressionParser.ts
@@ -348,7 +348,7 @@ export class KustoExpressionParser {
     }
 
     return !!this.templateSrv.getVariables().find((variable: any) => {
-      return `$${variable?.id}` === value;
+      return `$${variable?.id}` === value || value.startsWith(`\$\{${variable?.id}:`);
     });
   }
 }

--- a/src/KustoExpressionParser.ts
+++ b/src/KustoExpressionParser.ts
@@ -352,7 +352,7 @@ export class KustoExpressionParser {
     const val = typeof value === 'string' ? value : value.value || '';
 
     return !!this.templateSrv.getVariables().find((variable: any) => {
-      return val.includes(`$${variable?.id}`) || val.startsWith(`\$\{${variable?.id}:`);
+      return `$${variable?.id}` === val || `'$${variable?.id}'` === val || val.startsWith(`\$\{${variable?.id}:`);
     });
   }
 }

--- a/src/editor/components/filter/QueryEditorFieldAndOperator.test.tsx
+++ b/src/editor/components/filter/QueryEditorFieldAndOperator.test.tsx
@@ -56,7 +56,7 @@ describe('QueryEditorFieldAndOperator', () => {
     // select a column
     screen.getByText(defaultProps.fields[0].value).click();
 
-    const valueSel = screen.getByLabelText('select value');
+    const valueSel = screen.getByLabelText('select value for where filter');
     openMenu(valueSel);
     const valueTemplateVariableGroup = screen.getByText('Template Variables');
     valueTemplateVariableGroup.click();

--- a/src/editor/components/filter/QueryEditorFieldAndOperator.test.tsx
+++ b/src/editor/components/filter/QueryEditorFieldAndOperator.test.tsx
@@ -1,0 +1,76 @@
+import { render, screen } from '@testing-library/react';
+import { QueryEditorExpressionType, QueryEditorOperatorExpression } from 'editor/expressions';
+import { QueryEditorPropertyType } from 'editor/types';
+import React from 'react';
+import { QueryEditorFieldAndOperator } from './QueryEditorFieldAndOperator';
+import { openMenu } from 'react-select-event';
+
+const defaultProps = {
+  fields: [
+    {
+      value: 'bar',
+      type: QueryEditorPropertyType.String,
+    },
+  ],
+  templateVariableOptions: {
+    label: 'Template Variables',
+    options: [{ label: '$foo', value: '$foo' }],
+  },
+  operators: [
+    {
+      value: '==',
+      supportTypes: [QueryEditorPropertyType.String],
+      label: '==',
+      description: 'equal to',
+      multipleValues: false,
+      booleanValues: false,
+    },
+  ],
+  onChange: jest.fn(),
+  getSuggestions: jest.fn().mockResolvedValue([]),
+};
+
+describe('QueryEditorFieldAndOperator', () => {
+  it('should render without errors', () => {
+    render(<QueryEditorFieldAndOperator {...defaultProps} />);
+    expect(screen.getByText('Choose column...')).toBeInTheDocument();
+  });
+
+  it('should add an option to quote variables if it targets a string', async () => {
+    const value: QueryEditorOperatorExpression = {
+      property: {
+        type: QueryEditorPropertyType.String,
+        name: 'myvar',
+      },
+      operator: {
+        name: '==',
+        value: '==',
+      },
+      type: QueryEditorExpressionType.Or,
+    };
+    const onChange = jest.fn();
+    render(<QueryEditorFieldAndOperator {...defaultProps} value={value} onChange={onChange} />);
+
+    const sel = screen.getByLabelText('choose column');
+    openMenu(sel);
+    const templateVariableGroup = screen.getByText('Template Variables');
+    templateVariableGroup.click();
+    // The template variables for the keys should not be expanded
+    expect(screen.getByText('$foo')).toBeInTheDocument();
+    expect(screen.queryByText('${foo:singlequote}')).not.toBeInTheDocument();
+    screen.getByText(defaultProps.fields[0].value).click();
+
+    const valueSel = screen.getByLabelText('select value');
+    openMenu(valueSel);
+    const valueTemplateVariableGroup = screen.getByText('Template Variables');
+    valueTemplateVariableGroup.click();
+    expect(screen.getByText('$foo')).toBeInTheDocument();
+    screen.getByText('${foo:singlequote}').click();
+
+    expect(onChange).toBeCalledWith({
+      operator: { name: '==', value: '${foo:singlequote}' },
+      property: { name: 'myvar', type: 'string' },
+      type: 'or',
+    });
+  });
+});

--- a/src/editor/components/filter/QueryEditorFieldAndOperator.test.tsx
+++ b/src/editor/components/filter/QueryEditorFieldAndOperator.test.tsx
@@ -51,7 +51,7 @@ describe('QueryEditorFieldAndOperator', () => {
     const onChange = jest.fn();
     render(<QueryEditorFieldAndOperator {...defaultProps} value={value} onChange={onChange} />);
 
-    const sel = screen.getByLabelText('choose column');
+    const sel = screen.getByLabelText('choose column for where filter');
     openMenu(sel);
     // select a column
     screen.getByText(defaultProps.fields[0].value).click();

--- a/src/editor/components/filter/QueryEditorFieldAndOperator.test.tsx
+++ b/src/editor/components/filter/QueryEditorFieldAndOperator.test.tsx
@@ -36,7 +36,7 @@ describe('QueryEditorFieldAndOperator', () => {
     expect(screen.getByText('Choose column...')).toBeInTheDocument();
   });
 
-  it('should add an option to quote variables if it targets a string', async () => {
+  it('should quote variables if it targets a string', async () => {
     const value: QueryEditorOperatorExpression = {
       property: {
         type: QueryEditorPropertyType.String,
@@ -53,11 +53,7 @@ describe('QueryEditorFieldAndOperator', () => {
 
     const sel = screen.getByLabelText('choose column');
     openMenu(sel);
-    const templateVariableGroup = screen.getByText('Template Variables');
-    templateVariableGroup.click();
-    // The template variables for the keys should not be expanded
-    expect(screen.getByText('$foo')).toBeInTheDocument();
-    expect(screen.queryByText('${foo:singlequote}')).not.toBeInTheDocument();
+    // select a column
     screen.getByText(defaultProps.fields[0].value).click();
 
     const valueSel = screen.getByLabelText('select value');
@@ -65,10 +61,10 @@ describe('QueryEditorFieldAndOperator', () => {
     const valueTemplateVariableGroup = screen.getByText('Template Variables');
     valueTemplateVariableGroup.click();
     expect(screen.getByText('$foo')).toBeInTheDocument();
-    screen.getByText('${foo:singlequote}').click();
+    screen.getByText('$foo').click();
 
     expect(onChange).toBeCalledWith({
-      operator: { name: '==', value: '${foo:singlequote}' },
+      operator: { name: '==', value: `'$foo'`, labelValue: '$foo' },
       property: { name: 'myvar', type: 'string' },
       type: 'or',
     });

--- a/src/editor/components/filter/QueryEditorFieldAndOperator.tsx
+++ b/src/editor/components/filter/QueryEditorFieldAndOperator.tsx
@@ -105,7 +105,7 @@ export const QueryEditorFieldAndOperator: React.FC<Props> = (props: Props) => {
       if (Array.isArray(templateVariableOptionsValues)) {
         const variables = templateVariableOptionsValues.filter((v) => {
           if (typeof v?.value === 'string') {
-            return v.value.indexOf(txt) > -1;
+            return v.value.includes(txt);
           }
           return false;
         });
@@ -132,7 +132,7 @@ export const QueryEditorFieldAndOperator: React.FC<Props> = (props: Props) => {
         templateVariableOptions={props.templateVariableOptions}
         onChange={onFieldChanged}
         placeholder="Choose column..."
-        aria-label="choose column"
+        aria-label="choose column for where filter"
       />
       {showOperators && (
         <QueryEditorOperatorComponent

--- a/src/editor/components/filter/QueryEditorFieldAndOperator.tsx
+++ b/src/editor/components/filter/QueryEditorFieldAndOperator.tsx
@@ -33,9 +33,8 @@ export const QueryEditorFieldAndOperator: React.FC<Props> = (props: Props) => {
   // If the value is a string, template variable can be quoted when used as values
   const templateVariableOptionsValues = cloneDeep(props.templateVariableOptions);
   if (Array.isArray(props.templateVariableOptions.options) && props.value?.property.type === 'string') {
-    props.templateVariableOptions.options.forEach((op: SelectableValue<string>) => {
-      const v = op.value?.replace(/\$(.*)/, '${$1:singlequote}');
-      templateVariableOptionsValues.options.push({ label: v, value: v });
+    templateVariableOptionsValues.options = props.templateVariableOptions.options.map((op: SelectableValue<string>) => {
+      return { label: op.value, value: `'${op.value}'` };
     });
   }
 

--- a/src/editor/components/operators/QueryEditorMultiOperator.tsx
+++ b/src/editor/components/operators/QueryEditorMultiOperator.tsx
@@ -3,10 +3,11 @@ import { AsyncMultiSelect } from '@grafana/ui';
 import { ExpressionSuggestor } from '../types';
 import { QueryEditorOperatorDefinition, QueryEditorOperator } from '../../types';
 import { SelectableValue } from '@grafana/data';
+import { isStringArray } from 'editor/guards';
 
 interface Props {
-  values: string[] | undefined;
-  onChange: (expression: QueryEditorOperator<string[]>) => void;
+  values: string[] | SelectableValue<string>[] | undefined;
+  onChange: (expression: QueryEditorOperator<string[] | SelectableValue<string>[]>) => void;
   operator: QueryEditorOperatorDefinition;
   getSuggestions: ExpressionSuggestor;
   templateVariableOptions: SelectableValue<string>;
@@ -31,7 +32,12 @@ export class QueryEditorMultiOperator extends PureComponent<Props, State> {
       return;
     }
     // Append the new value
-    const values = (this.props.values || []).concat(value);
+    const values = this.props.values || [];
+    if (isStringArray(values)) {
+      values.push(value);
+    } else {
+      values.push({ label: value, value: value });
+    }
     this.props.onChange({
       value: values,
       name: this.props.operator.value,
@@ -44,7 +50,9 @@ export class QueryEditorMultiOperator extends PureComponent<Props, State> {
     }
 
     this.props.onChange({
-      value: selectable.map((s) => s.value),
+      value: selectable.map((s) => {
+        return { value: s.value, label: s.label };
+      }),
       name: this.props.operator.value,
     });
   };
@@ -64,10 +72,14 @@ export class QueryEditorMultiOperator extends PureComponent<Props, State> {
 
   render() {
     const values = this.props.values || [];
-    const current = values.map((v) => {
-      return { label: v, value: v };
-    });
-
+    let current: SelectableValue<string>[];
+    if (isStringArray(values)) {
+      current = values.map((v) => {
+        return { label: v, value: v };
+      });
+    } else {
+      current = values;
+    }
     return (
       <AsyncMultiSelect
         width={30}

--- a/src/editor/components/operators/QueryEditorMultiOperator.tsx
+++ b/src/editor/components/operators/QueryEditorMultiOperator.tsx
@@ -6,8 +6,8 @@ import { SelectableValue } from '@grafana/data';
 import { isStringArray } from 'editor/guards';
 
 interface Props {
-  values: string[] | SelectableValue<string>[] | undefined;
-  onChange: (expression: QueryEditorOperator<string[] | SelectableValue<string>[]>) => void;
+  values: string[] | Array<SelectableValue<string>> | undefined;
+  onChange: (expression: QueryEditorOperator<string[] | Array<SelectableValue<string>>>) => void;
   operator: QueryEditorOperatorDefinition;
   getSuggestions: ExpressionSuggestor;
   templateVariableOptions: SelectableValue<string>;
@@ -72,7 +72,7 @@ export class QueryEditorMultiOperator extends PureComponent<Props, State> {
 
   render() {
     const values = this.props.values || [];
-    let current: SelectableValue<string>[];
+    let current: Array<SelectableValue<string>>;
     if (isStringArray(values)) {
       current = values.map((v) => {
         return { label: v, value: v };

--- a/src/editor/components/operators/QueryEditorMultiOperator.tsx
+++ b/src/editor/components/operators/QueryEditorMultiOperator.tsx
@@ -81,6 +81,7 @@ export class QueryEditorMultiOperator extends PureComponent<Props, State> {
         onCreateOption={this.onCreate}
         noOptionsMessage="No options found"
         isClearable
+        allowCustomValue
       />
     );
   }

--- a/src/editor/components/operators/QueryEditorOperator.tsx
+++ b/src/editor/components/operators/QueryEditorOperator.tsx
@@ -174,6 +174,7 @@ const renderOperatorInput = (
         <QueryEditorSingleOperator
           operator={definition}
           value={operator?.value}
+          labelValue={operator?.labelValue}
           onChange={onChangeValue}
           getSuggestions={getSuggestions}
           templateVariableOptions={templateVariableOptions}

--- a/src/editor/components/operators/QueryEditorSingleOperator.tsx
+++ b/src/editor/components/operators/QueryEditorSingleOperator.tsx
@@ -88,6 +88,7 @@ export class QueryEditorSingleOperator extends PureComponent<Props, State> {
         backspaceRemovesValue
         isClearable
         noOptionsMessage="No options found"
+        aria-label="select value"
       />
     );
   }

--- a/src/editor/components/operators/QueryEditorSingleOperator.tsx
+++ b/src/editor/components/operators/QueryEditorSingleOperator.tsx
@@ -86,7 +86,7 @@ export class QueryEditorSingleOperator extends PureComponent<Props, State> {
         backspaceRemovesValue
         isClearable
         noOptionsMessage="No options found"
-        aria-label="select value"
+        aria-label="select value for where filter"
       />
     );
   }

--- a/src/editor/components/operators/QueryEditorSingleOperator.tsx
+++ b/src/editor/components/operators/QueryEditorSingleOperator.tsx
@@ -10,6 +10,7 @@ interface Props {
   operator: QueryEditorOperatorDefinition;
   getSuggestions: ExpressionSuggestor;
   templateVariableOptions: SelectableValue<string>;
+  labelValue?: string;
 }
 
 interface State {
@@ -36,8 +37,9 @@ export class QueryEditorSingleOperator extends PureComponent<Props, State> {
       return;
     }
     this.props.onChange({
-      value: `${evt.value}`, // Currently strings only
+      value: evt.value,
       name: this.props.operator.value,
+      labelValue: evt.label,
     });
   };
 
@@ -65,20 +67,16 @@ export class QueryEditorSingleOperator extends PureComponent<Props, State> {
   };
 
   render() {
-    const { value } = this.props;
-    const current = value
-      ? {
-          label: value,
-          value,
-        }
-      : undefined;
+    const { value, labelValue } = this.props;
+    const label = labelValue || value;
+    const current = value ? { label, value } : undefined;
 
     return (
       <AsyncSelect
         width={30}
         placeholder="Start typing to add filters..."
         loadOptions={this.getSuggestions}
-        onOpenMenu={() => this.getSuggestions(value ?? '')}
+        onOpenMenu={() => this.getSuggestions(label ?? '')}
         defaultOptions={this.state.defaultOptions}
         isLoading={this.state.isLoading}
         value={current}

--- a/src/editor/guards.ts
+++ b/src/editor/guards.ts
@@ -1,3 +1,4 @@
+import { SelectableValue } from '@grafana/data';
 import {
   QueryEditorReduceExpression,
   QueryEditorPropertyExpression,
@@ -54,7 +55,21 @@ export const isDateTimeOperator = (
   return propertyType === QueryEditorPropertyType.DateTime && typeof operator?.value === 'string';
 };
 
-export const isMultiOperator = (operator?: QueryEditorOperator): operator is QueryEditorOperator<string[]> => {
+export const isStringArray = (value: any): value is string[] => {
+  if (value instanceof Array) {
+    for (const item of value) {
+      if (typeof item !== 'string') {
+        return false;
+      }
+    }
+    return true;
+  }
+  return false;
+};
+
+export const isMultiOperator = (
+  operator?: QueryEditorOperator
+): operator is QueryEditorOperator<string[] | SelectableValue<string>[]> => {
   return Array.isArray(operator?.value);
 };
 

--- a/src/editor/guards.ts
+++ b/src/editor/guards.ts
@@ -56,15 +56,7 @@ export const isDateTimeOperator = (
 };
 
 export const isStringArray = (value: any): value is string[] => {
-  if (value instanceof Array) {
-    for (const item of value) {
-      if (typeof item !== 'string') {
-        return false;
-      }
-    }
-    return true;
-  }
-  return false;
+  return value instanceof Array && value.every((item) => typeof item === 'string');
 };
 
 export const isMultiOperator = (

--- a/src/editor/guards.ts
+++ b/src/editor/guards.ts
@@ -69,7 +69,7 @@ export const isStringArray = (value: any): value is string[] => {
 
 export const isMultiOperator = (
   operator?: QueryEditorOperator
-): operator is QueryEditorOperator<string[] | SelectableValue<string>[]> => {
+): operator is QueryEditorOperator<string[] | Array<SelectableValue<string>>> => {
   return Array.isArray(operator?.value);
 };
 

--- a/src/editor/types.ts
+++ b/src/editor/types.ts
@@ -1,3 +1,5 @@
+import { SelectableValue } from '@grafana/data';
+
 export enum QueryEditorPropertyType {
   Number = 'number',
   String = 'string',
@@ -13,12 +15,13 @@ export interface QueryEditorProperty {
   name: string;
 }
 
-export type QueryEditorOperatorType = string | boolean | number;
+export type QueryEditorOperatorType = string | boolean | number | SelectableValue<string>;
 type QueryEditorOperatorValueType = QueryEditorOperatorType | QueryEditorOperatorType[];
 
 export interface QueryEditorOperator<T = QueryEditorOperatorValueType> {
   name: string;
   value: T;
+  labelValue?: string;
 }
 
 export interface QueryEditorOperatorDefinition {


### PR DESCRIPTION
The goal of this PR is to automatically quote variables when used as strings in the query builder.

The main difficulty here is that not all variables should be quoted, only when comparing strings it makes sense to quote them. This means that we cannot just modify the behavior of the template service to quote everything because we still want to maintain other variables un-quoted, based on the schema and the position.

We can do that in the component that handle filters for the query: `filter/QueryEditorFieldAndOperator.tsx`. Here, we have access to the target property (and its type) and the list of template variables.

Another change is that before we were not handling labels in the selector. The labels were just equal to the value. I need to modify that because I want to show the label unquoted, while the final value should contain the single quotes. This behavior is similar to the editor from @grafana/experimental code so it should be easier to migrate once we tackle #391.

![Screenshot from 2022-06-20 15-56-03](https://user-images.githubusercontent.com/4025665/174620103-f5898b66-85c9-4d3b-9bb9-76ba6a364bcb.png)

![Screenshot from 2022-06-20 15-55-51](https://user-images.githubusercontent.com/4025665/174620200-576c9613-88d6-4d57-a567-abd5ff8d3185.png)

One final change is that it's now allowed to write a custom value for the filter, in case a different format is needed:

![Screenshot from 2022-06-20 15-59-10](https://user-images.githubusercontent.com/4025665/174620429-07e81eff-b3c7-458c-b9f5-8745cef30052.png)

