### PR TITLE
Bug fix: change table when changing the database

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change Log
 
+## [4.1.5]
+
+- Fix: Update table in the KQL expression when changing the database.
+
 ## [4.1.4]
 
 - Change the default format to table data to avoid accidental high consumption of memory.

--- a/cypress/integration/smoke.spec.ts
+++ b/cypress/integration/smoke.spec.ts
@@ -69,6 +69,7 @@ e2e.scenario({
         e2e.flows.addPanel({
           matchScreenshot: false,
           visitDashboardAtStart: false,
+          dataSourceName: '', // avoid issue selecting the data source before the editor is fully loaded
           queriesForm: () => {
             e2eSelectors.queryEditor.database.input().click({ force: true });
             cy.contains('PerfTest').click({ force: true });
@@ -115,6 +116,7 @@ e2e.scenario({
         e2e.flows.addPanel({
           matchScreenshot: false,
           visitDashboardAtStart: false,
+          dataSourceName: '', // avoid issue selecting the data source before the editor is fully loaded
           queriesForm: () => {
             e2eSelectors.queryEditor.database.input().click({ force: true });
             cy.contains('PerfTest').click({ force: true });

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "grafana-azure-data-explorer-datasource",
-  "version": "4.1.4",
+  "version": "4.1.5",
   "description": "Grafana data source for Azure Data Explorer",
   "scripts": {
     "build": "grafana-toolkit plugin:build",

--- a/src/components/LegacyQueryEditor/VisualQueryEditor.tsx
+++ b/src/components/LegacyQueryEditor/VisualQueryEditor.tsx
@@ -80,14 +80,13 @@ export const VisualQueryEditor: React.FC<Props> = (props) => {
     const name = tableMapping?.value ?? tableName;
     const schema = await getTableSchema(datasource, databaseName, name);
     const expression = query.expression ?? defaultQuery.expression;
-    const from = expression.from ?? table;
 
     onChangeQuery({
       ...query,
       query: parseExpression(
         {
           ...expression,
-          from,
+          from: table,
         },
         schema
       ),


### PR DESCRIPTION
When changing the database, the table in the expression generated was not being changed, producing a wrong query.

Uncovered after #440 since before, the table was not saved in the expression before changing the database in the e2e test.

Note that this fixes `main`.
