### PR TITLE
Codeowners: update to reflect name change

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -11,4 +11,4 @@
 # In each subsection folders are ordered first by depth, then alphabetically.
 # This should make it easy to add new rules without breaking existing ones.
 
-* @grafana/cloud-datasources
+* @grafana/cloud-provider-plugins


### PR DESCRIPTION
**What this PR does / why we need it**:
The cloud datasources team is splitting into two teams. This PR updates the `CODEOWNERS` file to reflect the change.
