### PR TITLE
Fix query builder for dynamic fields with multiple types

### DIFF
--- a/src/datasource.test.ts
+++ b/src/datasource.test.ts
@@ -365,6 +365,39 @@ describe('AdxDataSource', () => {
         ],
       });
     });
+
+    it('should return select the first type if multiple types are returned', async () => {
+      const datasource = mockDatasource();
+      datasource.query = jest.fn().mockReturnValue({
+        toPromise: jest.fn().mockResolvedValue({
+          data: [
+            toDataFrame({
+              fields: [
+                {
+                  name: 'schema_Teams',
+                  type: 'string',
+                  typeInfo: {
+                    frame: 'string',
+                  },
+                  config: {},
+                  values: ['{"18":{"TeamID":["long","double"]}}'],
+                  entities: {},
+                },
+              ],
+            }),
+          ],
+        }),
+      });
+
+      expect(await datasource.getDynamicSchema('foo', 'bar', ['col'])).toEqual({
+        Teams: [
+          {
+            CslType: 'long',
+            Name: 'Teams["18"]["TeamID"]',
+          },
+        ],
+      });
+    });
   });
 });
 

--- a/src/datasource.ts
+++ b/src/datasource.ts
@@ -389,13 +389,18 @@ const recordSchema = (columnName: string, schema: any, result: AdxColumnSchema[]
     if (Array.isArray(schema[name])) {
       // If a field can have different types (e.g. long and double)
       // we select the first, assuming they are interchangeable
+      const defaultCslType = schema[name][0];
       if (schema[name].every((t: string) => toPropertyType(t) === QueryEditorPropertyType.Number)) {
         // If all the types are numbers, the double takes precedence since it has more precission.
-        const cslType = schema[name].find((t: string) => t === 'double' || t === 'real') || schema[name][0];
+        const cslType = schema[name].find((t: string) => t === 'double' || t === 'real') || defaultCslType;
         result.push({ Name: key, CslType: cslType });
       } else {
-        console.warn(`schema ${name} may contain different types, assuming ${schema[name][0]}`);
-        result.push({ Name: key, CslType: schema[name][0] });
+        console.warn(`schema ${name} may contain different types, assuming ${defaultCslType}`);
+        if (typeof defaultCslType === 'object') {
+          recordSchema(key, schema[name][0], result);
+        } else {
+          result.push({ Name: key, CslType: defaultCslType });
+        }
       }
       continue;
     }

--- a/src/datasource.ts
+++ b/src/datasource.ts
@@ -385,6 +385,13 @@ const recordSchema = (columnName: string, schema: any, result: AdxColumnSchema[]
     // https://docs.microsoft.com/en-us/azure/data-explorer/kusto/query/scalar-data-types/dynamic#dynamic-object-accessors
     const key = `${columnName}["${name}"]`;
 
+    if (Array.isArray(schema[name])) {
+      // If a field can have different types (e.g. long and double)
+      // we select the first for simplicity
+      result.push({ Name: key, CslType: schema[name][0] });
+      continue;
+    }
+
     if (typeof schema[name] === 'string') {
       result.push({
         Name: key,

--- a/src/schema/mapper.ts
+++ b/src/schema/mapper.ts
@@ -61,7 +61,7 @@ export const columnsToDefinition = (columns: AdxColumnSchema[]): QueryEditorProp
   });
 };
 
-const toPropertyType = (kustoType: string): QueryEditorPropertyType => {
+export const toPropertyType = (kustoType: string): QueryEditorPropertyType => {
   switch (kustoType) {
     case 'real':
     case 'int':

--- a/src/schema/mapper.ts
+++ b/src/schema/mapper.ts
@@ -66,6 +66,8 @@ const toPropertyType = (kustoType: string): QueryEditorPropertyType => {
     case 'real':
     case 'int':
     case 'long':
+    case 'double':
+    case 'decimal':
       return QueryEditorPropertyType.Number;
     case 'datetime':
       return QueryEditorPropertyType.DateTime;


### PR DESCRIPTION
`dynamic` types are not limited to just one scalar type (even though it is normal to use just one). This caused that when building an schema from values, done with the KQL function [`buildschema`](https://docs.microsoft.com/en-us/azure/data-explorer/kusto/query/buildschema-aggfunction), the array was wronly interpreted as an object with as many values as the array lenght (details in #411).

Note that we are using this parsed type for two things:
 - To decide the input type and the available operators (e.g. a dynamic `int` will have `input=number` and available operators like `==`, `>`, etc)
 - To convert them when aggregating them (e.g. a dynamic `int` will generate an aggregation function like `| summarize sum(toint(col))`

In theory, any combination of types is possible for a dynamic column according to the [docs](https://docs.microsoft.com/en-us/azure/data-explorer/kusto/query/buildschema-aggfunction#example) but that's not likely to happen in real data. To simplify the logic here, I have:

 - Added a check to validate if all the types are numbers. For example, `long` (0) and `double` (1.1). If that's the case, we select the more precise one (double). This is likely the most common case since a column that includes integer and decimal values will return these two types.
 - If not (e.g. `string` and `boolean`), we simply select the first one. This is unlikely to happen since this data cannot be easily processed. If the first type is an object, we keep iterating building the inner schema.