### PR TITLE
Query builder: Fix dynamic resolution for simple types

### DIFF
--- a/src/datasource.test.ts
+++ b/src/datasource.test.ts
@@ -1,7 +1,6 @@
 import { AdxDataSource, sortStartsWithValuesFirst } from './datasource';
-import { dateTime, toDataFrame } from '@grafana/data';
+import { toDataFrame } from '@grafana/data';
 import _ from 'lodash';
-import { setBackendSrv, BackendSrv, BackendSrvRequest } from '@grafana/runtime';
 import { EditorMode } from 'types';
 import { mockDatasource } from 'components/__fixtures__/Datasource';
 
@@ -101,208 +100,6 @@ describe('AdxDataSource', () => {
       });
     });
   });
-
-  it.skip('when performing annotations query', () => {
-    const tableResponse = {
-      Tables: [
-        {
-          TableName: 'Table_0',
-          Columns: [
-            {
-              ColumnName: 'Timestamp',
-              DataType: 'DateTime',
-              ColumnType: 'datetime',
-            },
-            { ColumnName: 'Text', DataType: 'String', ColumnType: 'string' },
-            { ColumnName: 'Tags', DataType: 'String', ColumnType: 'string' },
-          ],
-          Rows: [
-            ['2018-06-02T20:20:00Z', 'Computer1', 'tag1,tag2'],
-            ['2018-06-02T20:28:00Z', 'Computer2', 'tag2'],
-          ],
-        },
-      ],
-    };
-
-    const databasesResponse = {
-      Tables: [
-        {
-          TableName: 'Table_0',
-          Columns: [
-            { ColumnName: 'DatabaseName', DataType: 'String' },
-            { ColumnName: 'PersistentStorage', DataType: 'String' },
-            { ColumnName: 'Version', DataType: 'String' },
-            { ColumnName: 'IsCurrent', DataType: 'Boolean' },
-            { ColumnName: 'DatabaseAccessMode', DataType: 'String' },
-            { ColumnName: 'PrettyName', DataType: 'String' },
-            {
-              ColumnName: 'CurrentUserIsUnrestrictedViewer',
-              DataType: 'Boolean',
-            },
-            { ColumnName: 'DatabaseId', DataType: 'Guid' },
-          ],
-          Rows: [
-            [
-              'Grafana',
-              'https://4bukustoragekus86a3c.blob.core.windows.net/grafanamd201806201624130602',
-              'v5.2',
-              false,
-              'ReadWrite',
-              null,
-              false,
-              'a955a3ed-0668-4d00-a2e5-9c4e610ef057',
-            ],
-          ],
-        },
-      ],
-    };
-
-    let annotationResults;
-
-    beforeEach(async () => {
-      setBackendSrv({
-        datasourceRequest(options: BackendSrvRequest): Promise<any> {
-          if (options.url.indexOf('rest/mgmt') > -1) {
-            return Promise.resolve({ data: databasesResponse });
-          } else {
-            return Promise.resolve({ data: tableResponse });
-          }
-        },
-      } as BackendSrv);
-      ctx.ds = new AdxDataSource(ctx.instanceSettings);
-
-      annotationResults = await ctx.ds.annotationQuery({
-        annotation: {
-          rawQuery: 'Heartbeat | where $__timeFilter(TimeGenerated)| project TimeGenerated, Text=Computer, tags="test"',
-          database: 'Grafana',
-        },
-        range: {
-          from: dateTime([2017, 8, 11, 20, 0]),
-          to: dateTime([2017, 8, 11, 23, 59]),
-        },
-        rangeRaw: {
-          from: 'now-4h',
-          to: 'now',
-        },
-      });
-    });
-
-    it('should return a list of categories in the correct format', () => {
-      expect(annotationResults.length).toBe(2);
-
-      expect(annotationResults[0].time).toBe(1527970800000);
-      expect(annotationResults[0].text).toBe('Computer1');
-      expect(annotationResults[0].tags[0]).toBe('tag1');
-      expect(annotationResults[0].tags[1]).toBe('tag2');
-
-      expect(annotationResults[1].time).toBe(1527971280000);
-      expect(annotationResults[1].text).toBe('Computer2');
-      expect(annotationResults[1].tags[0]).toBe('tag2');
-    });
-  });
-
-  it.skip('Test cache ttl', () => {
-    it('should return 30 seconds when json minimal cache is not set', () => {
-      const ttl = ctx.ds.getCacheTtl(ctx.instanceSettings);
-      expect(ttl).toEqual(30000);
-    });
-
-    it('should return the minimal cache value supplied in the json data', () => {
-      ctx.instanceSettings.jsonData = {
-        minimalCache: 1,
-      };
-      const ttl = ctx.ds.getCacheTtl(ctx.instanceSettings);
-      expect(ttl).toEqual(1000);
-    });
-
-    it('should throw an exception when minimun cache is lower than 1', () => {
-      ctx.instanceSettings.jsonData = {
-        minimalCache: -5,
-      };
-
-      try {
-        ctx.ds.getCacheTtl(ctx.instanceSettings);
-      } catch (err: any) {
-        expect(err.message).toContain('Minimal cache must be greater than or equal to 1.');
-      }
-    });
-  });
-
-  it.skip('test alias parsing', () => {
-    it('Should parse adx timeseries data responses with default alias', () => {
-      const result = ctx.ds.processAlias(
-        {
-          A: {
-            alias: '',
-            database: 'Grafana',
-            query:
-              "print id='abc', Timestamp=range(bin(now(), 1h)-11h, bin(now(), 1h), 1h), y=dynamic([2,5,6,8,11,15,17,18,25,26,30,30])",
-            refId: 'A',
-            resultFormat: 'time_series_adx_series',
-            datasource: 'ADX',
-          },
-        },
-        {
-          data: [
-            {
-              target: {
-                y: {
-                  id: 'abc',
-                },
-              },
-              datapoints: [[2, 1582171200000]],
-              refId: 'A',
-              meta: {
-                KustoError: '',
-                RawQuery:
-                  "print id='abc', Timestamp=range(bin(now(), 1h)-11h, bin(now(), 1h), 1h), y=dynamic([2,5,6,8,11,15,17,18,25,26,30,30])",
-                TimeNotASC: false,
-              },
-            },
-          ],
-          valueCount: 1,
-        }
-      );
-      expect(result.data[0].target).toEqual('abc');
-    });
-
-    it('Should parse adx timeseries data responses with custom alias', () => {
-      const result = ctx.ds.processAlias(
-        {
-          A: {
-            alias: '$value',
-            database: 'Grafana',
-            query:
-              "print id='abc', Timestamp=range(bin(now(), 1h)-11h, bin(now(), 1h), 1h), y=dynamic([2,5,6,8,11,15,17,18,25,26,30,30])",
-            refId: 'A',
-            resultFormat: 'time_series_adx_series',
-            datasource: 'ADX',
-          },
-        },
-        {
-          data: [
-            {
-              target: {
-                y: {
-                  id: 'abc',
-                },
-              },
-              datapoints: [[2, 1582171200000]],
-              refId: 'A',
-              meta: {
-                KustoError: '',
-                RawQuery:
-                  "print id='abc', Timestamp=range(bin(now(), 1h)-11h, bin(now(), 1h), 1h), y=dynamic([2,5,6,8,11,15,17,18,25,26,30,30])",
-                TimeNotASC: false,
-              },
-            },
-          ],
-          valueCount: 1,
-        }
-      );
-      expect(result.data[0].target).toEqual('y');
-    });
-  });
 });
 
 describe('AdxDataSource', () => {
@@ -381,6 +178,8 @@ describe('AdxDataSource', () => {
           expected: { Name: `Teams["TeamID"]["a"]`, CslType: 'string' },
           warn: true,
         },
+        { schema: '["long","double"]', expected: { Name: `Teams`, CslType: 'double' } },
+        { schema: '"long"', expected: { Name: `Teams`, CslType: 'long' } },
       ].forEach((t) => {
         const consoleWarn = console.warn;
         beforeEach(() => {

--- a/src/types.ts
+++ b/src/types.ts
@@ -141,6 +141,8 @@ export interface AdxFunctionSchema {
 
 export interface AdxFunctionInputParameterSchema extends AdxColumnSchema {}
 
+export type AdxSchemaDefinition = string | AdxSchemaDefinition[] | { [k: string]: AdxSchemaDefinition };
+
 // must be in synch with clouds.go
 export enum AzureCloudType {
   AzurePublic = 'azuremonitor',


### PR DESCRIPTION
Fixes https://github.com/grafana/azure-data-explorer-datasource/issues/417

The `dynamic` type can be a simple type, an object or an array of simple types or objects. We were only considering the option that the type was an object.

Additional notes:
 - I have defined a new type that should cover the above, avoiding using the type `any`
 - I have removed some unused tests (that didn't reference any real code)