### PR TITLE
Query builder: Add support for colums with spaces

### DIFF
--- a/pkg/azuredx/models/macro.go
+++ b/pkg/azuredx/models/macro.go
@@ -35,7 +35,7 @@ func NewMacroData(tr *backend.TimeRange, intervalMS int64) MacroData {
 // macroRE is a regular expression to match available macros
 var macroRE = regexp.MustCompile(`\$__` + // Prefix: $__
 	`(timeFilter|timeFrom|timeTo|timeInterval)` + // one of macro root names
-	`(\([a-zA-Z0-9_\s.-]*?\))?`) // optional () or optional (someArg)
+	`(\([a-zA-Z0-9_\s\[\]\"\'.-]*?\))?`) // optional () or optional (someArg)
 
 // Interpolate replaces macros with their values for the given query.
 func (md MacroData) Interpolate(query string) (string, error) {
@@ -68,7 +68,7 @@ func (md MacroData) Interpolate(query string) (string, error) {
 
 func quoteForSpacesDotsDashes(s string) string {
 	// https://docs.microsoft.com/en-us/azure/data-explorer/kusto/query/schema-entities/entity-names#identifier-quoting
-	if strings.ContainsAny(s, " .-") {
+	if strings.ContainsAny(s, " .-") && !strings.ContainsAny(s, "['\"]") {
 		return fmt.Sprintf("['%s']", s)
 	}
 	return s

--- a/pkg/azuredx/models/macro_test.go
+++ b/pkg/azuredx/models/macro_test.go
@@ -84,6 +84,17 @@ func TestMacroData_Interpolate(t *testing.T) {
 			returnVal: fmt.Sprintf("CatCount >= %v and CatCount <= %v", fromString, toString),
 		},
 		{
+			name: "should parse $__timeFilter([\"Cat Count\"])",
+			macroData: NewMacroData(&backend.TimeRange{
+				From: fromTime,
+				To:   toTime,
+			}, 0),
+			errorIs:   assert.NoError,
+			query:     "$__timeFilter([\"Cat Count\"])",
+			returnIs:  assert.Equal,
+			returnVal: fmt.Sprintf(`["Cat Count"] >= %v and ["Cat Count"] <= %v`, fromString, toString),
+		},
+		{
 			name: "should parse and quote identifier with space",
 			macroData: NewMacroData(&backend.TimeRange{
 				From: fromTime,

--- a/src/KustoExpressionParser.test.ts
+++ b/src/KustoExpressionParser.test.ts
@@ -187,9 +187,7 @@ describe('KustoExpressionParser', () => {
         where: createArray([createOperator('event type', '==', 'ThunderStorm')]),
       });
 
-      expect(parser.toQuery(expression)).toEqual(
-        'StormEvents' +
-          '\n| where ["event type"] == \'ThunderStorm\''      );
+      expect(parser.toQuery(expression)).toEqual('StormEvents' + '\n| where ["event type"] == \'ThunderStorm\'');
     });
 
     it('should parse reduce expression with a space', () => {
@@ -198,9 +196,7 @@ describe('KustoExpressionParser', () => {
         reduce: createArray([createReduce('reduce thing', 'none')]),
       });
 
-      expect(parser.toQuery(expression)).toEqual(
-        'StormEvents' +
-          '\n| project ["reduce thing"]');
+      expect(parser.toQuery(expression)).toEqual('StormEvents' + '\n| project ["reduce thing"]');
     });
 
     it('should parse reduce with a function expression with a space', () => {
@@ -209,24 +205,22 @@ describe('KustoExpressionParser', () => {
         reduce: createArray([createReduce('reduce thing 2', 'sum')]),
       });
 
-      expect(parser.toQuery(expression)).toEqual(
-        'StormEvents' +
-          '\n| summarize sum(["reduce thing 2"])');
+      expect(parser.toQuery(expression)).toEqual('StormEvents' + '\n| summarize sum(["reduce thing 2"])');
     });
-    
-    it('should parse xreduce expression with a space', () => {
+
+    it('should parse a expression with spaces in multiple places', () => {
       const expression = createQueryExpression({
         from: createProperty('StormEvents'),
         where: createArray([createOperator('event type', '==', 'ThunderStorm')]),
-        reduce: createArray([createReduce('reduce thing', 'none'), createReduce('reduce thing 2', 'sum')]),
+        reduce: createArray([createReduce('reduce thing', 'sum')]),
         groupBy: createArray([createGroupBy('Start Time', '1h')]),
       });
 
       expect(parser.toQuery(expression)).toEqual(
         'StormEvents' +
+          '\n| where $__timeFilter(["Start Time"])' +
           '\n| where ["event type"] == \'ThunderStorm\'' +
-          '\n| project ["reduce thing"]' +
-          '\n| summarize sum(["reduce thing 2"])' +
+          '\n| summarize sum(["reduce thing"]) by bin(["Start Time"], 1h)' +
           '\n| order by ["Start Time"] asc'
       );
     });

--- a/src/KustoExpressionParser.test.ts
+++ b/src/KustoExpressionParser.test.ts
@@ -181,7 +181,7 @@ describe('KustoExpressionParser', () => {
       expect(parser.toQuery(expression)).toEqual('StormEvents' + "\n| where eventType == 'ThunderStorm'");
     });
 
-    it('should parse expression with where equal to string value', () => {
+    it('should parse expression with a space', () => {
       const expression = createQueryExpression({
         from: createProperty('StormEvents'),
         where: createArray([createOperator('event type', '==', 'ThunderStorm')]),

--- a/src/KustoExpressionParser.test.ts
+++ b/src/KustoExpressionParser.test.ts
@@ -181,6 +181,15 @@ describe('KustoExpressionParser', () => {
       expect(parser.toQuery(expression)).toEqual('StormEvents' + "\n| where eventType == 'ThunderStorm'");
     });
 
+    it('should parse expression with where equal to string value', () => {
+      const expression = createQueryExpression({
+        from: createProperty('StormEvents'),
+        where: createArray([createOperator('event type', '==', 'ThunderStorm')]),
+      });
+
+      expect(parser.toQuery(expression)).toEqual('StormEvents' + '\n| where ["event type"] == \'ThunderStorm\'');
+    });
+
     it('should parse an expression with a table name that contains special characters', () => {
       const expression = createQueryExpression({
         from: createProperty('events.all'),

--- a/src/KustoExpressionParser.test.ts
+++ b/src/KustoExpressionParser.test.ts
@@ -181,7 +181,40 @@ describe('KustoExpressionParser', () => {
       expect(parser.toQuery(expression)).toEqual('StormEvents' + "\n| where eventType == 'ThunderStorm'");
     });
 
-    it('should parse expression with a space', () => {
+    it('should parse where operator with a space', () => {
+      const expression = createQueryExpression({
+        from: createProperty('StormEvents'),
+        where: createArray([createOperator('event type', '==', 'ThunderStorm')]),
+      });
+
+      expect(parser.toQuery(expression)).toEqual(
+        'StormEvents' +
+          '\n| where ["event type"] == \'ThunderStorm\''      );
+    });
+
+    it('should parse reduce expression with a space', () => {
+      const expression = createQueryExpression({
+        from: createProperty('StormEvents'),
+        reduce: createArray([createReduce('reduce thing', 'none')]),
+      });
+
+      expect(parser.toQuery(expression)).toEqual(
+        'StormEvents' +
+          '\n| project ["reduce thing"]');
+    });
+
+    it('should parse reduce with a function expression with a space', () => {
+      const expression = createQueryExpression({
+        from: createProperty('StormEvents'),
+        reduce: createArray([createReduce('reduce thing 2', 'sum')]),
+      });
+
+      expect(parser.toQuery(expression)).toEqual(
+        'StormEvents' +
+          '\n| summarize sum(["reduce thing 2"])');
+    });
+    
+    it('should parse xreduce expression with a space', () => {
       const expression = createQueryExpression({
         from: createProperty('StormEvents'),
         where: createArray([createOperator('event type', '==', 'ThunderStorm')]),

--- a/src/KustoExpressionParser.test.ts
+++ b/src/KustoExpressionParser.test.ts
@@ -171,6 +171,32 @@ describe('KustoExpressionParser', () => {
           '\n| take 251'
       );
     });
+
+    it('should parse expression and exclude current filter with spaces', () => {
+      const expression = createQueryExpression({
+        from: createProperty('StormEvents'),
+        where: createArray([
+          createOperator('event type', '==', 'ThunderStorm'),
+          createOperator('state name', '==', ''),
+        ]),
+      });
+
+      const acQuery: AutoCompleteQuery = {
+        expression,
+        search: createOperator('state name', 'contains', 'TEXAS'),
+        index: '1',
+        database: 'Samples',
+      };
+
+      expect(parser.toAutoCompleteQuery(acQuery)).toEqual(
+        'StormEvents' +
+          '\n| where ["event type"] == \'ThunderStorm\'' +
+          '\n| where ["state name"] contains \'TEXAS\'' +
+          '\n| take 50000' +
+          '\n| distinct ["state name"]' +
+          '\n| take 251'
+      );
+    });
   });
 
   describe('toQuery', () => {
@@ -208,6 +234,25 @@ describe('KustoExpressionParser', () => {
       });
 
       expect(parser.toQuery(expression)).toEqual('StormEvents' + '\n| summarize sum(["reduce thing 2"])');
+    });
+
+    it('should parse reduce with a function expression with a space and a dynamic column', () => {
+      const expression = createQueryExpression({
+        from: createProperty('StormEvents'),
+        reduce: createArray([createReduce('reduce thing', 'sum')]),
+      });
+
+      const tableSchema: AdxColumnSchema[] = [
+        {
+          Name: 'reduce thing',
+          CslType: 'long',
+          isDynamic: true,
+        },
+      ];
+
+      expect(parser.toQuery(expression, tableSchema)).toEqual(
+        'StormEvents' + '\n| summarize sum(tolong(["reduce thing"]))'
+      );
     });
 
     it('should parse a expression with spaces in multiple places', () => {

--- a/src/KustoExpressionParser.test.ts
+++ b/src/KustoExpressionParser.test.ts
@@ -185,9 +185,17 @@ describe('KustoExpressionParser', () => {
       const expression = createQueryExpression({
         from: createProperty('StormEvents'),
         where: createArray([createOperator('event type', '==', 'ThunderStorm')]),
+        reduce: createArray([createReduce('reduce thing', 'none'), createReduce('reduce thing 2', 'sum')]),
+        groupBy: createArray([createGroupBy('Start Time', '1h')]),
       });
 
-      expect(parser.toQuery(expression)).toEqual('StormEvents' + '\n| where ["event type"] == \'ThunderStorm\'');
+      expect(parser.toQuery(expression)).toEqual(
+        'StormEvents' +
+          '\n| where ["event type"] == \'ThunderStorm\'' +
+          '\n| project ["reduce thing"]' +
+          '\n| summarize sum(["reduce thing 2"])' +
+          '\n| order by ["Start Time"] asc'
+      );
     });
 
     it('should parse an expression with a table name that contains special characters', () => {

--- a/src/KustoExpressionParser.ts
+++ b/src/KustoExpressionParser.ts
@@ -275,15 +275,16 @@ export class KustoExpressionParser {
     if (!property.name || !operator.name) {
       return;
     }
+    const propertyName = property.name.includes(' ') ? `["${property.name}"]` : property.name
 
     switch (operator.name) {
       case 'isnotempty':
-        parts.push(withPrefix(`${operator.name}(${property.name})`, prefix));
+        parts.push(withPrefix(`${operator.name}(${propertyName})`, prefix));
         break;
 
       default:
         const value = this.formatValue(operator.value, property.type);
-        const name = this.addExpanPartsdIfNeeded(property.name, expandParts);
+        const name = this.addExpanPartsdIfNeeded(propertyName, expandParts);
         parts.push(withPrefix(`${name} ${operator.name} ${value}`, prefix));
         break;
     }

--- a/src/KustoExpressionParser.ts
+++ b/src/KustoExpressionParser.ts
@@ -158,6 +158,10 @@ export class KustoExpressionParser {
     }
     const eParts = expandParts ? expandParts : [];
 
+    console.log('context ', context);
+    console.log('expression ', expression);
+    console.log('parts ', parts);
+
     if (isAndExpression(expression)) {
       return expression.expressions.forEach((exp) => this.appendWhere(context, exp, parts, prefix, eParts));
     }

--- a/src/KustoExpressionParser.ts
+++ b/src/KustoExpressionParser.ts
@@ -202,7 +202,7 @@ export class KustoExpressionParser {
       const func = expression.reduce.name;
       const parameters = expression.parameters;
       const name = this.addExpanPartsdIfNeeded(expression.property.name, expandParts);
-      const column = context.castIfDynamic(name, expression.property.name);
+      const column = this.escapeColumn(context.castIfDynamic(name, expression.property.name));
       columns.push(column);
 
       if (Array.isArray(parameters)) {
@@ -264,6 +264,10 @@ export class KustoExpressionParser {
     }
   }
 
+  private escapeColumn(column: string) {
+    return column.includes(' ') ? `["${column}"]` : column
+  }
+
   private appendOperator(
     expression: QueryEditorOperatorExpression,
     parts: string[],
@@ -275,7 +279,7 @@ export class KustoExpressionParser {
     if (!property.name || !operator.name) {
       return;
     }
-    const propertyName = property.name.includes(' ') ? `["${property.name}"]` : property.name
+    const propertyName = this.escapeColumn(property.name)
 
     switch (operator.name) {
       case 'isnotempty':

--- a/src/datasource.ts
+++ b/src/datasource.ts
@@ -11,7 +11,7 @@ import { BackendSrv, DataSourceWithBackend, getBackendSrv, getTemplateSrv, Templ
 import { firstStringFieldToMetricFindValue } from 'common/responseHelpers';
 import { QueryEditorPropertyExpression } from 'editor/expressions';
 import { QueryEditorOperator, QueryEditorPropertyType } from 'editor/types';
-import { KustoExpressionParser } from 'KustoExpressionParser';
+import { KustoExpressionParser, escapeColumn } from 'KustoExpressionParser';
 import { map } from 'lodash';
 import { AdxSchemaMapper } from 'schema/AdxSchemaMapper';
 import { cache } from 'schema/cache';
@@ -177,6 +177,10 @@ export class AdxDataSource extends DataSourceWithBackend<KustoQuery, AdxDataSour
     return functionSchemaParser(response.data as DataFrame[]);
   }
 
+  // private escapeColumn(column: string) {
+  //   return column.match(/[\s\.-]/) ? `["${column}"]` : column;
+  // }
+
   async getDynamicSchema(
     database: string,
     source: string,
@@ -188,9 +192,9 @@ export class AdxDataSource extends DataSourceWithBackend<KustoQuery, AdxDataSour
     const queryParts: string[] = [];
 
     const take = 'take 50000';
-    const where = `where ${columns.map((column) => `isnotnull(${column})`).join(' and ')}`;
-    const project = `project ${columns.map((column) => column).join(', ')}`;
-    const summarize = `summarize ${columns.map((column) => `buildschema(${column})`).join(', ')}`;
+    const where = `where ${columns.map((column) => `isnotnull(${escapeColumn(column)})`).join(' and ')}`;
+    const project = `project ${columns.map((column) => escapeColumn(column)).join(', ')}`;
+    const summarize = `summarize ${columns.map((column) => `buildschema(${escapeColumn(column)})`).join(', ')}`;
 
     queryParts.push(source);
     queryParts.push(take);

--- a/src/datasource.ts
+++ b/src/datasource.ts
@@ -177,10 +177,6 @@ export class AdxDataSource extends DataSourceWithBackend<KustoQuery, AdxDataSour
     return functionSchemaParser(response.data as DataFrame[]);
   }
 
-  // private escapeColumn(column: string) {
-  //   return column.match(/[\s\.-]/) ? `["${column}"]` : column;
-  // }
-
   async getDynamicSchema(
     database: string,
     source: string,

--- a/src/schema/AdxSchemaResolver.ts
+++ b/src/schema/AdxSchemaResolver.ts
@@ -73,15 +73,11 @@ export class AdxSchemaResolver {
         (column) => column.Name
       );
 
-      console.log('dynamic columns ', dynamicColumns);
-
       const schemaByColumn = await this.datasource.getDynamicSchema(
         databaseName,
         mapping?.name ?? tableName,
         dynamicColumns
       );
-
-      console.log('schemaByColumn ', schemaByColumn);
 
       return schema.OrderedColumns.reduce((columns: AdxColumnSchema[], column) => {
         const schemaForDynamicColumn = schemaByColumn[column.Name];

--- a/src/schema/AdxSchemaResolver.ts
+++ b/src/schema/AdxSchemaResolver.ts
@@ -73,11 +73,15 @@ export class AdxSchemaResolver {
         (column) => column.Name
       );
 
+      console.log('dynamic columns ', dynamicColumns);
+
       const schemaByColumn = await this.datasource.getDynamicSchema(
         databaseName,
         mapping?.name ?? tableName,
         dynamicColumns
       );
+
+      console.log('schemaByColumn ', schemaByColumn);
 
       return schema.OrderedColumns.reduce((columns: AdxColumnSchema[], column) => {
         const schemaForDynamicColumn = schemaByColumn[column.Name];


### PR DESCRIPTION
Started as a mob session, I finished work left.

![Screenshot from 2022-08-03 13-15-17](https://user-images.githubusercontent.com/4025665/182595096-8602c44e-28c6-4214-82ea-28f1f090d334.png)

This ended up no being so trivial because there are several corner cases, like queries used to get suggestions (`toAutoCompleteQuery`), columns that apart from having a space are `dynamic` or the additional handling made for macros in the backend.

I think I have added a test for all those cases but let me know if you spot something else!

Fixes #318