### PR TITLE
Fix reload schema button in configuration

### DIFF
--- a/src/components/ConfigEditor/ConfigEditor.test.tsx
+++ b/src/components/ConfigEditor/ConfigEditor.test.tsx
@@ -1,7 +1,6 @@
 import React from 'react';
 import { render, screen, waitFor } from '@testing-library/react';
 import ConfigEditor from './index';
-import * as refreshSchema from './refreshSchema';
 import * as grafanaRuntime from '@grafana/runtime';
 import { Chance } from 'chance';
 import { mockConfigEditorProps } from 'components/__fixtures__/ConfigEditor.fixtures';
@@ -9,15 +8,9 @@ import { mockConfigEditorProps } from 'components/__fixtures__/ConfigEditor.fixt
 const originalConfigValue = grafanaRuntime.config.featureToggles.adxOnBehalfOf;
 
 describe('ConfigEditor', () => {
-  let refreshSchemaSpy: jest.SpyInstance;
-
   beforeEach(() => {
     // reset config
     grafanaRuntime.config.featureToggles.adxOnBehalfOf = originalConfigValue;
-
-    refreshSchemaSpy = jest
-      .spyOn(refreshSchema, 'refreshSchema')
-      .mockResolvedValue({ databases: [], schemaMappingOptions: [] });
 
     jest.spyOn(grafanaRuntime, 'getDataSourceSrv').mockReturnValue({
       get: jest.fn().mockReturnValue({ url: Chance().url() }),
@@ -35,19 +28,6 @@ describe('ConfigEditor', () => {
     render(<ConfigEditor {...mockConfigEditorProps()} />);
 
     await waitFor(() => expect(screen.getByTestId('azure-data-explorer-config-editor')).toBeInTheDocument());
-  });
-
-  it('calls refreshSchema on render', async () => {
-    render(<ConfigEditor {...mockConfigEditorProps()} />);
-
-    await waitFor(() => expect(refreshSchemaSpy).toHaveBeenCalledTimes(1));
-  });
-
-  it('calls refreshSchema on click of "Reload schema" button', async () => {
-    render(<ConfigEditor {...mockConfigEditorProps()} />);
-    screen.getByText('Reload schema').click();
-
-    await waitFor(() => expect(refreshSchemaSpy).toHaveBeenCalledTimes(2));
   });
 
   it('should show the beta OBO toggle if feature gate enabled', async () => {

--- a/src/components/ConfigEditor/DatabaseConfig.test.tsx
+++ b/src/components/ConfigEditor/DatabaseConfig.test.tsx
@@ -1,0 +1,65 @@
+import React from 'react';
+import { render, screen, waitFor } from '@testing-library/react';
+import { mockConfigEditorProps } from 'components/__fixtures__/ConfigEditor.fixtures';
+import DatabaseConfig from './DatabaseConfig';
+import { mockDatasource } from 'components/__fixtures__/Datasource';
+import createMockSchema from 'components/__fixtures__/schema';
+import { openMenu } from 'react-select-event';
+
+const jestPut = jest.fn().mockResolvedValue({ datasource: {} });
+const mockDS = mockDatasource();
+mockDS.getSchema = jest.fn().mockResolvedValue(createMockSchema());
+
+jest.mock('@grafana/runtime', () => ({
+  ...jest.requireActual('@grafana/runtime'),
+  getBackendSrv: () => ({
+    put: jestPut,
+  }),
+  getDataSourceSrv: () => ({
+    get: jest.fn().mockResolvedValue(mockDS),
+  }),
+}));
+
+const defaultProps = {
+  ...mockConfigEditorProps(),
+  updateJsonData: jest.fn(),
+};
+describe('DatabaseConfig', () => {
+  it('should render', async () => {
+    render(<DatabaseConfig {...defaultProps} />);
+    await waitFor(() => expect(screen.getByText('Default database')).toBeInTheDocument());
+  });
+
+  it('should disable the refresh schema button if there is some missing info', async () => {
+    render(<DatabaseConfig {...defaultProps} />);
+    await waitFor(() => expect(screen.getByRole('button')).toBeDisabled());
+  });
+
+  it('should save the data source and refresh the schema', async () => {
+    const props = {
+      ...defaultProps,
+      options: {
+        ...defaultProps.options,
+        jsonData: {
+          ...defaultProps.options.jsonData,
+          clusterUrl: 'http://url',
+          tenantId: 'id',
+          clientId: 'id',
+        },
+        secureJsonFields: {
+          ...defaultProps.options.secureJsonFields,
+          clientSecret: true,
+        },
+      },
+    };
+    render(<DatabaseConfig {...props} />);
+    const refreshButton = await waitFor(() => screen.getByRole('button'));
+    expect(refreshButton).toBeEnabled();
+    refreshButton.click();
+    expect(jestPut).toHaveBeenCalled();
+    expect(mockDS.getSchema).toHaveBeenCalled();
+    const sel = screen.getByLabelText('choose default database');
+    openMenu(sel);
+    await waitFor(() => expect(screen.getByText('testdb')).toBeInTheDocument());
+  });
+});

--- a/src/components/ConfigEditor/DatabaseConfig.tsx
+++ b/src/components/ConfigEditor/DatabaseConfig.tsx
@@ -120,7 +120,7 @@ const DatabaseConfig: React.FC<DatabaseConfigProps> = (props: DatabaseConfigProp
     }
   };
 
-  const saveAndUpdateSchema = useCallback(async () => {
+  const saveAndUpdateSchema = async () => {
     // Save latest changes in the datasource so we can retrieve the schema
     await getBackendSrv()
       .put(baseURL, props.options)
@@ -132,7 +132,7 @@ const DatabaseConfig: React.FC<DatabaseConfigProps> = (props: DatabaseConfigProp
       });
 
     updateSchema();
-  }, [props.options]);
+  };
 
   useEffectOnce(() => {
     if (options.id && canGetSchema()) {

--- a/src/components/ConfigEditor/DatabaseConfig.tsx
+++ b/src/components/ConfigEditor/DatabaseConfig.tsx
@@ -154,6 +154,7 @@ const DatabaseConfig: React.FC<DatabaseConfigProps> = (props: DatabaseConfigProp
           options={schema.databases}
           value={schema.databases.find((v) => v.value === jsonData.defaultDatabase)}
           onChange={(change: SelectableValue<string>) => updateJsonData('defaultDatabase', change.value || '')}
+          aria-label="choose default database"
         />
       </InlineField>
 

--- a/src/components/ConfigEditor/index.tsx
+++ b/src/components/ConfigEditor/index.tsx
@@ -1,57 +1,27 @@
-import React, { useEffect, useState, useCallback } from 'react';
+import React, { useState, useCallback } from 'react';
 import { DataSourcePluginOptionsEditorProps } from '@grafana/data';
-import { FetchResponse, getDataSourceSrv } from '@grafana/runtime';
 import ConfigHelp from 'components/ConfigEditor/ConfigHelp';
-import { AdxDataSourceOptions, AdxDataSourceSecureOptions } from 'types';
+import { AdxDataSourceOptions, AdxDataSourceSecureOptions, AdxDataSourceSettings } from 'types';
 import ConnectionConfig from './ConnectionConfig';
 import DatabaseConfig from './DatabaseConfig';
 import QueryConfig from './QueryConfig';
-import { refreshSchema, Schema } from './refreshSchema';
 import TrackingConfig from './TrackingConfig';
-import { Alert } from '@grafana/ui';
-import { AdxDataSource } from 'datasource';
 
 export interface ConfigEditorProps
   extends DataSourcePluginOptionsEditorProps<AdxDataSourceOptions, AdxDataSourceSecureOptions> {}
 
-type FetchErrorResponse = FetchResponse<{
-  error?: string;
-  message?: string;
-  response?: string;
-}>;
-
 const ConfigEditor: React.FC<ConfigEditorProps> = (props) => {
-  const { options, onOptionsChange } = props;
-  const [schema, setSchema] = useState<Schema>({ databases: [], schemaMappingOptions: [] });
-  const [schemaError, setSchemaError] = useState<FetchErrorResponse['data']>();
+  const { options, onOptionsChange: _onOptionsChange } = props;
+  const [saved, setSaved] = useState(true);
   const { jsonData } = options;
 
-  const getDatasource = useCallback(async (): Promise<AdxDataSource> => {
-    const datasource = await getDataSourceSrv().get(options.name);
-    return datasource as unknown as AdxDataSource;
-  }, [options.name]);
-
-  const updateSchema = useCallback(async () => {
-    // no credentials, can't request datasource yet
-    if (!options.secureJsonFields || Object.keys(options.secureJsonFields).length === 0) {
-      return;
-    }
-
-    try {
-      const datasource = await getDatasource();
-      const schemaData = await refreshSchema(datasource);
-
-      if (!schemaData) {
-        return;
-      }
-
-      setSchema(schemaData);
-      setSchemaError(undefined);
-    } catch (err: any) {
-      // TODO: make sure err.data is the format we are expecting
-      setSchemaError(err.data);
-    }
-  }, [getDatasource, options.secureJsonFields]);
+  const onOptionsChange = useCallback(
+    (options: AdxDataSourceSettings) => {
+      setSaved(false);
+      _onOptionsChange(options);
+    },
+    [setSaved, _onOptionsChange]
+  );
 
   const updateJsonData = useCallback(
     <T extends keyof AdxDataSourceOptions>(fieldName: T, value: AdxDataSourceOptions[T]) => {
@@ -65,16 +35,6 @@ const ConfigEditor: React.FC<ConfigEditorProps> = (props) => {
     },
     [jsonData, onOptionsChange, options]
   );
-
-  useEffect(() => {
-    options.id && updateSchema();
-  }, [options.id, updateSchema]);
-
-  useEffect(() => {
-    if (!jsonData.defaultDatabase && schema?.databases.length) {
-      updateJsonData('defaultDatabase', schema?.databases[0].value);
-    }
-  }, [schema?.databases, jsonData.defaultDatabase, updateJsonData]);
 
   const handleClearClientSecret = useCallback(() => {
     onOptionsChange({
@@ -104,20 +64,14 @@ const ConfigEditor: React.FC<ConfigEditorProps> = (props) => {
       <QueryConfig options={options} onOptionsChange={onOptionsChange} updateJsonData={updateJsonData} />
 
       <DatabaseConfig
-        schema={schema}
         options={options}
         onOptionsChange={onOptionsChange}
         updateJsonData={updateJsonData}
-        onRefresh={updateSchema}
+        saved={saved}
+        setSaved={setSaved}
       />
 
       <TrackingConfig options={options} onOptionsChange={onOptionsChange} updateJsonData={updateJsonData} />
-
-      {schemaError && (
-        <Alert severity="error" title="Error updating Azure Data Explorer schema">
-          {schemaError.message}
-        </Alert>
-      )}
     </div>
   );
 };

--- a/src/components/ConfigEditor/index.tsx
+++ b/src/components/ConfigEditor/index.tsx
@@ -1,7 +1,7 @@
-import React, { useState, useCallback } from 'react';
+import React, { useCallback } from 'react';
 import { DataSourcePluginOptionsEditorProps } from '@grafana/data';
 import ConfigHelp from 'components/ConfigEditor/ConfigHelp';
-import { AdxDataSourceOptions, AdxDataSourceSecureOptions, AdxDataSourceSettings } from 'types';
+import { AdxDataSourceOptions, AdxDataSourceSecureOptions } from 'types';
 import ConnectionConfig from './ConnectionConfig';
 import DatabaseConfig from './DatabaseConfig';
 import QueryConfig from './QueryConfig';
@@ -11,17 +11,8 @@ export interface ConfigEditorProps
   extends DataSourcePluginOptionsEditorProps<AdxDataSourceOptions, AdxDataSourceSecureOptions> {}
 
 const ConfigEditor: React.FC<ConfigEditorProps> = (props) => {
-  const { options, onOptionsChange: _onOptionsChange } = props;
-  const [saved, setSaved] = useState(true);
+  const { options, onOptionsChange } = props;
   const { jsonData } = options;
-
-  const onOptionsChange = useCallback(
-    (options: AdxDataSourceSettings) => {
-      setSaved(false);
-      _onOptionsChange(options);
-    },
-    [setSaved, _onOptionsChange]
-  );
 
   const updateJsonData = useCallback(
     <T extends keyof AdxDataSourceOptions>(fieldName: T, value: AdxDataSourceOptions[T]) => {
@@ -63,13 +54,7 @@ const ConfigEditor: React.FC<ConfigEditorProps> = (props) => {
 
       <QueryConfig options={options} onOptionsChange={onOptionsChange} updateJsonData={updateJsonData} />
 
-      <DatabaseConfig
-        options={options}
-        onOptionsChange={onOptionsChange}
-        updateJsonData={updateJsonData}
-        saved={saved}
-        setSaved={setSaved}
-      />
+      <DatabaseConfig options={options} onOptionsChange={onOptionsChange} updateJsonData={updateJsonData} />
 
       <TrackingConfig options={options} onOptionsChange={onOptionsChange} updateJsonData={updateJsonData} />
     </div>

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,4 +1,4 @@
-import { DataQuery, DataSourceJsonData } from '@grafana/data';
+import { DataQuery, DataSourceJsonData, DataSourceSettings } from '@grafana/data';
 
 import {
   QueryEditorArrayExpression,
@@ -147,3 +147,5 @@ export enum AzureCloudType {
   AzureUSGovernment = 'govazuremonitor',
   AzureChina = 'chinaazuremonitor',
 }
+
+export type AdxDataSourceSettings = DataSourceSettings<AdxDataSourceOptions, AdxDataSourceSecureOptions>;


### PR DESCRIPTION
When clicking in the "Reload Schema" button, the current status of the data source is saved and the schema is loaded to properly show the list of databases:

![Peek 2022-06-24 17-07](https://user-images.githubusercontent.com/4025665/175564219-c632da46-73c1-4249-81ad-30766e839666.gif)

Note: I have also moved all the logic related to the schema retrieval to the DateabaseConfig component, since it's only there where this data is used (not the parent ConfigEditor).

Fixes: #406
