### PR TITLE
Improve parsing of configuration variables

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change Log
 
+## [4.1.6]
+
+- Fix: Appropriately parse boolean configuration variables when instantiating datasource.
+
 ## [4.1.5]
 
 - Fix: Update table in the KQL expression when changing the database.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "grafana-azure-data-explorer-datasource",
-  "version": "4.1.5",
+  "version": "4.1.6",
   "description": "Grafana data source for Azure Data Explorer",
   "scripts": {
     "build": "grafana-toolkit plugin:build",

--- a/pkg/azuredx/models/settings.go
+++ b/pkg/azuredx/models/settings.go
@@ -3,6 +3,7 @@ package models
 import (
 	"encoding/json"
 	"fmt"
+	"strconv"
 	"time"
 
 	"github.com/grafana/grafana-plugin-sdk-go/backend"
@@ -42,10 +43,67 @@ type DatasourceSettings struct {
 // It also sets the QueryTimeout and ServerTimeoutValues by parsing QueryTimeoutRaw.
 func (d *DatasourceSettings) Load(config backend.DataSourceInstanceSettings) error {
 	var err error
+	var jsonData map[string]interface{}
 	if config.JSONData != nil && len(config.JSONData) > 1 {
-		if err := json.Unmarshal(config.JSONData, d); err != nil {
+		if err := json.Unmarshal(config.JSONData, &jsonData); err != nil {
 			return fmt.Errorf("could not unmarshal DatasourceSettings json: %w", err)
 		}
+	}
+
+	if jsonData["clientId"] != nil {
+		d.ClientID = jsonData["clientId"].(string)
+	}
+	if jsonData["tenantId"] != nil {
+		d.TenantID = jsonData["tenantId"].(string)
+	}
+	if jsonData["clusterUrl"] != nil {
+		d.ClusterURL = jsonData["clusterUrl"].(string)
+	}
+	if jsonData["defaultDatabase"] != nil {
+		d.DefaultDatabase = jsonData["defaultDatabase"].(string)
+	}
+	if jsonData["dataConsistency"] != nil {
+		d.DataConsistency = jsonData["dataConsistency"].(string)
+	}
+	if jsonData["cacheMaxAge"] != nil {
+		d.CacheMaxAge = jsonData["cacheMaxAge"].(string)
+	}
+	if jsonData["dynamicCaching"] != nil {
+		if dynamicCaching, err := strconv.ParseBool(jsonData["dynamicCaching"].(string)); err == nil {
+			d.DynamicCaching = dynamicCaching
+		} else {
+			return fmt.Errorf("could not parse DynamicCaching value: %w", err)
+		}
+
+	}
+	if jsonData["enableUserTracking"] != nil {
+		if enableUserTracking, err := strconv.ParseBool(jsonData["enableUserTracking"].(string)); err == nil {
+			d.EnableUserTracking = enableUserTracking
+		} else {
+			return fmt.Errorf("could not parse EnableUserTracking value: %w", err)
+		}
+
+	}
+	if jsonData["onBehalfOf"] != nil {
+		if onBehalfOf, err := strconv.ParseBool(jsonData["onBehalfOf"].(string)); err == nil {
+			d.OnBehalfOf = onBehalfOf
+		} else {
+			return fmt.Errorf("could not parse OnBehalf of value: %w", err)
+		}
+	}
+	if jsonData["oauthPassThru"] != nil {
+		if oauthPassThru, err := strconv.ParseBool(jsonData["oauthPassThru"].(string)); err == nil {
+			d.OAuthPassThru = oauthPassThru
+		} else {
+			return fmt.Errorf("could not parse OAuthPassThru value: %w", err)
+		}
+
+	}
+	if jsonData["azureCloud"] != nil {
+		d.AzureCloud = jsonData["azureCloud"].(string)
+	}
+	if jsonData["queryTimeout"] != nil {
+		d.QueryTimeoutRaw = jsonData["queryTimeout"].(string)
 	}
 
 	if d.QueryTimeoutRaw == "" {


### PR DESCRIPTION
When instantiating a new datasource the current flow assumes that all input variables in the config `JSONData` are of the correct type. This leads to the creation of the datasource failing if an environment variable is used to provide a value for a property that is of type `bool`.

Fixes #442 