### PR TITLE
Fix "Aggregate" and "Group by" removal logic

### DIFF
--- a/src/editor/components/groupBy/QueryEditorGroupBy.tsx
+++ b/src/editor/components/groupBy/QueryEditorGroupBy.tsx
@@ -21,6 +21,13 @@ export const QueryEditorGroupBy: React.FC<Props> = (props) => {
   const [interval, setInterval] = useState(props.value?.interval);
   const styles = useStyles2(getStyles);
 
+  useEffect(() => {
+    if (props.value) {
+      setField(props.value.property);
+      setInterval(props.value.interval);
+    }
+  }, [props.value]);
+
   const onChangeField = useCallback(
     (property: QueryEditorProperty) => {
       setField(property);

--- a/src/editor/components/reduce/QueryEditorReduce.tsx
+++ b/src/editor/components/reduce/QueryEditorReduce.tsx
@@ -35,6 +35,14 @@ export const QueryEditorReduce: React.FC<Props> = (props) => {
   const applyOnField = useApplyOnField(reduce, props.functions);
   const styles = useStyles2(getStyles);
 
+  useEffect(() => {
+    if (props.value) {
+      setField(props.value.property);
+      setReduce(props.value.reduce);
+      setParameters(props.value.parameters);
+    }
+  }, [props.value]);
+
   const onChangeField = useCallback(
     (property: QueryEditorProperty) => {
       setField(property);


### PR DESCRIPTION
Fixes https://github.com/grafana/azure-data-explorer-datasource/issues/403

This was a rendering issue, the right element was being removed from the array but the component didn't re-render with the new data.

![Peek 2022-07-11 14-41](https://user-images.githubusercontent.com/4025665/178267387-41e1af31-dad1-455f-beed-0e6845768800.gif)

I am not adding tests because this code should go away once we tackle https://github.com/grafana/azure-data-explorer-datasource/issues/391