### PR TITLE
New editor: Add format selector

### DIFF
--- a/src/components/QueryEditor/QueryHeader.test.tsx
+++ b/src/components/QueryEditor/QueryHeader.test.tsx
@@ -70,4 +70,30 @@ describe('QueryEditor', () => {
       expect(onChange).toHaveBeenCalledWith(expect.objectContaining({ database: 'bar' }));
     });
   });
+
+  describe('format selector', () => {
+    it('should select a format', async () => {
+      const onChange = jest.fn();
+      render(<QueryHeader {...defaultProps} onChange={onChange} />);
+      const sel = await waitFor(() => screen.getByLabelText('Format as:'));
+      openMenu(sel);
+      screen.getByText('Time series').click();
+      expect(onChange).toHaveBeenCalledWith(expect.objectContaining({ resultFormat: 'time_series' }));
+    });
+
+    it('should select handle ADX time series format', async () => {
+      const onChange = jest.fn();
+      let query = { ...defaultProps.query, rawMode: true };
+      const { rerender } = render(<QueryHeader {...defaultProps} onChange={onChange} query={query} />);
+      const sel = await waitFor(() => screen.getByLabelText('Format as:'));
+      openMenu(sel);
+      screen.getByText('ADX Time series').click();
+      expect(onChange).toHaveBeenCalledWith(expect.objectContaining({ resultFormat: 'time_series_adx_series' }));
+      // simulate change of mode
+      query = { ...defaultProps.query, rawMode: false, resultFormat: 'time_series_adx_series' };
+      rerender(<QueryHeader {...defaultProps} onChange={onChange} query={query} />);
+      // it should change to time_series since it's using the visual editor
+      expect(onChange).toHaveBeenCalledWith(expect.objectContaining({ resultFormat: 'time_series' }));
+    });
+  });
 });

--- a/src/components/QueryEditor/QueryHeader.tsx
+++ b/src/components/QueryEditor/QueryHeader.tsx
@@ -43,12 +43,15 @@ export const QueryHeader = (props: QueryEditorHeaderProps) => {
       setFormats(EDITOR_FORMATS.concat(adxTimeFormat));
     } else {
       setFormats(EDITOR_FORMATS);
-      if (query.resultFormat === adxTimeFormat.value) {
-        // Fallback to Time Series since time_series_adx_series is not available
-        onChange({ ...query, resultFormat: 'time_series' });
-      }
     }
   }, [rawMode]);
+
+  useEffect(() => {
+    if (query.resultFormat === adxTimeFormat.value && !formats.includes(adxTimeFormat)) {
+      // Fallback to Time Series since time_series_adx_series is not available
+      onChange({ ...query, resultFormat: 'time_series' });
+    }
+  }, [query, formats, onChange]);
 
   return (
     <EditorHeader>

--- a/src/components/QueryEditor/QueryHeader.tsx
+++ b/src/components/QueryEditor/QueryHeader.tsx
@@ -1,4 +1,4 @@
-import React, { useMemo } from 'react';
+import React, { useMemo, useState, useEffect } from 'react';
 
 import { EditorHeader, FlexItem, InlineSelect, RadioButtonGroup } from '@grafana/ui';
 
@@ -8,6 +8,7 @@ import { AdxDataSource } from 'datasource';
 import { QueryEditorPropertyDefinition } from 'schema/types';
 import { useAsync } from 'react-use';
 import { databaseToDefinition } from 'schema/mapper';
+import { SelectableValue } from '@grafana/data';
 
 export interface QueryEditorHeaderProps {
   datasource: AdxDataSource;
@@ -21,10 +22,33 @@ const EDITOR_MODES = [
   { label: 'KQL', value: EditorMode.Raw },
 ];
 
+const EDITOR_FORMATS: Array<SelectableValue<string>> = [
+  { label: 'Table', value: 'table' },
+  { label: 'Time series', value: 'time_series' },
+];
+
+const adxTimeFormat: SelectableValue<string> = {
+  label: 'ADX Time series',
+  value: 'time_series_adx_series',
+};
+
 export const QueryHeader = (props: QueryEditorHeaderProps) => {
   const { query, onChange, schema, datasource } = props;
+  const { rawMode } = query;
   const databases = useDatabaseOptions(schema.value);
   const database = useSelectedDatabase(databases, props.query, datasource);
+  const [formats, setFormats] = useState(EDITOR_FORMATS);
+  useEffect(() => {
+    if (rawMode) {
+      setFormats(EDITOR_FORMATS.concat(adxTimeFormat));
+    } else {
+      setFormats(EDITOR_FORMATS);
+      if (query.resultFormat === adxTimeFormat.value) {
+        // Fallback to Time Series since time_series_adx_series is not available
+        onChange({ ...query, resultFormat: 'time_series' });
+      }
+    }
+  }, [rawMode]);
 
   return (
     <EditorHeader>
@@ -35,6 +59,14 @@ export const QueryHeader = (props: QueryEditorHeaderProps) => {
         isLoading={schema.loading}
         onChange={({ value }) => {
           onChange({ ...query, database: value! });
+        }}
+      />
+      <InlineSelect
+        label="Format as"
+        options={formats}
+        value={query.resultFormat}
+        onChange={({ value }) => {
+          onChange({ ...query, resultFormat: value! });
         }}
       />
       <FlexItem grow={1} />


### PR DESCRIPTION
Ref: #391 

Adding the "Format as" selector, maintaining existing logic. I added it to the header since it's common for both visual and KLQ editor: 

![Screenshot from 2022-08-10 16-21-35](https://user-images.githubusercontent.com/4025665/183925842-d876e6ce-c6de-4089-a6f3-42c14e628bcc.png)
