### PR TITLE
Visual Editor: Table selector

### DIFF
--- a/src/components/QueryEditor/QueryEditor.tsx
+++ b/src/components/QueryEditor/QueryEditor.tsx
@@ -9,6 +9,7 @@ import { AdxDataSourceOptions, EditorMode, KustoQuery } from 'types';
 import { AdxDataSource } from '../../datasource';
 import { QueryHeader } from './QueryHeader';
 import { RawQueryEditor } from './RawQueryEditor';
+import { VisualQueryEditor } from './VisualQueryEditor';
 
 type Props = QueryEditorProps<AdxDataSource, KustoQuery, AdxDataSourceOptions>;
 
@@ -54,7 +55,12 @@ export const QueryEditor: React.FC<Props> = (props) => {
           setDirty={() => !dirty && setDirty(true)}
         />
       ) : (
-        <>[VISUAL EDITOR] To be implemented</>
+        <VisualQueryEditor
+          {...props}
+          schema={schema.value}
+          database={query.database}
+          templateVariableOptions={templateVariables}
+        />
       )}
     </>
   );

--- a/src/components/QueryEditor/VisualQueryEditor.test.tsx
+++ b/src/components/QueryEditor/VisualQueryEditor.test.tsx
@@ -1,0 +1,60 @@
+import { render, screen, waitFor } from '@testing-library/react';
+import React from 'react';
+import { VisualQueryEditor } from './VisualQueryEditor';
+import { mockDatasource, mockQuery } from '../__fixtures__/Datasource';
+
+jest.mock('@grafana/runtime', () => {
+  const original = jest.requireActual('@grafana/runtime');
+  return {
+    ...original,
+    getTemplateSrv: () => ({
+      getVariables: () => [],
+      replace: (s: string) => s,
+    }),
+  };
+});
+
+const defaultProps = {
+  database: '',
+  query: mockQuery,
+  onChange: jest.fn(),
+  onRunQuery: jest.fn(),
+  datasource: mockDatasource(),
+  templateVariableOptions: {},
+};
+
+const schema = {
+  Databases: {
+    foo: {
+      Name: 'foo',
+      Tables: {
+        bar: {
+          Name: 'bar',
+          OrderedColumns: [
+            {
+              Name: 'foobar',
+              CslType: 'string',
+            },
+          ],
+        },
+      },
+      ExternalTables: {},
+      Functions: {},
+      MaterializedViews: {},
+    },
+  },
+};
+
+describe('VisualQueryEditor', () => {
+  it('should render the VisualQueryEditor', async () => {
+    render(<VisualQueryEditor {...defaultProps} schema={{ Databases: {} }} />);
+    await waitFor(() => screen.getByText('Table schema loaded successfully but without any columns'));
+  });
+
+  it('should render the VisualQueryEditor with a schema', async () => {
+    const datasource = mockDatasource();
+    datasource.getSchema = jest.fn().mockResolvedValue(schema);
+    render(<VisualQueryEditor {...defaultProps} datasource={datasource} database="foo" schema={schema} />);
+    await waitFor(() => screen.getByText('bar'));
+  });
+});

--- a/src/components/QueryEditor/VisualQueryEditor.tsx
+++ b/src/components/QueryEditor/VisualQueryEditor.tsx
@@ -1,0 +1,150 @@
+import { QueryEditorProps, SelectableValue } from '@grafana/data';
+import { getTemplateSrv } from '@grafana/runtime';
+import { Alert, EditorField, EditorFieldGroup, EditorRow, EditorRows, Select } from '@grafana/ui';
+import { QueryEditorExpressionType } from 'components/LegacyQueryEditor/editor/expressions';
+import { AdxDataSource } from 'datasource';
+import React, { useMemo } from 'react';
+import { useAsync } from 'react-use';
+import { AdxSchemaResolver } from 'schema/AdxSchemaResolver';
+import { QueryEditorPropertyDefinition, QueryEditorPropertyType } from 'schema/types';
+import { AdxDataSourceOptions, AdxSchema, defaultQuery, KustoQuery } from 'types';
+
+type Props = QueryEditorProps<AdxDataSource, KustoQuery, AdxDataSourceOptions>;
+
+interface VisualQueryEditorProps extends Props {
+  schema?: AdxSchema;
+  database: string;
+  templateVariableOptions: SelectableValue<string>;
+}
+
+export const VisualQueryEditor: React.FC<VisualQueryEditorProps> = (props) => {
+  const templateSrv = getTemplateSrv();
+  const { schema, database, datasource, query, onChange, templateVariableOptions } = props;
+  const { id: datasourceId, parseExpression, getSchemaMapper } = datasource;
+  const databaseName = templateSrv.replace(database);
+  const tables = useTableOptions(schema, databaseName, datasource);
+  const table = useSelectedTable(tables, query, datasource);
+  const tableOptions = (tables as SelectableValue<string>[]).concat(templateVariableOptions);
+  const tableName = getTemplateSrv().replace(table?.value ?? '');
+  const tableMapping = getSchemaMapper().getMappingByValue(table?.value);
+  const tableSchema = useAsync(async () => {
+    if (!table || !table.value) {
+      return [];
+    }
+
+    const name = tableMapping?.value ?? tableName;
+    const schema = await getTableSchema(datasource, databaseName, name);
+    const expression = query.expression ?? defaultQuery.expression;
+
+    onChange({
+      ...query,
+      query: parseExpression(
+        {
+          ...expression,
+          from: {
+            type: QueryEditorExpressionType.Property,
+            property: { type: QueryEditorPropertyType.String, name: table.value },
+          },
+        },
+        schema
+      ),
+    });
+
+    return schema;
+  }, [datasourceId, databaseName, tableName, tableMapping?.value]);
+
+  if (!schema) {
+    return null;
+  }
+
+  return (
+    <EditorRows>
+      <EditorRow>
+        <EditorFieldGroup>
+          {tableSchema.error && (
+            <Alert severity="error" title="Could not load table schema">
+              {tableSchema.error?.message}
+            </Alert>
+          )}
+          {!tableSchema.loading && tableSchema.value?.length === 0 && (
+            <Alert severity="warning" title="Table schema loaded successfully but without any columns" />
+          )}
+          <EditorField label="Table" width={16}>
+            <Select
+              aria-label="Table"
+              isLoading={tableSchema.loading}
+              value={table}
+              options={tableOptions}
+              allowCustomValue
+              onChange={({ value }) => {
+                onChange({
+                  ...query,
+                  expression: {
+                    ...defaultQuery.expression,
+                    from: {
+                      type: QueryEditorExpressionType.Property,
+                      property: { type: QueryEditorPropertyType.String, name: value },
+                    },
+                  },
+                });
+              }}
+            />
+          </EditorField>
+        </EditorFieldGroup>
+      </EditorRow>
+    </EditorRows>
+  );
+};
+
+const useTableOptions = (
+  schema: AdxSchema | undefined,
+  database: string,
+  datasource: AdxDataSource
+): QueryEditorPropertyDefinition[] => {
+  const mapper = datasource.getSchemaMapper();
+
+  return useMemo(() => {
+    if (!schema || !schema.Databases) {
+      return [];
+    }
+    return mapper.getTableOptions(schema, database);
+  }, [database, schema, mapper]);
+};
+
+const useSelectedTable = (
+  options: QueryEditorPropertyDefinition[],
+  query: KustoQuery,
+  datasource: AdxDataSource
+): SelectableValue<string> | undefined => {
+  const variables = datasource.getVariables();
+
+  const table = query.expression?.from?.property.name;
+
+  return useMemo(() => {
+    const selected = options.find((option) => option.value === table);
+
+    if (selected) {
+      return selected;
+    }
+
+    const variable = variables.find((variable) => variable === table);
+
+    if (variable) {
+      return {
+        label: variable,
+        value: variable,
+      };
+    }
+
+    if (options.length > 0) {
+      return options[0];
+    }
+
+    return;
+  }, [options, table, variables]);
+};
+
+async function getTableSchema(datasource: AdxDataSource, databaseName: string, tableName: string) {
+  const schemaResolver = new AdxSchemaResolver(datasource);
+  return await schemaResolver.getColumnsForTable(databaseName, tableName);
+}

--- a/src/components/QueryEditor/VisualQueryEditor.tsx
+++ b/src/components/QueryEditor/VisualQueryEditor.tsx
@@ -24,7 +24,7 @@ export const VisualQueryEditor: React.FC<VisualQueryEditorProps> = (props) => {
   const databaseName = templateSrv.replace(database);
   const tables = useTableOptions(schema, databaseName, datasource);
   const table = useSelectedTable(tables, query, datasource);
-  const tableOptions = (tables as SelectableValue<string>[]).concat(templateVariableOptions);
+  const tableOptions = (tables as Array<SelectableValue<string>>).concat(templateVariableOptions);
   const tableName = getTemplateSrv().replace(table?.value ?? '');
   const tableMapping = getSchemaMapper().getMappingByValue(table?.value);
   const tableSchema = useAsync(async () => {

--- a/src/components/QueryEditor/VisualQueryEditor.tsx
+++ b/src/components/QueryEditor/VisualQueryEditor.tsx
@@ -59,16 +59,16 @@ export const VisualQueryEditor: React.FC<VisualQueryEditorProps> = (props) => {
 
   return (
     <EditorRows>
+      {tableSchema.error && (
+        <Alert severity="error" title="Could not load table schema">
+          {tableSchema.error?.message}
+        </Alert>
+      )}
+      {!tableSchema.loading && tableSchema.value?.length === 0 && (
+        <Alert severity="warning" title="Table schema loaded successfully but without any columns" />
+      )}
       <EditorRow>
         <EditorFieldGroup>
-          {tableSchema.error && (
-            <Alert severity="error" title="Could not load table schema">
-              {tableSchema.error?.message}
-            </Alert>
-          )}
-          {!tableSchema.loading && tableSchema.value?.length === 0 && (
-            <Alert severity="warning" title="Table schema loaded successfully but without any columns" />
-          )}
           <EditorField label="Table" width={16}>
             <Select
               aria-label="Table"


### PR DESCRIPTION
First component of the visual editor, the table selector:

![Screenshot from 2022-08-22 16-53-49](https://user-images.githubusercontent.com/4025665/185953042-86a5b86d-14a8-44de-bf74-0fd6d5147f1a.png)

The code is a small adaptation of the one already existing in the LegacyEditor, the only changes are visual.

Additional notes:

I considered changing how the query is structured and avoid the `expression` definition which is a bit complex (basically an `expression` object can define anything, from a table selection to a summarize function). At the end I decided not to go that path for two major reasons: It would be reinventing the wheel, having to re-define the Kusto parser and it would also require to migrate queries based on `expressions` to the new format, which doesn't help with the complexity of the code to maintain.

Also:

The `VisualQueryEditor` component is likely to get huge so I may move this code to another subcomponent in the future. I haven't done that yet since I prefer to have the full layout first.