### PR TITLE
Fix: return configured database instead of the first one.

### DIFF
--- a/src/components/QueryEditor.tsx
+++ b/src/components/QueryEditor.tsx
@@ -140,6 +140,7 @@ const useSelectedDatabase = (
   query: KustoQuery,
   datasource: AdxDataSource
 ): string => {
+  const defaultDB = useAsync(() => datasource.getDefaultOrFirstDatabase(), [datasource]);
   const variables = datasource.getVariables();
 
   return useMemo(() => {
@@ -156,11 +157,15 @@ const useSelectedDatabase = (
     }
 
     if (options.length > 0) {
-      return options[0].value;
+      const result = options.find((x) => x.value === defaultDB.value);
+
+      if (result) {
+        return result.value;
+      }
     }
 
     return '';
-  }, [options, variables, query.database]);
+  }, [options, variables, query.database, defaultDB.value]);
 };
 
 const useDatabaseOptions = (schema?: AdxSchema): QueryEditorPropertyDefinition[] => {


### PR DESCRIPTION
Previously we just returned the first configured database in the query editor database dropdown. This now compares the default DB to the list of DBs and returns the match if there is one.

![image](https://user-images.githubusercontent.com/1048831/178360069-5ca57039-411a-4767-9ca0-2f05ec4791e8.png)


Fixes #419 