### PR TITLE
Correctly cast dynamically typed columns

### DIFF
--- a/src/KustoExpressionParser.test.ts
+++ b/src/KustoExpressionParser.test.ts
@@ -116,6 +116,7 @@ describe('KustoExpressionParser', () => {
         {
           Name: 'column["type"]',
           CslType: 'string',
+          Type: 'dynamic',
         },
       ];
 
@@ -152,6 +153,7 @@ describe('KustoExpressionParser', () => {
         {
           Name: 'column["type"]',
           CslType: 'string',
+          Type: 'dynamic',
         },
         {
           Name: 'StartTime',
@@ -429,6 +431,7 @@ describe('KustoExpressionParser', () => {
         {
           Name: 'column["level"]["active"]',
           CslType: 'int',
+          Type: 'dynamic',
         },
       ];
 
@@ -448,6 +451,7 @@ describe('KustoExpressionParser', () => {
         {
           Name: 'column["level"]["active"]',
           CslType: 'int',
+          Type: 'dynamic',
         },
         {
           Name: 'StartTime',
@@ -474,6 +478,7 @@ describe('KustoExpressionParser', () => {
         {
           Name: 'column["level"]["active"]',
           CslType: 'int',
+          Type: 'dynamic',
         },
         {
           Name: 'StartTime',
@@ -501,6 +506,7 @@ describe('KustoExpressionParser', () => {
         {
           Name: 'column["level"]["active"]',
           CslType: 'int',
+          Type: 'dynamic',
         },
         {
           Name: 'StartTime',
@@ -528,6 +534,7 @@ describe('KustoExpressionParser', () => {
         {
           Name: 'column["level"]["active"]',
           CslType: 'int',
+          Type: 'dynamic',
         },
         {
           Name: 'StartTime',
@@ -555,6 +562,7 @@ describe('KustoExpressionParser', () => {
         {
           Name: 'column["level"]["active"]',
           CslType: 'int',
+          Type: 'dynamic',
         },
         {
           Name: 'StartTime',
@@ -582,6 +590,7 @@ describe('KustoExpressionParser', () => {
         {
           Name: 'column["level"]["active"]',
           CslType: 'int',
+          Type: 'dynamic',
         },
         {
           Name: 'StartTime',
@@ -613,6 +622,7 @@ describe('KustoExpressionParser', () => {
         {
           Name: 'column["level"]["active"]',
           CslType: 'int',
+          Type: 'dynamic',
         },
         {
           Name: 'StartTime',
@@ -621,6 +631,7 @@ describe('KustoExpressionParser', () => {
         {
           Name: 'column["EndTime"]',
           CslType: 'datetime',
+          Type: 'dynamic',
         },
       ];
 
@@ -644,6 +655,7 @@ describe('KustoExpressionParser', () => {
         {
           Name: 'column["type"]',
           CslType: 'string',
+          Type: 'dynamic',
         },
         {
           Name: 'StartTime',
@@ -688,6 +700,7 @@ describe('KustoExpressionParser', () => {
         {
           Name: 'column["type"]',
           CslType: 'string',
+          Type: 'dynamic',
         },
         {
           Name: 'StartTime',
@@ -732,6 +745,7 @@ describe('KustoExpressionParser', () => {
         {
           Name: 'column["type"]',
           CslType: 'string',
+          Type: 'dynamic',
         },
         {
           Name: 'StartTime',
@@ -758,6 +772,7 @@ describe('KustoExpressionParser', () => {
         {
           Name: 'column["type"]',
           CslType: 'string',
+          Type: 'dynamic',
         },
         {
           Name: 'StartTime',
@@ -784,6 +799,7 @@ describe('KustoExpressionParser', () => {
         {
           Name: 'column["type"]',
           CslType: 'string',
+          Type: 'dynamic',
         },
         {
           Name: 'StartTime',
@@ -810,6 +826,7 @@ describe('KustoExpressionParser', () => {
         {
           Name: 'column["type"]',
           CslType: 'string',
+          Type: 'dynamic',
         },
         {
           Name: 'StartTime',
@@ -836,6 +853,7 @@ describe('KustoExpressionParser', () => {
         {
           Name: 'column["type"]',
           CslType: 'string',
+          Type: 'dynamic',
         },
         {
           Name: 'StartTime',
@@ -861,6 +879,7 @@ describe('KustoExpressionParser', () => {
         {
           Name: 'column["`indexer`"]',
           CslType: 'string',
+          Type: 'dynamic',
         },
         {
           Name: 'StartTime',
@@ -888,6 +907,7 @@ describe('KustoExpressionParser', () => {
         {
           Name: 'column["`indexer`"]["foo"]["`indexer`"]',
           CslType: 'string',
+          Type: 'dynamic',
         },
         {
           Name: 'StartTime',
@@ -1072,6 +1092,7 @@ describe('KustoExpressionParser', () => {
         {
           Name: 'column["`indexer`"]',
           CslType: 'string',
+          Type: 'dynamic',
         },
         {
           Name: 'StartTime',
@@ -1097,6 +1118,7 @@ describe('KustoExpressionParser', () => {
         {
           Name: 'column["`indexer`"]["foo"]["`indexer`"]',
           CslType: 'string',
+          Type: 'dynamic',
         },
         {
           Name: 'StartTime',

--- a/src/KustoExpressionParser.test.ts
+++ b/src/KustoExpressionParser.test.ts
@@ -116,7 +116,7 @@ describe('KustoExpressionParser', () => {
         {
           Name: 'column["type"]',
           CslType: 'string',
-          Type: 'dynamic',
+          isDynamic: true,
         },
       ];
 
@@ -153,7 +153,7 @@ describe('KustoExpressionParser', () => {
         {
           Name: 'column["type"]',
           CslType: 'string',
-          Type: 'dynamic',
+          isDynamic: true,
         },
         {
           Name: 'StartTime',
@@ -327,6 +327,7 @@ describe('KustoExpressionParser', () => {
         {
           Name: 'Column["StartTime"]',
           CslType: 'datetime',
+          isDynamic: true,
         },
       ];
 
@@ -348,6 +349,7 @@ describe('KustoExpressionParser', () => {
         {
           Name: 'Column["StartTime"]',
           CslType: 'datetime',
+          isDynamic: true,
         },
         {
           Name: 'SavedTime',
@@ -431,7 +433,7 @@ describe('KustoExpressionParser', () => {
         {
           Name: 'column["level"]["active"]',
           CslType: 'int',
-          Type: 'dynamic',
+          isDynamic: true,
         },
       ];
 
@@ -451,7 +453,7 @@ describe('KustoExpressionParser', () => {
         {
           Name: 'column["level"]["active"]',
           CslType: 'int',
-          Type: 'dynamic',
+          isDynamic: true,
         },
         {
           Name: 'StartTime',
@@ -478,7 +480,7 @@ describe('KustoExpressionParser', () => {
         {
           Name: 'column["level"]["active"]',
           CslType: 'int',
-          Type: 'dynamic',
+          isDynamic: true,
         },
         {
           Name: 'StartTime',
@@ -506,7 +508,7 @@ describe('KustoExpressionParser', () => {
         {
           Name: 'column["level"]["active"]',
           CslType: 'int',
-          Type: 'dynamic',
+          isDynamic: true,
         },
         {
           Name: 'StartTime',
@@ -534,7 +536,7 @@ describe('KustoExpressionParser', () => {
         {
           Name: 'column["level"]["active"]',
           CslType: 'int',
-          Type: 'dynamic',
+          isDynamic: true,
         },
         {
           Name: 'StartTime',
@@ -562,7 +564,7 @@ describe('KustoExpressionParser', () => {
         {
           Name: 'column["level"]["active"]',
           CslType: 'int',
-          Type: 'dynamic',
+          isDynamic: true,
         },
         {
           Name: 'StartTime',
@@ -590,7 +592,7 @@ describe('KustoExpressionParser', () => {
         {
           Name: 'column["level"]["active"]',
           CslType: 'int',
-          Type: 'dynamic',
+          isDynamic: true,
         },
         {
           Name: 'StartTime',
@@ -622,7 +624,7 @@ describe('KustoExpressionParser', () => {
         {
           Name: 'column["level"]["active"]',
           CslType: 'int',
-          Type: 'dynamic',
+          isDynamic: true,
         },
         {
           Name: 'StartTime',
@@ -631,7 +633,7 @@ describe('KustoExpressionParser', () => {
         {
           Name: 'column["EndTime"]',
           CslType: 'datetime',
-          Type: 'dynamic',
+          isDynamic: true,
         },
       ];
 
@@ -655,7 +657,7 @@ describe('KustoExpressionParser', () => {
         {
           Name: 'column["type"]',
           CslType: 'string',
-          Type: 'dynamic',
+          isDynamic: true,
         },
         {
           Name: 'StartTime',
@@ -700,7 +702,7 @@ describe('KustoExpressionParser', () => {
         {
           Name: 'column["type"]',
           CslType: 'string',
-          Type: 'dynamic',
+          isDynamic: true,
         },
         {
           Name: 'StartTime',
@@ -745,7 +747,7 @@ describe('KustoExpressionParser', () => {
         {
           Name: 'column["type"]',
           CslType: 'string',
-          Type: 'dynamic',
+          isDynamic: true,
         },
         {
           Name: 'StartTime',
@@ -772,7 +774,7 @@ describe('KustoExpressionParser', () => {
         {
           Name: 'column["type"]',
           CslType: 'string',
-          Type: 'dynamic',
+          isDynamic: true,
         },
         {
           Name: 'StartTime',
@@ -799,7 +801,7 @@ describe('KustoExpressionParser', () => {
         {
           Name: 'column["type"]',
           CslType: 'string',
-          Type: 'dynamic',
+          isDynamic: true,
         },
         {
           Name: 'StartTime',
@@ -826,7 +828,7 @@ describe('KustoExpressionParser', () => {
         {
           Name: 'column["type"]',
           CslType: 'string',
-          Type: 'dynamic',
+          isDynamic: true,
         },
         {
           Name: 'StartTime',
@@ -853,7 +855,7 @@ describe('KustoExpressionParser', () => {
         {
           Name: 'column["type"]',
           CslType: 'string',
-          Type: 'dynamic',
+          isDynamic: true,
         },
         {
           Name: 'StartTime',
@@ -879,7 +881,7 @@ describe('KustoExpressionParser', () => {
         {
           Name: 'column["`indexer`"]',
           CslType: 'string',
-          Type: 'dynamic',
+          isDynamic: true,
         },
         {
           Name: 'StartTime',
@@ -907,7 +909,7 @@ describe('KustoExpressionParser', () => {
         {
           Name: 'column["`indexer`"]["foo"]["`indexer`"]',
           CslType: 'string',
-          Type: 'dynamic',
+          isDynamic: true,
         },
         {
           Name: 'StartTime',
@@ -1092,7 +1094,7 @@ describe('KustoExpressionParser', () => {
         {
           Name: 'column["`indexer`"]',
           CslType: 'string',
-          Type: 'dynamic',
+          isDynamic: true,
         },
         {
           Name: 'StartTime',
@@ -1118,7 +1120,7 @@ describe('KustoExpressionParser', () => {
         {
           Name: 'column["`indexer`"]["foo"]["`indexer`"]',
           CslType: 'string',
-          Type: 'dynamic',
+          isDynamic: true,
         },
         {
           Name: 'StartTime',

--- a/src/KustoExpressionParser.ts
+++ b/src/KustoExpressionParser.ts
@@ -399,16 +399,22 @@ const defaultTimeColumn = (columns?: AdxColumnSchema[], expression?: QueryExpres
   return toType(column.CslType, column.Name);
 };
 
-const isDynamic = (column: string): boolean => {
-  return !!(column && column.indexOf('[') > -1) || !!(column && column.indexOf('todynamic') > -1);
+const isDynamic = (column: string | AdxColumnSchema | undefined): boolean => {
+  if (column && typeof column === 'object') {
+    return column.Type === 'dynamic';
+  } else if (typeof column === 'string') {
+    return !!(column && column.indexOf('[') > -1) || !!(column && column.indexOf('todynamic') > -1);
+  } else {
+    return false;
+  }
 };
 
 const castIfDynamic = (column: string, tableSchema?: AdxColumnSchema[], schemaName?: string): string => {
-  if (!isDynamic(schemaName || column) || !Array.isArray(tableSchema)) {
+  const columnSchema = tableSchema?.find((c) => c.Name === (schemaName || column));
+
+  if (!isDynamic(columnSchema || schemaName || column) || !Array.isArray(tableSchema)) {
     return column;
   }
-
-  const columnSchema = tableSchema.find((c) => c.Name === (schemaName || column));
 
   if (!columnSchema) {
     return column;

--- a/src/KustoExpressionParser.ts
+++ b/src/KustoExpressionParser.ts
@@ -108,13 +108,7 @@ export class KustoExpressionParser {
       return;
     }
 
-    let columnName = context.timeColumn;
     if (context.timeColumn.includes('todatetime')) {
-      columnName = context.timeColumn.replace('todatetime(', '').replace(')', '');
-    }
-    const columnSchema = tableSchema?.find((c) => c.Name === columnName);
-
-    if (isDynamic(columnSchema)) {
       parts.push(`where ${context.timeColumn} between ($__timeFrom .. $__timeTo)`);
       return;
     }
@@ -406,18 +400,10 @@ const defaultTimeColumn = (columns?: AdxColumnSchema[], expression?: QueryExpres
   return toType(column.CslType, column.Name);
 };
 
-const isDynamic = (column: AdxColumnSchema | undefined): boolean => {
-  if (column && column.isDynamic) {
-    return column.isDynamic;
-  } else {
-    return false;
-  }
-};
-
 const castIfDynamic = (column: string, tableSchema?: AdxColumnSchema[], schemaName?: string): string => {
   const columnSchema = tableSchema?.find((c) => c.Name === (schemaName || column));
 
-  if (!isDynamic(columnSchema) || !Array.isArray(tableSchema)) {
+  if (!columnSchema?.isDynamic || !Array.isArray(tableSchema)) {
     return column;
   }
 

--- a/src/datasource.test.ts
+++ b/src/datasource.test.ts
@@ -158,6 +158,7 @@ describe('AdxDataSource', () => {
           {
             CslType: 'long',
             Name: 'Teams["18"]["TeamID"]',
+            Type: 'dynamic',
           },
         ],
       });
@@ -165,21 +166,30 @@ describe('AdxDataSource', () => {
 
     describe('when there are multiple types returned', () => {
       [
-        { schema: '{"TeamID":["long","double"]}', expected: { Name: `Teams["TeamID"]`, CslType: 'double' } },
-        { schema: '{"TeamID":["long","real"]}', expected: { Name: `Teams["TeamID"]`, CslType: 'real' } },
-        { schema: '{"TeamID":["long","int"]}', expected: { Name: `Teams["TeamID"]`, CslType: 'long' } },
+        {
+          schema: '{"TeamID":["long","double"]}',
+          expected: { Name: `Teams["TeamID"]`, CslType: 'double', Type: 'dynamic' },
+        },
+        {
+          schema: '{"TeamID":["long","real"]}',
+          expected: { Name: `Teams["TeamID"]`, CslType: 'real', Type: 'dynamic' },
+        },
+        {
+          schema: '{"TeamID":["long","int"]}',
+          expected: { Name: `Teams["TeamID"]`, CslType: 'long', Type: 'dynamic' },
+        },
         {
           schema: '{"TeamID":["string","bool"]}',
-          expected: { Name: `Teams["TeamID"]`, CslType: 'string' },
+          expected: { Name: `Teams["TeamID"]`, CslType: 'string', Type: 'dynamic' },
           warn: true,
         },
         {
           schema: '{"TeamID":[{"a":"string"},"bool"]}',
-          expected: { Name: `Teams["TeamID"]["a"]`, CslType: 'string' },
+          expected: { Name: `Teams["TeamID"]["a"]`, CslType: 'string', Type: 'dynamic' },
           warn: true,
         },
-        { schema: '["long","double"]', expected: { Name: `Teams`, CslType: 'double' } },
-        { schema: '"long"', expected: { Name: `Teams`, CslType: 'long' } },
+        { schema: '["long","double"]', expected: { Name: `Teams`, CslType: 'double', Type: 'dynamic' } },
+        { schema: '"long"', expected: { Name: `Teams`, CslType: 'long', Type: 'dynamic' } },
       ].forEach((t) => {
         const consoleWarn = console.warn;
         beforeEach(() => {

--- a/src/datasource.ts
+++ b/src/datasource.ts
@@ -383,13 +383,13 @@ const recordSchemaArray = (name: string, types: AdxSchemaDefinition[], result: A
   if (types.every((t) => typeof t === 'string' && toPropertyType(t) === QueryEditorPropertyType.Number)) {
     // If all the types are numbers, the double takes precedence since it has more precission.
     const cslType = types.find((t) => typeof t === 'string' && (t === 'double' || t === 'real')) || defaultCslType;
-    result.push({ Name: name, CslType: cslType as string });
+    result.push({ Name: name, CslType: cslType as string, Type: 'dynamic' });
   } else {
     console.warn(`schema ${name} may contain different types, assuming ${defaultCslType}`);
     if (typeof defaultCslType === 'object') {
       recordSchema(name, types[0], result);
     } else {
-      result.push({ Name: name, CslType: defaultCslType });
+      result.push({ Name: name, CslType: defaultCslType, Type: 'dynamic' });
     }
   }
 };
@@ -405,6 +405,7 @@ const recordSchema = (columnName: string, schema: AdxSchemaDefinition, result: A
     result.push({
       Name: columnName,
       CslType: schema,
+      Type: 'dynamic',
     });
     return;
   }

--- a/src/schema/AdxSchemaResolver.test.ts
+++ b/src/schema/AdxSchemaResolver.test.ts
@@ -58,7 +58,7 @@ describe('Test schema resolution', () => {
       { Name: 'dynamic', CslType: 'dynamic', Type: 'System.Object' },
     ];
     datasource.getDynamicSchema = jest.fn().mockResolvedValue({
-      dynamic: [{ Name: 'Modes["`indexer`"]', CslType: 'string' }],
+      dynamic: [{ Name: 'Modes["`indexer`"]', CslType: 'string', Type: 'dynamic' }],
     });
     const schema = createMockSchema();
     schema.Databases['testdb'].Tables = {
@@ -73,7 +73,9 @@ describe('Test schema resolution', () => {
     datasource.getSchema = jest.fn().mockResolvedValue(schema);
     const columns = await schemaResolver.getColumnsForTable('testdb', 'testdynamictable');
     expect(columns).toHaveLength(testColumns.length);
-    expect(columns).toEqual(expect.arrayContaining([{ CslType: 'string', Name: 'Modes["`indexer`"]' }]));
+    expect(columns).toEqual(
+      expect.arrayContaining([{ CslType: 'string', Name: 'Modes["`indexer`"]', Type: 'dynamic' }])
+    );
   });
 
   it('Will correctly include columns with type "dynamic" and containing nested arrays', async () => {
@@ -106,7 +108,9 @@ describe('Test schema resolution', () => {
     datasource.getSchema = jest.fn().mockResolvedValue(schema);
     const columns = await schemaResolver.getColumnsForTable('testdb', 'testdynamictable');
     expect(columns).toHaveLength(testColumns.length);
-    expect(columns).toEqual(expect.arrayContaining([{ CslType: 'string', Name: 'Modes["`indexer`"]' }]));
+    expect(columns).toEqual(
+      expect.arrayContaining([{ CslType: 'string', Name: 'Modes["`indexer`"]', Type: 'dynamic' }])
+    );
   });
 
   it('Will correctly include columns with type "dynamic" and simple properties', async () => {

--- a/src/types.ts
+++ b/src/types.ts
@@ -128,6 +128,7 @@ export interface AdxColumnSchema {
   CslType: string;
   Type?: string;
   CslDefaultValue?: string;
+  isDynamic?: boolean;
 }
 
 export interface AdxFunctionSchema {


### PR DESCRIPTION
Fixes #429 where 'simple' dynamic columns were not being appropriately cast in `group by` and `summarize` statements.