### PR TITLE
New editor: Filters

### DIFF
--- a/src/KustoExpressionParser.ts
+++ b/src/KustoExpressionParser.ts
@@ -46,9 +46,11 @@ export class KustoExpressionParser {
     this.appendProperty(context, query.expression.from, parts);
     this.appendTimeFilter(context, undefined, parts, tableSchema);
 
-    const where = replaceByIndex(query.index, query.expression.where, query.search);
+    if (query.index) {
+      const where = replaceByIndex(query.index, query.expression.where, query.search);
+      this.appendWhere(context, where, parts, 'where');
+    }
     const column = query.search.property.name;
-    this.appendWhere(context, where, parts, 'where');
 
     parts.push('take 50000');
     parts.push(`distinct ${context.castIfDynamic(column)}`);

--- a/src/components/QueryEditor/VisualQueryEditor.tsx
+++ b/src/components/QueryEditor/VisualQueryEditor.tsx
@@ -8,6 +8,7 @@ import { useAsync } from 'react-use';
 import { AdxSchemaResolver } from 'schema/AdxSchemaResolver';
 import { QueryEditorPropertyDefinition, QueryEditorPropertyType } from 'schema/types';
 import { AdxDataSourceOptions, AdxSchema, defaultQuery, KustoQuery } from 'types';
+import FilterSection from './VisualQueryEditor/FilterSection';
 
 type Props = QueryEditorProps<AdxDataSource, KustoQuery, AdxDataSourceOptions>;
 
@@ -92,6 +93,9 @@ export const VisualQueryEditor: React.FC<VisualQueryEditorProps> = (props) => {
           </EditorField>
         </EditorFieldGroup>
       </EditorRow>
+      <FilterSection {...props} tableSchema={tableSchema} />
+      {/* TODO: Use proper preview component */}
+      <pre>{query.query}</pre>
     </EditorRows>
   );
 };

--- a/src/components/QueryEditor/VisualQueryEditor/FilterItem.test.tsx
+++ b/src/components/QueryEditor/VisualQueryEditor/FilterItem.test.tsx
@@ -1,0 +1,94 @@
+import { render, screen } from '@testing-library/react';
+import { mockDatasource, mockQuery } from 'components/__fixtures__/Datasource';
+import { AdxColumnSchema } from 'types';
+import FilterItem from './FilterItem';
+import React from 'react';
+import { openMenu } from 'react-select-event';
+import { QueryEditorPropertyType } from 'schema/types';
+import userEvent from '@testing-library/user-event';
+
+const defaultProps = {
+  datasource: mockDatasource(),
+  query: mockQuery,
+  filter: {},
+  columns: [],
+  templateVariableOptions: {},
+  onChange: jest.fn(),
+  onDelete: jest.fn(),
+};
+
+describe('FilterItem', () => {
+  it('should select a column', () => {
+    const onChange = jest.fn();
+    const columns: AdxColumnSchema[] = [
+      {
+        Name: 'foo',
+        CslType: 'string',
+      },
+    ];
+    render(<FilterItem {...defaultProps} columns={columns} onChange={onChange} />);
+    const sel = screen.getByLabelText('column');
+    openMenu(sel);
+    screen.getByText('foo').click();
+    expect(onChange).toHaveBeenCalledWith(
+      expect.objectContaining({ property: { name: 'foo', type: QueryEditorPropertyType.String } })
+    );
+  });
+
+  it('should select an operator', () => {
+    const onChange = jest.fn();
+    render(<FilterItem {...defaultProps} onChange={onChange} />);
+    const sel = screen.getByLabelText('operator');
+    openMenu(sel);
+    screen.getByText('!=').click();
+    expect(onChange).toHaveBeenCalledWith(expect.objectContaining({ operator: { name: '!=', value: '' } }));
+  });
+
+  it('should select a value', async () => {
+    const datasource = mockDatasource();
+    datasource.autoCompleteQuery = jest.fn().mockResolvedValue(['foo', 'bar']);
+    const onChange = jest.fn();
+    const filter = { property: { name: 'col', type: QueryEditorPropertyType.String } };
+    render(<FilterItem {...defaultProps} datasource={datasource} onChange={onChange} filter={filter} />);
+    const sel = screen.getByLabelText('column value');
+    openMenu(sel);
+    (await screen.findByText('foo')).click();
+    expect(onChange).toHaveBeenCalledWith(expect.objectContaining({ operator: { name: '==', value: 'foo' } }));
+  });
+
+  it('should select a template variable', async () => {
+    const datasource = mockDatasource();
+    datasource.autoCompleteQuery = jest.fn().mockResolvedValue([]);
+    const onChange = jest.fn();
+    const filter = { property: { name: 'col', type: QueryEditorPropertyType.String } };
+    const templateVariableOptions = {
+      label: 'Template Variables',
+      options: [{ label: '$foo', value: '$foo' }],
+    };
+    render(
+      <FilterItem
+        {...defaultProps}
+        datasource={datasource}
+        onChange={onChange}
+        filter={filter}
+        templateVariableOptions={templateVariableOptions}
+      />
+    );
+    const sel = screen.getByLabelText('column value');
+    openMenu(sel);
+    (await screen.findByText('Template Variables')).click();
+    (await screen.findByText('$foo')).click();
+    expect(onChange).toHaveBeenCalledWith(expect.objectContaining({ operator: { name: '==', value: "'$foo'" } }));
+  });
+
+  it('should select a template variable', async () => {
+    const datasource = mockDatasource();
+    datasource.autoCompleteQuery = jest.fn().mockResolvedValue([]);
+    const onChange = jest.fn();
+    const filter = { property: { name: 'col', type: QueryEditorPropertyType.Number } };
+    render(<FilterItem {...defaultProps} datasource={datasource} onChange={onChange} filter={filter} />);
+    const input = screen.getByLabelText('column number value');
+    userEvent.type(input, '1{enter}');
+    expect(onChange).toHaveBeenCalledWith(expect.objectContaining({ operator: { name: '==', value: 1 } }));
+  });
+});

--- a/src/components/QueryEditor/VisualQueryEditor/FilterItem.test.tsx
+++ b/src/components/QueryEditor/VisualQueryEditor/FilterItem.test.tsx
@@ -81,7 +81,7 @@ describe('FilterItem', () => {
     expect(onChange).toHaveBeenCalledWith(expect.objectContaining({ operator: { name: '==', value: "'$foo'" } }));
   });
 
-  it('should select a template variable', async () => {
+  it('type a numeric value', async () => {
     const datasource = mockDatasource();
     datasource.autoCompleteQuery = jest.fn().mockResolvedValue([]);
     const onChange = jest.fn();

--- a/src/components/QueryEditor/VisualQueryEditor/FilterItem.test.tsx
+++ b/src/components/QueryEditor/VisualQueryEditor/FilterItem.test.tsx
@@ -88,7 +88,18 @@ describe('FilterItem', () => {
     const filter = { property: { name: 'col', type: QueryEditorPropertyType.Number } };
     render(<FilterItem {...defaultProps} datasource={datasource} onChange={onChange} filter={filter} />);
     const input = screen.getByLabelText('column number value');
-    userEvent.type(input, '1{enter}');
+    userEvent.type(input, '1');
     expect(onChange).toHaveBeenCalledWith(expect.objectContaining({ operator: { name: '==', value: 1 } }));
+  });
+
+  it('type a datetime value', async () => {
+    const datasource = mockDatasource();
+    datasource.autoCompleteQuery = jest.fn().mockResolvedValue([]);
+    const onChange = jest.fn();
+    const filter = { property: { name: 'col', type: QueryEditorPropertyType.DateTime } };
+    render(<FilterItem {...defaultProps} datasource={datasource} onChange={onChange} filter={filter} />);
+    const input = screen.getByLabelText('column datetime value');
+    userEvent.type(input, '1');
+    expect(onChange).toHaveBeenCalledWith(expect.objectContaining({ operator: { name: '==', value: '1' } }));
   });
 });

--- a/src/components/QueryEditor/VisualQueryEditor/FilterItem.tsx
+++ b/src/components/QueryEditor/VisualQueryEditor/FilterItem.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { useAsyncFn } from 'react-use';
 
 import { SelectableValue, toOption } from '@grafana/data';
-import { AccessoryButton, AutoSizeInput, InputGroup, Select } from '@grafana/ui';
+import { AccessoryButton, Input, InputGroup, Select } from '@grafana/ui';
 
 import { AdxDataSource } from '../../../datasource';
 import { AdxColumnSchema, KustoQuery } from '../../../types';
@@ -64,6 +64,9 @@ const FilterItem: React.FC<FilterItemProps> = (props) => {
 
   const [state, loadOptions] = useAsyncFn(loadValues, [query, filter.property]);
 
+  const isNumber = filter.property?.type === QueryEditorPropertyType.Number;
+  const isDatetime = filter.property?.type === QueryEditorPropertyType.DateTime;
+  const isOther = !isNumber && !isDatetime;
   return (
     <InputGroup>
       <Select
@@ -81,17 +84,26 @@ const FilterItem: React.FC<FilterItemProps> = (props) => {
         options={toOperatorOptions(filter.property?.type)}
         onChange={({ value }) => value && onChange(setOperatorExpressionName(filter, value))}
       />
-      <div hidden={filter.property?.type !== QueryEditorPropertyType.Number}>
-        <AutoSizeInput
+      <div hidden={!isDatetime}>
+        <Input
+          aria-label="column datetime value"
+          value={typeof filter.operator?.value === 'string' ? filter.operator.value : ''}
+          onChange={(e) => {
+            onChange(setOperatorExpressionValue(filter, e.currentTarget.value));
+          }}
+        />
+      </div>
+      <div hidden={!isNumber}>
+        <Input
           aria-label="column number value"
-          value={(filter.operator?.value && parseInt(filter.operator.value.toString(), 10)) || 0}
+          value={typeof filter.operator?.value === 'number' ? filter.operator.value : 0}
           type="number"
-          onCommitChange={(e) => {
+          onChange={(e) => {
             onChange(setOperatorExpressionValue(filter, parseInt(e.currentTarget.value, 10)));
           }}
         />
       </div>
-      <div hidden={filter.property?.type === QueryEditorPropertyType.Number}>
+      <div hidden={!isOther}>
         <Select
           aria-label="column value"
           width="auto"

--- a/src/components/QueryEditor/VisualQueryEditor/FilterItem.tsx
+++ b/src/components/QueryEditor/VisualQueryEditor/FilterItem.tsx
@@ -1,0 +1,114 @@
+import React from 'react';
+import { useAsyncFn } from 'react-use';
+
+import { SelectableValue, toOption } from '@grafana/data';
+import { AccessoryButton, AutoSizeInput, InputGroup, Select } from '@grafana/ui';
+
+import { AdxDataSource } from '../../../datasource';
+import { AdxColumnSchema, KustoQuery } from '../../../types';
+import {
+  QueryEditorExpressionType,
+  QueryEditorOperatorExpression,
+} from 'components/LegacyQueryEditor/editor/expressions';
+import {
+  getOperatorExpressionOptions,
+  getOperatorExpressionValue,
+  setOperatorExpressionName,
+  setOperatorExpressionProperty,
+  setOperatorExpressionValue,
+} from './utils/utils';
+import { isMulti, toOperatorOptions } from './utils/operators';
+import { columnsToDefinition, valueToDefinition } from 'schema/mapper';
+import { QueryEditorPropertyType } from 'schema/types';
+
+interface FilterItemProps {
+  datasource: AdxDataSource;
+  query: KustoQuery;
+  filter: Partial<QueryEditorOperatorExpression>;
+  columns: AdxColumnSchema[] | undefined;
+  templateVariableOptions: SelectableValue<string>;
+  onChange: (item: QueryEditorOperatorExpression) => void;
+  onDelete: () => void;
+}
+
+const FilterItem: React.FC<FilterItemProps> = (props) => {
+  const { datasource, query, filter, onChange, onDelete, columns, templateVariableOptions } = props;
+
+  const loadValues = async () => {
+    if (!filter.property?.name) {
+      return [];
+    }
+
+    return datasource
+      .autoCompleteQuery(
+        {
+          ...query,
+          search: {
+            operator: { name: 'isnotempty', value: '' },
+            property: { name: filter.property?.name, type: filter.property.type },
+            type: QueryEditorExpressionType.Operator,
+          },
+        },
+        columns
+      )
+      .then((result: string[]) => {
+        if (Array.isArray(templateVariableOptions.options) && filter.property?.type === 'string') {
+          // When selecting a string, automatically quote template variables to generate a valid syntax
+          templateVariableOptions.options = templateVariableOptions.options.map((op: SelectableValue<string>) => {
+            return { label: op.value, value: `'${op.value}'` };
+          });
+        }
+        return result.map((r): SelectableValue<string> => ({ label: r, value: r })).concat(templateVariableOptions);
+      });
+  };
+
+  const [state, loadOptions] = useAsyncFn(loadValues, [query, filter.property]);
+
+  return (
+    <InputGroup>
+      <Select
+        aria-label="column"
+        width="auto"
+        value={filter.property?.name ? valueToDefinition(filter.property?.name) : null}
+        options={columns ? columnsToDefinition(columns) : []}
+        allowCustomValue
+        onChange={(e) => e.value && onChange(setOperatorExpressionProperty(filter, e.value, e.type))}
+      />
+      <Select
+        aria-label="operator"
+        width="auto"
+        value={filter.operator?.name && toOption(filter.operator.name)}
+        options={toOperatorOptions(filter.property?.type)}
+        onChange={({ value }) => value && onChange(setOperatorExpressionName(filter, value))}
+      />
+      <div hidden={filter.property?.type !== QueryEditorPropertyType.Number}>
+        <AutoSizeInput
+          aria-label="column number value"
+          value={(filter.operator?.value && parseInt(filter.operator.value.toString(), 10)) || 0}
+          type="number"
+          onCommitChange={(e) => {
+            onChange(setOperatorExpressionValue(filter, parseInt(e.currentTarget.value, 10)));
+          }}
+        />
+      </div>
+      <div hidden={filter.property?.type === QueryEditorPropertyType.Number}>
+        <Select
+          aria-label="column value"
+          width="auto"
+          isLoading={state.loading}
+          value={getOperatorExpressionValue(filter.operator?.value)}
+          options={getOperatorExpressionOptions(state.value, filter.operator?.value)}
+          allowCustomValue
+          onOpenMenu={loadOptions}
+          onChange={(e: SelectableValue<string> | Array<SelectableValue<string>>) =>
+            onChange(setOperatorExpressionValue(filter, e))
+          }
+          isMulti={isMulti(filter.operator?.name)}
+        />
+      </div>
+      <AccessoryButton aria-label="remove" icon="times" variant="secondary" onClick={onDelete} />
+    </InputGroup>
+  );
+};
+
+export default FilterItem;

--- a/src/components/QueryEditor/VisualQueryEditor/FilterItem.tsx
+++ b/src/components/QueryEditor/VisualQueryEditor/FilterItem.tsx
@@ -2,7 +2,8 @@ import React from 'react';
 import { useAsyncFn } from 'react-use';
 
 import { SelectableValue, toOption } from '@grafana/data';
-import { AccessoryButton, Input, InputGroup, Select } from '@grafana/ui';
+import { Input, Select } from '@grafana/ui';
+import { AccessoryButton, InputGroup } from '@grafana/experimental';
 
 import { AdxDataSource } from '../../../datasource';
 import { AdxColumnSchema, KustoQuery } from '../../../types';

--- a/src/components/QueryEditor/VisualQueryEditor/FilterSection.test.tsx
+++ b/src/components/QueryEditor/VisualQueryEditor/FilterSection.test.tsx
@@ -1,0 +1,76 @@
+import { render, screen } from '@testing-library/react';
+import { QueryEditorExpressionType } from 'components/LegacyQueryEditor/editor/expressions';
+import { mockDatasource, mockQuery } from 'components/__fixtures__/Datasource';
+import React from 'react';
+import { QueryEditorPropertyType } from 'schema/types';
+import FilterSection from './FilterSection';
+
+const defaultProps = {
+  datasource: mockDatasource(),
+  query: mockQuery,
+  templateVariableOptions: {},
+  tableSchema: {
+    loading: false,
+  },
+  database: 'db',
+  onChange: jest.fn(),
+  onRunQuery: jest.fn(),
+};
+
+describe('FilterSection', () => {
+  it('should render a filter group per where expression', () => {
+    const query = {
+      ...mockQuery,
+      expression: {
+        ...mockQuery.expression,
+        where: {
+          expressions: [
+            {
+              expressions: [
+                {
+                  operator: { name: '==', value: 'foo' },
+                  property: {
+                    name: 'ActivityName',
+                    type: QueryEditorPropertyType.String,
+                  },
+                  type: QueryEditorExpressionType.Operator,
+                },
+              ],
+              type: QueryEditorExpressionType.Or,
+            },
+            {
+              expressions: [
+                {
+                  operator: { name: '==', value: 'bar' },
+                  property: {
+                    name: 'ID',
+                    type: QueryEditorPropertyType.String,
+                  },
+                  type: QueryEditorExpressionType.Operator,
+                },
+              ],
+              type: QueryEditorExpressionType.Or,
+            },
+          ],
+          type: QueryEditorExpressionType.And,
+        },
+      },
+    };
+    render(<FilterSection {...defaultProps} query={query} />);
+    expect(screen.getAllByText('Filter group')).toHaveLength(2);
+  });
+
+  it('should add a filter group', () => {
+    const onChange = jest.fn();
+    render(<FilterSection {...defaultProps} onChange={onChange} />);
+    const b = screen.getByRole('button');
+    b.click();
+    expect(onChange).toHaveBeenCalledWith(
+      expect.objectContaining({
+        expression: expect.objectContaining({
+          where: { expressions: [{ expressions: [{ expressions: [], type: 'or' }], type: 'or' }], type: 'and' },
+        }),
+      })
+    );
+  });
+});

--- a/src/components/QueryEditor/VisualQueryEditor/FilterSection.tsx
+++ b/src/components/QueryEditor/VisualQueryEditor/FilterSection.tsx
@@ -1,5 +1,6 @@
 import { QueryEditorProps, SelectableValue } from '@grafana/data';
-import { Button, EditorField, EditorFieldGroup, EditorRow } from '@grafana/ui';
+import { Button } from '@grafana/ui';
+import { EditorField, EditorFieldGroup, EditorRow } from '@grafana/experimental';
 import { QueryEditorExpressionType } from 'components/LegacyQueryEditor/editor/expressions';
 import { AdxDataSource } from 'datasource';
 import React from 'react';

--- a/src/components/QueryEditor/VisualQueryEditor/FilterSection.tsx
+++ b/src/components/QueryEditor/VisualQueryEditor/FilterSection.tsx
@@ -1,0 +1,77 @@
+import { QueryEditorProps, SelectableValue } from '@grafana/data';
+import { Button, EditorField, EditorFieldGroup, EditorRow } from '@grafana/ui';
+import { QueryEditorExpressionType } from 'components/LegacyQueryEditor/editor/expressions';
+import { AdxDataSource } from 'datasource';
+import React from 'react';
+import { AsyncState } from 'react-use/lib/useAsyncFn';
+import { AdxColumnSchema, AdxDataSourceOptions, KustoQuery } from 'types';
+import KQLFilter from './KQLFilter';
+
+type Props = QueryEditorProps<AdxDataSource, KustoQuery, AdxDataSourceOptions>;
+
+interface FilterSectionProps extends Props {
+  tableSchema: AsyncState<AdxColumnSchema[]>;
+  database: string;
+  templateVariableOptions: SelectableValue<string>;
+}
+
+const FilterSection: React.FC<FilterSectionProps> = ({
+  query,
+  onChange,
+  datasource,
+  tableSchema,
+  templateVariableOptions,
+}) => {
+  return (
+    <>
+      {query.expression.where.expressions.map((_, i) => (
+        <EditorRow key={`filter-${i}`}>
+          <EditorFieldGroup>
+            <EditorField
+              label="Filter group"
+              optional={true}
+              tooltip="Any of the conditions of the group should return true"
+            >
+              <KQLFilter
+                index={i}
+                query={query}
+                onChange={onChange}
+                datasource={datasource}
+                columns={tableSchema.value}
+                templateVariableOptions={templateVariableOptions}
+              />
+            </EditorField>
+          </EditorFieldGroup>
+        </EditorRow>
+      ))}
+      <EditorRow>
+        <EditorFieldGroup>
+          <EditorField label="Add filter group" optional={true} tooltip="All filter groups should return true">
+            <Button
+              variant="secondary"
+              icon="plus"
+              onClick={() => {
+                const expr = query.expression.where.expressions.concat({
+                  type: QueryEditorExpressionType.Or,
+                  expressions: [{ type: QueryEditorExpressionType.Or, expressions: [] }],
+                });
+                onChange({
+                  ...query,
+                  expression: {
+                    ...query.expression,
+                    where: {
+                      ...query.expression.where,
+                      expressions: expr,
+                    },
+                  },
+                });
+              }}
+            />
+          </EditorField>
+        </EditorFieldGroup>
+      </EditorRow>
+    </>
+  );
+};
+
+export default FilterSection;

--- a/src/components/QueryEditor/VisualQueryEditor/KQLFilter.test.tsx
+++ b/src/components/QueryEditor/VisualQueryEditor/KQLFilter.test.tsx
@@ -57,7 +57,7 @@ describe('KQLFilter', () => {
     expect(onChange.mock.calls[0][0].expression.where.expressions.length).toBe(0);
   });
 
-  it('should update filters if props change', () => {
+  it('should update filters if props change', async () => {
     const onChange = jest.fn();
     const query = {
       ...mockQuery,
@@ -98,7 +98,7 @@ describe('KQLFilter', () => {
     };
     const { rerender } = render(<KQLFilter {...defaultProps} onChange={onChange} index={1} query={query} />);
     expect(screen.getByText('Other')).toBeInTheDocument();
-    query.expression.where.expressions.pop();
+    screen.getByLabelText('remove').click();
     rerender(<KQLFilter {...defaultProps} onChange={onChange} index={0} query={query} />);
     expect(screen.getByText('ActivityName')).toBeInTheDocument();
   });

--- a/src/components/QueryEditor/VisualQueryEditor/KQLFilter.test.tsx
+++ b/src/components/QueryEditor/VisualQueryEditor/KQLFilter.test.tsx
@@ -56,4 +56,50 @@ describe('KQLFilter', () => {
     expect(onChange).toHaveBeenCalledTimes(1);
     expect(onChange.mock.calls[0][0].expression.where.expressions.length).toBe(0);
   });
+
+  it('should update filters if props change', () => {
+    const onChange = jest.fn();
+    const query = {
+      ...mockQuery,
+      expression: {
+        ...mockQuery.expression,
+        where: {
+          expressions: [
+            {
+              expressions: [
+                {
+                  operator: { name: '==', value: 'foo' },
+                  property: {
+                    name: 'ActivityName',
+                    type: QueryEditorPropertyType.String,
+                  },
+                  type: QueryEditorExpressionType.Operator,
+                },
+              ],
+              type: QueryEditorExpressionType.Or,
+            },
+            {
+              expressions: [
+                {
+                  operator: { name: '==', value: 'bar' },
+                  property: {
+                    name: 'Other',
+                    type: QueryEditorPropertyType.String,
+                  },
+                  type: QueryEditorExpressionType.Operator,
+                },
+              ],
+              type: QueryEditorExpressionType.Or,
+            },
+          ],
+          type: QueryEditorExpressionType.And,
+        },
+      },
+    };
+    const { rerender } = render(<KQLFilter {...defaultProps} onChange={onChange} index={1} query={query} />);
+    expect(screen.getByText('Other')).toBeInTheDocument();
+    query.expression.where.expressions.pop();
+    rerender(<KQLFilter {...defaultProps} onChange={onChange} index={0} query={query} />);
+    expect(screen.getByText('ActivityName')).toBeInTheDocument();
+  });
 });

--- a/src/components/QueryEditor/VisualQueryEditor/KQLFilter.test.tsx
+++ b/src/components/QueryEditor/VisualQueryEditor/KQLFilter.test.tsx
@@ -1,0 +1,59 @@
+import { render, screen } from '@testing-library/react';
+import { QueryEditorExpressionType } from 'components/LegacyQueryEditor/editor/expressions';
+import { mockDatasource, mockQuery } from 'components/__fixtures__/Datasource';
+import React from 'react';
+import { QueryEditorPropertyType } from 'schema/types';
+import KQLFilter from './KQLFilter';
+
+const defaultProps = {
+  index: 0,
+  datasource: mockDatasource(),
+  query: {
+    ...mockQuery,
+    expression: {
+      ...mockQuery.expression,
+      where: {
+        expressions: [
+          {
+            expressions: [
+              {
+                operator: { name: '==', value: 'foo' },
+                property: {
+                  name: 'ActivityName',
+                  type: QueryEditorPropertyType.String,
+                },
+                type: QueryEditorExpressionType.Operator,
+              },
+            ],
+            type: QueryEditorExpressionType.Or,
+          },
+        ],
+        type: QueryEditorExpressionType.And,
+      },
+    },
+  },
+  templateVariableOptions: {},
+  onChange: jest.fn(),
+};
+
+describe('KQLFilter', () => {
+  it('should render a filter', () => {
+    render(<KQLFilter {...defaultProps} />);
+    expect(screen.getByText('ActivityName')).toBeInTheDocument();
+  });
+
+  it('should add a new item', () => {
+    const onChange = jest.fn();
+    render(<KQLFilter {...defaultProps} onChange={onChange} />);
+    screen.getByLabelText('Add').click();
+    expect(onChange).toHaveBeenCalledTimes(1);
+  });
+
+  it('should remove the filter group when removing the last element', () => {
+    const onChange = jest.fn();
+    render(<KQLFilter {...defaultProps} onChange={onChange} />);
+    screen.getByLabelText('remove').click();
+    expect(onChange).toHaveBeenCalledTimes(1);
+    expect(onChange.mock.calls[0][0].expression.where.expressions.length).toBe(0);
+  });
+});

--- a/src/components/QueryEditor/VisualQueryEditor/KQLFilter.tsx
+++ b/src/components/QueryEditor/VisualQueryEditor/KQLFilter.tsx
@@ -1,7 +1,7 @@
 import React, { useState, useEffect } from 'react';
 
 import { SelectableValue } from '@grafana/data';
-import { EditorList } from '@grafana/ui';
+import { EditorList } from '@grafana/experimental';
 
 import { AdxDataSource } from '../../../datasource';
 import { AdxColumnSchema, KustoQuery } from '../../../types';

--- a/src/components/QueryEditor/VisualQueryEditor/KQLFilter.tsx
+++ b/src/components/QueryEditor/VisualQueryEditor/KQLFilter.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useState, useEffect } from 'react';
 
 import { SelectableValue } from '@grafana/data';
 import { EditorList } from '@grafana/ui';
@@ -33,9 +33,12 @@ const KQLFilter: React.FC<KQLFilterProps> = ({
   templateVariableOptions,
 }) => {
   // Each expression is a group of several OR statements
-  const [filters, setFilters] = useState(
-    (query.expression.where.expressions[index] as QueryEditorArrayExpression)?.expressions
-  );
+  const expressions = (query.expression.where.expressions[index] as QueryEditorArrayExpression)?.expressions;
+  const [filters, setFilters] = useState(expressions);
+
+  useEffect(() => {
+    setFilters(expressions);
+  }, [expressions]);
 
   const onChange = (newItems: Array<Partial<QueryEditorOperatorExpression>>) => {
     // As new (empty object) items come in, with need to make sure they have the correct type

--- a/src/components/QueryEditor/VisualQueryEditor/KQLFilter.tsx
+++ b/src/components/QueryEditor/VisualQueryEditor/KQLFilter.tsx
@@ -37,8 +37,10 @@ const KQLFilter: React.FC<KQLFilterProps> = ({
   const [filters, setFilters] = useState(expressions);
 
   useEffect(() => {
-    setFilters(expressions);
-  }, [expressions]);
+    if (!filters.length && expressions?.length) {
+      setFilters(expressions);
+    }
+  }, [filters.length, expressions]);
 
   const onChange = (newItems: Array<Partial<QueryEditorOperatorExpression>>) => {
     // As new (empty object) items come in, with need to make sure they have the correct type

--- a/src/components/QueryEditor/VisualQueryEditor/KQLFilter.tsx
+++ b/src/components/QueryEditor/VisualQueryEditor/KQLFilter.tsx
@@ -1,0 +1,112 @@
+import React, { useState } from 'react';
+
+import { SelectableValue } from '@grafana/data';
+import { EditorList } from '@grafana/ui';
+
+import { AdxDataSource } from '../../../datasource';
+import { AdxColumnSchema, KustoQuery } from '../../../types';
+import {
+  QueryEditorArrayExpression,
+  QueryEditorExpression,
+  QueryEditorExpressionType,
+  QueryEditorOperatorExpression,
+} from 'components/LegacyQueryEditor/editor/expressions';
+import { QueryEditorPropertyType } from 'schema/types';
+import { sanitizeOperator } from './utils/utils';
+import FilterItem from './FilterItem';
+
+interface KQLFilterProps {
+  index: number;
+  query: KustoQuery;
+  datasource: AdxDataSource;
+  columns?: AdxColumnSchema[];
+  templateVariableOptions: SelectableValue<string>;
+  onChange: (query: KustoQuery) => void;
+}
+
+const KQLFilter: React.FC<KQLFilterProps> = ({
+  index,
+  query,
+  onChange: onQueryChange,
+  datasource,
+  columns,
+  templateVariableOptions,
+}) => {
+  // Each expression is a group of several OR statements
+  const [filters, setFilters] = useState(
+    (query.expression.where.expressions[index] as QueryEditorArrayExpression)?.expressions
+  );
+
+  const onChange = (newItems: Array<Partial<QueryEditorOperatorExpression>>) => {
+    // As new (empty object) items come in, with need to make sure they have the correct type
+    const cleaned = newItems.map(
+      (v): QueryEditorOperatorExpression => ({
+        type: QueryEditorExpressionType.Operator,
+        property: v.property ?? { type: QueryEditorPropertyType.String, name: '' },
+        operator: v.operator ?? { name: '==', value: '' },
+      })
+    );
+    setFilters(cleaned);
+
+    // Only save valid and complete filters into the query state
+    const validExpressions: QueryEditorOperatorExpression[] = [];
+    for (const operatorExpression of cleaned) {
+      const validated = sanitizeOperator(operatorExpression);
+      if (validated) {
+        validExpressions.push(validated);
+      }
+    }
+
+    const where = { ...query.expression.where };
+    if (newItems.length) {
+      (where.expressions[index] as QueryEditorArrayExpression).expressions = validExpressions;
+    } else {
+      // The expression is empty, remove it
+      const expr = where.expressions;
+      expr.splice(index, 1);
+      where.expressions = expr;
+    }
+
+    const newExpression = { ...query.expression, where };
+    onQueryChange({ ...query, expression: newExpression, query: datasource.parseExpression(newExpression, columns) });
+  };
+
+  return (
+    <EditorList
+      items={filters}
+      onChange={onChange}
+      renderItem={makeRenderFilter(datasource, query, columns, templateVariableOptions)}
+    />
+  );
+};
+
+// Making component functions in the render body is not recommended, but it works for now.
+// If some problems arise (perhaps with state going missing), consider this to be a potential cause
+function makeRenderFilter(
+  datasource: AdxDataSource,
+  query: KustoQuery,
+  columns: AdxColumnSchema[] | undefined,
+  templateVariableOptions: SelectableValue<string>
+) {
+  function renderFilter(
+    item: Partial<QueryEditorExpression>,
+    onChange: (item: QueryEditorExpression) => void,
+    onDelete: () => void
+  ) {
+    return (
+      <FilterItem
+        datasource={datasource}
+        query={query}
+        filter={item}
+        onChange={onChange}
+        onDelete={onDelete}
+        columns={columns}
+        templateVariableOptions={templateVariableOptions}
+      />
+    );
+  }
+
+  return renderFilter;
+}
+
+export default KQLFilter;

--- a/src/components/QueryEditor/VisualQueryEditor/utils/operators.test.ts
+++ b/src/components/QueryEditor/VisualQueryEditor/utils/operators.test.ts
@@ -1,0 +1,18 @@
+import { isMulti, toOperatorOptions } from './operators';
+
+describe('toOperatorOptions', () => {
+  it('should return operators', () => {
+    expect(toOperatorOptions().length).toBeGreaterThan(1);
+  });
+
+  it('should include descriptions', () => {
+    toOperatorOptions().forEach((op) => expect(op.description).toBeDefined());
+  });
+});
+
+describe('isMulti', () => {
+  it('detect an operator with multiple possible values', () => {
+    expect(isMulti('in')).toBe(true);
+    expect(isMulti('==')).toBe(false);
+  });
+});

--- a/src/components/QueryEditor/VisualQueryEditor/utils/operators.ts
+++ b/src/components/QueryEditor/VisualQueryEditor/utils/operators.ts
@@ -1,0 +1,340 @@
+import { SelectableValue } from '@grafana/data';
+import { QueryEditorPropertyType } from 'schema/types';
+
+export type OperatorInfo = {
+  Operator: string;
+  Description: string;
+  Example?: string;
+  'Case-Sensitive'?: string;
+};
+
+export const toOperatorOptions = (
+  type: QueryEditorPropertyType = QueryEditorPropertyType.String
+): Array<SelectableValue<string>> => {
+  return OPERATORS[type].map((op) => ({
+    label: op.Operator,
+    value: op.Operator,
+    description: `${op['Case-Sensitive'] ? '(Case-Sensitive) ' : ''}${op.Description}`,
+    title: op.Example,
+  }));
+};
+
+export const isMulti = (operator?: string) => {
+  // Some operators can be used to compare multiple values
+  return !!operator && ['in', '!in', 'in~', '!in~', 'has_all', 'has_any'].includes(operator);
+};
+
+export const OPERATORS: { [type: string]: OperatorInfo[] } = {
+  [QueryEditorPropertyType.Number]: [
+    {
+      Operator: '<',
+      Description: 'Less',
+      Example: '1 < 10, 10sec < 1h, now() < datetime(2100-01-01)',
+    },
+    {
+      Operator: '>',
+      Description: 'Greater',
+      Example: '0.23 > 0.22, 10min > 1sec, now() > ago(1d)',
+    },
+    {
+      Operator: '==',
+      Description: 'Equals',
+      Example: '1 == 1',
+    },
+    {
+      Operator: '!=',
+      Description: 'Not equals',
+      Example: '1 != 0',
+    },
+    {
+      Operator: '<=',
+      Description: 'Less or Equal',
+      Example: '4 <= 5',
+    },
+    {
+      Operator: '>=',
+      Description: 'Greater or Equal',
+      Example: '5 >= 4',
+    },
+    {
+      Operator: 'in',
+      Description: 'Equals to one of the elements',
+    },
+    {
+      Operator: '!in',
+      Description: 'Not equals to any of the elements',
+    },
+  ],
+  [QueryEditorPropertyType.String]: [
+    {
+      Operator: '==',
+      Description: 'Equals',
+      'Case-Sensitive': 'Yes',
+      Example: '"aBc" == "aBc"',
+    },
+    {
+      Operator: '!=',
+      Description: 'Not equals',
+      'Case-Sensitive': 'Yes',
+      Example: '"abc" != "ABC"',
+    },
+    {
+      Operator: '=~',
+      Description: 'Equals',
+      'Case-Sensitive': 'No',
+      Example: '"abc" =~ "ABC"',
+    },
+    {
+      Operator: '!~',
+      Description: 'Not equals',
+      'Case-Sensitive': 'No',
+      Example: '"aBc" !~ "xyz"',
+    },
+    {
+      Operator: 'contains',
+      Description: 'RHS occurs as a subsequence of LHS',
+      'Case-Sensitive': 'No',
+      Example: '"FabriKam" contains "BRik"',
+    },
+    {
+      Operator: '!contains',
+      Description: "RHS doesn't occur in LHS",
+      'Case-Sensitive': 'No',
+      Example: '"Fabrikam" !contains "xyz"',
+    },
+    {
+      Operator: 'contains_cs',
+      Description: 'RHS occurs as a subsequence of LHS',
+      'Case-Sensitive': 'Yes',
+      Example: '"FabriKam" contains_cs "Kam"',
+    },
+    {
+      Operator: '!contains_cs',
+      Description: "RHS doesn't occur in LHS",
+      'Case-Sensitive': 'Yes',
+      Example: '"Fabrikam" !contains_cs "Kam"',
+    },
+    {
+      Operator: 'endswith',
+      Description: 'RHS is a closing subsequence of LHS',
+      'Case-Sensitive': 'No',
+      Example: '"Fabrikam" endswith "Kam"',
+    },
+    {
+      Operator: '!endswith',
+      Description: "RHS isn't a closing subsequence of LHS",
+      'Case-Sensitive': 'No',
+      Example: '"Fabrikam" !endswith "brik"',
+    },
+    {
+      Operator: 'endswith_cs',
+      Description: 'RHS is a closing subsequence of LHS',
+      'Case-Sensitive': 'Yes',
+      Example: '"Fabrikam" endswith_cs "kam"',
+    },
+    {
+      Operator: '!endswith_cs',
+      Description: "RHS isn't a closing subsequence of LHS",
+      'Case-Sensitive': 'Yes',
+      Example: '"Fabrikam" !endswith_cs "brik"',
+    },
+    {
+      Operator: 'has',
+      Description: 'Right-hand-side (RHS) is a whole term in left-hand-side (LHS)',
+      'Case-Sensitive': 'No',
+      Example: '"North America" has "america"',
+    },
+    {
+      Operator: '!has',
+      Description: "RHS isn't a full term in LHS",
+      'Case-Sensitive': 'No',
+      Example: '"North America" !has "amer"',
+    },
+    {
+      Operator: 'has_all',
+      Description: 'Same as has but works on all of the elements',
+      'Case-Sensitive': 'No',
+      Example: '"North and South America" has_all("south", "north")',
+    },
+    {
+      Operator: 'has_any',
+      Description: 'Same as has but works on any of the elements',
+      'Case-Sensitive': 'No',
+      Example: '"North America" has_any("south", "north")',
+    },
+    {
+      Operator: 'has_cs',
+      Description: 'RHS is a whole term in LHS',
+      'Case-Sensitive': 'Yes',
+      Example: '"North America" has_cs "America"',
+    },
+    {
+      Operator: '!has_cs',
+      Description: "RHS isn't a full term in LHS",
+      'Case-Sensitive': 'Yes',
+      Example: '"North America" !has_cs "amer"',
+    },
+    {
+      Operator: 'hasprefix',
+      Description: 'RHS is a term prefix in LHS',
+      'Case-Sensitive': 'No',
+      Example: '"North America" hasprefix "ame"',
+    },
+    {
+      Operator: '!hasprefix',
+      Description: "RHS isn't a term prefix in LHS",
+      'Case-Sensitive': 'No',
+      Example: '"North America" !hasprefix "mer"',
+    },
+    {
+      Operator: 'hasprefix_cs',
+      Description: 'RHS is a term prefix in LHS',
+      'Case-Sensitive': 'Yes',
+      Example: '"North America" hasprefix_cs "Ame"',
+    },
+    {
+      Operator: '!hasprefix_cs',
+      Description: "RHS isn't a term prefix in LHS",
+      'Case-Sensitive': 'Yes',
+      Example: '"North America" !hasprefix_cs "CA"',
+    },
+    {
+      Operator: 'hassuffix',
+      Description: 'RHS is a term suffix in LHS',
+      'Case-Sensitive': 'No',
+      Example: '"North America" hassuffix "ica"',
+    },
+    {
+      Operator: '!hassuffix',
+      Description: "RHS isn't a term suffix in LHS",
+      'Case-Sensitive': 'No',
+      Example: '"North America" !hassuffix "americ"',
+    },
+    {
+      Operator: 'hassuffix_cs',
+      Description: 'RHS is a term suffix in LHS',
+      'Case-Sensitive': 'Yes',
+      Example: '"North America" hassuffix_cs "ica"',
+    },
+    {
+      Operator: '!hassuffix_cs',
+      Description: "RHS isn't a term suffix in LHS",
+      'Case-Sensitive': 'Yes',
+      Example: '"North America" !hassuffix_cs "icA"',
+    },
+    {
+      Operator: 'in',
+      Description: 'Equals to one of the elements',
+      'Case-Sensitive': 'Yes',
+      Example: '"abc" in ("123", "345", "abc")',
+    },
+    {
+      Operator: '!in',
+      Description: 'Not equals to any of the elements',
+      'Case-Sensitive': 'Yes',
+      Example: '"bca" !in ("123", "345", "abc")',
+    },
+    {
+      Operator: 'in~',
+      Description: 'Equals to any of the elements',
+      'Case-Sensitive': 'No',
+      Example: '"Abc" in~ ("123", "345", "abc")',
+    },
+    {
+      Operator: '!in~',
+      Description: 'Not equals to any of the elements',
+      'Case-Sensitive': 'No',
+      Example: '"bCa" !in~ ("123", "345", "ABC")',
+    },
+    {
+      Operator: 'matches regex',
+      Description: 'LHS contains a match for RHS',
+      'Case-Sensitive': 'Yes',
+      Example: '"Fabrikam" matches regex "b.*k"',
+    },
+    {
+      Operator: 'startswith',
+      Description: 'RHS is an initial subsequence of LHS',
+      'Case-Sensitive': 'No',
+      Example: '"Fabrikam" startswith "fab"',
+    },
+    {
+      Operator: '!startswith',
+      Description: "RHS isn't an initial subsequence of LHS",
+      'Case-Sensitive': 'No',
+      Example: '"Fabrikam" !startswith "kam"',
+    },
+    {
+      Operator: 'startswith_cs',
+      Description: 'RHS is an initial subsequence of LHS',
+      'Case-Sensitive': 'Yes',
+      Example: '"Fabrikam" startswith_cs "Fab"',
+    },
+    {
+      Operator: '!startswith_cs',
+      Description: "RHS isn't an initial subsequence of LHS",
+      'Case-Sensitive': 'Yes',
+      Example: '"Fabrikam" !startswith_cs "fab"',
+    },
+  ],
+  [QueryEditorPropertyType.Boolean]: [
+    {
+      Operator: '==',
+      Description: 'Yields true if both operands are non-null and equal to each other. Otherwise, false.',
+    },
+    {
+      Operator: '!=',
+      Description:
+        'Yields true if any of the operands are null, or if the operands are not equal to each other. Otherwise, false.',
+    },
+    {
+      Operator: 'and',
+      Description: 'Yields true if both operands are true.',
+    },
+    {
+      Operator: 'or',
+      Description: 'Yields true if one of the operands is true, regardless of the other operand.',
+    },
+  ],
+  // Same for TimeSpan and Interval
+  [QueryEditorPropertyType.DateTime]: [
+    {
+      Operator: 'in',
+      Description: 'Equals to one of the elements',
+    },
+    {
+      Operator: '!in',
+      Description: 'Not equals to any of the elements',
+    },
+    {
+      Operator: '<',
+      Description: 'Less',
+      Example: '1 < 10, 10sec < 1h, now() < datetime(2100-01-01)',
+    },
+    {
+      Operator: '>',
+      Description: 'Greater',
+      Example: '0.23 > 0.22, 10min > 1sec, now() > ago(1d)',
+    },
+    {
+      Operator: '==',
+      Description: 'Equals',
+      Example: '1 == 1',
+    },
+    {
+      Operator: '!=',
+      Description: 'Not equals',
+      Example: '1 != 0',
+    },
+    {
+      Operator: '<=',
+      Description: 'Less or Equal',
+      Example: '4 <= 5',
+    },
+    {
+      Operator: '>=',
+      Description: 'Greater or Equal',
+      Example: '5 >= 4',
+    },
+  ],
+};

--- a/src/components/QueryEditor/VisualQueryEditor/utils/operators.ts
+++ b/src/components/QueryEditor/VisualQueryEditor/utils/operators.ts
@@ -11,7 +11,7 @@ export type OperatorInfo = {
 export const toOperatorOptions = (
   type: QueryEditorPropertyType = QueryEditorPropertyType.String
 ): Array<SelectableValue<string>> => {
-  return OPERATORS[type].map((op) => ({
+  return OPERATORS(type).map((op) => ({
     label: op.Operator,
     value: op.Operator,
     description: `${op['Case-Sensitive'] ? '(Case-Sensitive) ' : ''}${op.Description}`,
@@ -24,317 +24,323 @@ export const isMulti = (operator?: string) => {
   return !!operator && ['in', '!in', 'in~', '!in~', 'has_all', 'has_any'].includes(operator);
 };
 
-export const OPERATORS: { [type: string]: OperatorInfo[] } = {
-  [QueryEditorPropertyType.Number]: [
-    {
-      Operator: '<',
-      Description: 'Less',
-      Example: '1 < 10, 10sec < 1h, now() < datetime(2100-01-01)',
-    },
-    {
-      Operator: '>',
-      Description: 'Greater',
-      Example: '0.23 > 0.22, 10min > 1sec, now() > ago(1d)',
-    },
-    {
-      Operator: '==',
-      Description: 'Equals',
-      Example: '1 == 1',
-    },
-    {
-      Operator: '!=',
-      Description: 'Not equals',
-      Example: '1 != 0',
-    },
-    {
-      Operator: '<=',
-      Description: 'Less or Equal',
-      Example: '4 <= 5',
-    },
-    {
-      Operator: '>=',
-      Description: 'Greater or Equal',
-      Example: '5 >= 4',
-    },
-    {
-      Operator: 'in',
-      Description: 'Equals to one of the elements',
-    },
-    {
-      Operator: '!in',
-      Description: 'Not equals to any of the elements',
-    },
-  ],
-  [QueryEditorPropertyType.String]: [
-    {
-      Operator: '==',
-      Description: 'Equals',
-      'Case-Sensitive': 'Yes',
-      Example: '"aBc" == "aBc"',
-    },
-    {
-      Operator: '!=',
-      Description: 'Not equals',
-      'Case-Sensitive': 'Yes',
-      Example: '"abc" != "ABC"',
-    },
-    {
-      Operator: '=~',
-      Description: 'Equals',
-      'Case-Sensitive': 'No',
-      Example: '"abc" =~ "ABC"',
-    },
-    {
-      Operator: '!~',
-      Description: 'Not equals',
-      'Case-Sensitive': 'No',
-      Example: '"aBc" !~ "xyz"',
-    },
-    {
-      Operator: 'contains',
-      Description: 'RHS occurs as a subsequence of LHS',
-      'Case-Sensitive': 'No',
-      Example: '"FabriKam" contains "BRik"',
-    },
-    {
-      Operator: '!contains',
-      Description: "RHS doesn't occur in LHS",
-      'Case-Sensitive': 'No',
-      Example: '"Fabrikam" !contains "xyz"',
-    },
-    {
-      Operator: 'contains_cs',
-      Description: 'RHS occurs as a subsequence of LHS',
-      'Case-Sensitive': 'Yes',
-      Example: '"FabriKam" contains_cs "Kam"',
-    },
-    {
-      Operator: '!contains_cs',
-      Description: "RHS doesn't occur in LHS",
-      'Case-Sensitive': 'Yes',
-      Example: '"Fabrikam" !contains_cs "Kam"',
-    },
-    {
-      Operator: 'endswith',
-      Description: 'RHS is a closing subsequence of LHS',
-      'Case-Sensitive': 'No',
-      Example: '"Fabrikam" endswith "Kam"',
-    },
-    {
-      Operator: '!endswith',
-      Description: "RHS isn't a closing subsequence of LHS",
-      'Case-Sensitive': 'No',
-      Example: '"Fabrikam" !endswith "brik"',
-    },
-    {
-      Operator: 'endswith_cs',
-      Description: 'RHS is a closing subsequence of LHS',
-      'Case-Sensitive': 'Yes',
-      Example: '"Fabrikam" endswith_cs "kam"',
-    },
-    {
-      Operator: '!endswith_cs',
-      Description: "RHS isn't a closing subsequence of LHS",
-      'Case-Sensitive': 'Yes',
-      Example: '"Fabrikam" !endswith_cs "brik"',
-    },
-    {
-      Operator: 'has',
-      Description: 'Right-hand-side (RHS) is a whole term in left-hand-side (LHS)',
-      'Case-Sensitive': 'No',
-      Example: '"North America" has "america"',
-    },
-    {
-      Operator: '!has',
-      Description: "RHS isn't a full term in LHS",
-      'Case-Sensitive': 'No',
-      Example: '"North America" !has "amer"',
-    },
-    {
-      Operator: 'has_all',
-      Description: 'Same as has but works on all of the elements',
-      'Case-Sensitive': 'No',
-      Example: '"North and South America" has_all("south", "north")',
-    },
-    {
-      Operator: 'has_any',
-      Description: 'Same as has but works on any of the elements',
-      'Case-Sensitive': 'No',
-      Example: '"North America" has_any("south", "north")',
-    },
-    {
-      Operator: 'has_cs',
-      Description: 'RHS is a whole term in LHS',
-      'Case-Sensitive': 'Yes',
-      Example: '"North America" has_cs "America"',
-    },
-    {
-      Operator: '!has_cs',
-      Description: "RHS isn't a full term in LHS",
-      'Case-Sensitive': 'Yes',
-      Example: '"North America" !has_cs "amer"',
-    },
-    {
-      Operator: 'hasprefix',
-      Description: 'RHS is a term prefix in LHS',
-      'Case-Sensitive': 'No',
-      Example: '"North America" hasprefix "ame"',
-    },
-    {
-      Operator: '!hasprefix',
-      Description: "RHS isn't a term prefix in LHS",
-      'Case-Sensitive': 'No',
-      Example: '"North America" !hasprefix "mer"',
-    },
-    {
-      Operator: 'hasprefix_cs',
-      Description: 'RHS is a term prefix in LHS',
-      'Case-Sensitive': 'Yes',
-      Example: '"North America" hasprefix_cs "Ame"',
-    },
-    {
-      Operator: '!hasprefix_cs',
-      Description: "RHS isn't a term prefix in LHS",
-      'Case-Sensitive': 'Yes',
-      Example: '"North America" !hasprefix_cs "CA"',
-    },
-    {
-      Operator: 'hassuffix',
-      Description: 'RHS is a term suffix in LHS',
-      'Case-Sensitive': 'No',
-      Example: '"North America" hassuffix "ica"',
-    },
-    {
-      Operator: '!hassuffix',
-      Description: "RHS isn't a term suffix in LHS",
-      'Case-Sensitive': 'No',
-      Example: '"North America" !hassuffix "americ"',
-    },
-    {
-      Operator: 'hassuffix_cs',
-      Description: 'RHS is a term suffix in LHS',
-      'Case-Sensitive': 'Yes',
-      Example: '"North America" hassuffix_cs "ica"',
-    },
-    {
-      Operator: '!hassuffix_cs',
-      Description: "RHS isn't a term suffix in LHS",
-      'Case-Sensitive': 'Yes',
-      Example: '"North America" !hassuffix_cs "icA"',
-    },
-    {
-      Operator: 'in',
-      Description: 'Equals to one of the elements',
-      'Case-Sensitive': 'Yes',
-      Example: '"abc" in ("123", "345", "abc")',
-    },
-    {
-      Operator: '!in',
-      Description: 'Not equals to any of the elements',
-      'Case-Sensitive': 'Yes',
-      Example: '"bca" !in ("123", "345", "abc")',
-    },
-    {
-      Operator: 'in~',
-      Description: 'Equals to any of the elements',
-      'Case-Sensitive': 'No',
-      Example: '"Abc" in~ ("123", "345", "abc")',
-    },
-    {
-      Operator: '!in~',
-      Description: 'Not equals to any of the elements',
-      'Case-Sensitive': 'No',
-      Example: '"bCa" !in~ ("123", "345", "ABC")',
-    },
-    {
-      Operator: 'matches regex',
-      Description: 'LHS contains a match for RHS',
-      'Case-Sensitive': 'Yes',
-      Example: '"Fabrikam" matches regex "b.*k"',
-    },
-    {
-      Operator: 'startswith',
-      Description: 'RHS is an initial subsequence of LHS',
-      'Case-Sensitive': 'No',
-      Example: '"Fabrikam" startswith "fab"',
-    },
-    {
-      Operator: '!startswith',
-      Description: "RHS isn't an initial subsequence of LHS",
-      'Case-Sensitive': 'No',
-      Example: '"Fabrikam" !startswith "kam"',
-    },
-    {
-      Operator: 'startswith_cs',
-      Description: 'RHS is an initial subsequence of LHS',
-      'Case-Sensitive': 'Yes',
-      Example: '"Fabrikam" startswith_cs "Fab"',
-    },
-    {
-      Operator: '!startswith_cs',
-      Description: "RHS isn't an initial subsequence of LHS",
-      'Case-Sensitive': 'Yes',
-      Example: '"Fabrikam" !startswith_cs "fab"',
-    },
-  ],
-  [QueryEditorPropertyType.Boolean]: [
-    {
-      Operator: '==',
-      Description: 'Yields true if both operands are non-null and equal to each other. Otherwise, false.',
-    },
-    {
-      Operator: '!=',
-      Description:
-        'Yields true if any of the operands are null, or if the operands are not equal to each other. Otherwise, false.',
-    },
-    {
-      Operator: 'and',
-      Description: 'Yields true if both operands are true.',
-    },
-    {
-      Operator: 'or',
-      Description: 'Yields true if one of the operands is true, regardless of the other operand.',
-    },
-  ],
-  // Same for TimeSpan and Interval
-  [QueryEditorPropertyType.DateTime]: [
-    {
-      Operator: 'in',
-      Description: 'Equals to one of the elements',
-    },
-    {
-      Operator: '!in',
-      Description: 'Not equals to any of the elements',
-    },
-    {
-      Operator: '<',
-      Description: 'Less',
-      Example: '1 < 10, 10sec < 1h, now() < datetime(2100-01-01)',
-    },
-    {
-      Operator: '>',
-      Description: 'Greater',
-      Example: '0.23 > 0.22, 10min > 1sec, now() > ago(1d)',
-    },
-    {
-      Operator: '==',
-      Description: 'Equals',
-      Example: '1 == 1',
-    },
-    {
-      Operator: '!=',
-      Description: 'Not equals',
-      Example: '1 != 0',
-    },
-    {
-      Operator: '<=',
-      Description: 'Less or Equal',
-      Example: '4 <= 5',
-    },
-    {
-      Operator: '>=',
-      Description: 'Greater or Equal',
-      Example: '5 >= 4',
-    },
-  ],
+export const OPERATORS = (type: QueryEditorPropertyType): OperatorInfo[] => {
+  switch (type) {
+    case QueryEditorPropertyType.Number:
+      return [
+        {
+          Operator: '<',
+          Description: 'Less',
+          Example: '1 < 10, 10sec < 1h, now() < datetime(2100-01-01)',
+        },
+        {
+          Operator: '>',
+          Description: 'Greater',
+          Example: '0.23 > 0.22, 10min > 1sec, now() > ago(1d)',
+        },
+        {
+          Operator: '==',
+          Description: 'Equals',
+          Example: '1 == 1',
+        },
+        {
+          Operator: '!=',
+          Description: 'Not equals',
+          Example: '1 != 0',
+        },
+        {
+          Operator: '<=',
+          Description: 'Less or Equal',
+          Example: '4 <= 5',
+        },
+        {
+          Operator: '>=',
+          Description: 'Greater or Equal',
+          Example: '5 >= 4',
+        },
+        {
+          Operator: 'in',
+          Description: 'Equals to one of the elements',
+        },
+        {
+          Operator: '!in',
+          Description: 'Not equals to any of the elements',
+        },
+      ];
+    case QueryEditorPropertyType.String:
+      return [
+        {
+          Operator: '==',
+          Description: 'Equals',
+          'Case-Sensitive': 'Yes',
+          Example: '"aBc" == "aBc"',
+        },
+        {
+          Operator: '!=',
+          Description: 'Not equals',
+          'Case-Sensitive': 'Yes',
+          Example: '"abc" != "ABC"',
+        },
+        {
+          Operator: '=~',
+          Description: 'Equals',
+          'Case-Sensitive': 'No',
+          Example: '"abc" =~ "ABC"',
+        },
+        {
+          Operator: '!~',
+          Description: 'Not equals',
+          'Case-Sensitive': 'No',
+          Example: '"aBc" !~ "xyz"',
+        },
+        {
+          Operator: 'contains',
+          Description: 'RHS occurs as a subsequence of LHS',
+          'Case-Sensitive': 'No',
+          Example: '"FabriKam" contains "BRik"',
+        },
+        {
+          Operator: '!contains',
+          Description: "RHS doesn't occur in LHS",
+          'Case-Sensitive': 'No',
+          Example: '"Fabrikam" !contains "xyz"',
+        },
+        {
+          Operator: 'contains_cs',
+          Description: 'RHS occurs as a subsequence of LHS',
+          'Case-Sensitive': 'Yes',
+          Example: '"FabriKam" contains_cs "Kam"',
+        },
+        {
+          Operator: '!contains_cs',
+          Description: "RHS doesn't occur in LHS",
+          'Case-Sensitive': 'Yes',
+          Example: '"Fabrikam" !contains_cs "Kam"',
+        },
+        {
+          Operator: 'endswith',
+          Description: 'RHS is a closing subsequence of LHS',
+          'Case-Sensitive': 'No',
+          Example: '"Fabrikam" endswith "Kam"',
+        },
+        {
+          Operator: '!endswith',
+          Description: "RHS isn't a closing subsequence of LHS",
+          'Case-Sensitive': 'No',
+          Example: '"Fabrikam" !endswith "brik"',
+        },
+        {
+          Operator: 'endswith_cs',
+          Description: 'RHS is a closing subsequence of LHS',
+          'Case-Sensitive': 'Yes',
+          Example: '"Fabrikam" endswith_cs "kam"',
+        },
+        {
+          Operator: '!endswith_cs',
+          Description: "RHS isn't a closing subsequence of LHS",
+          'Case-Sensitive': 'Yes',
+          Example: '"Fabrikam" !endswith_cs "brik"',
+        },
+        {
+          Operator: 'has',
+          Description: 'Right-hand-side (RHS) is a whole term in left-hand-side (LHS)',
+          'Case-Sensitive': 'No',
+          Example: '"North America" has "america"',
+        },
+        {
+          Operator: '!has',
+          Description: "RHS isn't a full term in LHS",
+          'Case-Sensitive': 'No',
+          Example: '"North America" !has "amer"',
+        },
+        {
+          Operator: 'has_all',
+          Description: 'Same as has but works on all of the elements',
+          'Case-Sensitive': 'No',
+          Example: '"North and South America" has_all("south", "north")',
+        },
+        {
+          Operator: 'has_any',
+          Description: 'Same as has but works on any of the elements',
+          'Case-Sensitive': 'No',
+          Example: '"North America" has_any("south", "north")',
+        },
+        {
+          Operator: 'has_cs',
+          Description: 'RHS is a whole term in LHS',
+          'Case-Sensitive': 'Yes',
+          Example: '"North America" has_cs "America"',
+        },
+        {
+          Operator: '!has_cs',
+          Description: "RHS isn't a full term in LHS",
+          'Case-Sensitive': 'Yes',
+          Example: '"North America" !has_cs "amer"',
+        },
+        {
+          Operator: 'hasprefix',
+          Description: 'RHS is a term prefix in LHS',
+          'Case-Sensitive': 'No',
+          Example: '"North America" hasprefix "ame"',
+        },
+        {
+          Operator: '!hasprefix',
+          Description: "RHS isn't a term prefix in LHS",
+          'Case-Sensitive': 'No',
+          Example: '"North America" !hasprefix "mer"',
+        },
+        {
+          Operator: 'hasprefix_cs',
+          Description: 'RHS is a term prefix in LHS',
+          'Case-Sensitive': 'Yes',
+          Example: '"North America" hasprefix_cs "Ame"',
+        },
+        {
+          Operator: '!hasprefix_cs',
+          Description: "RHS isn't a term prefix in LHS",
+          'Case-Sensitive': 'Yes',
+          Example: '"North America" !hasprefix_cs "CA"',
+        },
+        {
+          Operator: 'hassuffix',
+          Description: 'RHS is a term suffix in LHS',
+          'Case-Sensitive': 'No',
+          Example: '"North America" hassuffix "ica"',
+        },
+        {
+          Operator: '!hassuffix',
+          Description: "RHS isn't a term suffix in LHS",
+          'Case-Sensitive': 'No',
+          Example: '"North America" !hassuffix "americ"',
+        },
+        {
+          Operator: 'hassuffix_cs',
+          Description: 'RHS is a term suffix in LHS',
+          'Case-Sensitive': 'Yes',
+          Example: '"North America" hassuffix_cs "ica"',
+        },
+        {
+          Operator: '!hassuffix_cs',
+          Description: "RHS isn't a term suffix in LHS",
+          'Case-Sensitive': 'Yes',
+          Example: '"North America" !hassuffix_cs "icA"',
+        },
+        {
+          Operator: 'in',
+          Description: 'Equals to one of the elements',
+          'Case-Sensitive': 'Yes',
+          Example: '"abc" in ("123", "345", "abc")',
+        },
+        {
+          Operator: '!in',
+          Description: 'Not equals to any of the elements',
+          'Case-Sensitive': 'Yes',
+          Example: '"bca" !in ("123", "345", "abc")',
+        },
+        {
+          Operator: 'in~',
+          Description: 'Equals to any of the elements',
+          'Case-Sensitive': 'No',
+          Example: '"Abc" in~ ("123", "345", "abc")',
+        },
+        {
+          Operator: '!in~',
+          Description: 'Not equals to any of the elements',
+          'Case-Sensitive': 'No',
+          Example: '"bCa" !in~ ("123", "345", "ABC")',
+        },
+        {
+          Operator: 'matches regex',
+          Description: 'LHS contains a match for RHS',
+          'Case-Sensitive': 'Yes',
+          Example: '"Fabrikam" matches regex "b.*k"',
+        },
+        {
+          Operator: 'startswith',
+          Description: 'RHS is an initial subsequence of LHS',
+          'Case-Sensitive': 'No',
+          Example: '"Fabrikam" startswith "fab"',
+        },
+        {
+          Operator: '!startswith',
+          Description: "RHS isn't an initial subsequence of LHS",
+          'Case-Sensitive': 'No',
+          Example: '"Fabrikam" !startswith "kam"',
+        },
+        {
+          Operator: 'startswith_cs',
+          Description: 'RHS is an initial subsequence of LHS',
+          'Case-Sensitive': 'Yes',
+          Example: '"Fabrikam" startswith_cs "Fab"',
+        },
+        {
+          Operator: '!startswith_cs',
+          Description: "RHS isn't an initial subsequence of LHS",
+          'Case-Sensitive': 'Yes',
+          Example: '"Fabrikam" !startswith_cs "fab"',
+        },
+      ];
+    case QueryEditorPropertyType.Boolean:
+      return [
+        {
+          Operator: '==',
+          Description: 'Yields true if both operands are non-null and equal to each other. Otherwise, false.',
+        },
+        {
+          Operator: '!=',
+          Description:
+            'Yields true if any of the operands are null, or if the operands are not equal to each other. Otherwise, false.',
+        },
+        {
+          Operator: 'and',
+          Description: 'Yields true if both operands are true.',
+        },
+        {
+          Operator: 'or',
+          Description: 'Yields true if one of the operands is true, regardless of the other operand.',
+        },
+      ];
+    // Same for TimeSpan and Interval
+    default:
+      return [
+        {
+          Operator: 'in',
+          Description: 'Equals to one of the elements',
+        },
+        {
+          Operator: '!in',
+          Description: 'Not equals to any of the elements',
+        },
+        {
+          Operator: '<',
+          Description: 'Less',
+          Example: '1 < 10, 10sec < 1h, now() < datetime(2100-01-01)',
+        },
+        {
+          Operator: '>',
+          Description: 'Greater',
+          Example: '0.23 > 0.22, 10min > 1sec, now() > ago(1d)',
+        },
+        {
+          Operator: '==',
+          Description: 'Equals',
+          Example: '1 == 1',
+        },
+        {
+          Operator: '!=',
+          Description: 'Not equals',
+          Example: '1 != 0',
+        },
+        {
+          Operator: '<=',
+          Description: 'Less or Equal',
+          Example: '4 <= 5',
+        },
+        {
+          Operator: '>=',
+          Description: 'Greater or Equal',
+          Example: '5 >= 4',
+        },
+      ];
+  }
 };

--- a/src/components/QueryEditor/VisualQueryEditor/utils/utils.test.ts
+++ b/src/components/QueryEditor/VisualQueryEditor/utils/utils.test.ts
@@ -42,7 +42,7 @@ describe('setOperatorExpressionProperty', () => {
     ).toEqual({
       type: QueryEditorExpressionType.Operator,
       property: { name: 'ID', type: QueryEditorPropertyType.Number },
-      operator: { name: '==', value: '' },
+      operator: { name: '==', value: 0 },
     });
   });
 });

--- a/src/components/QueryEditor/VisualQueryEditor/utils/utils.test.ts
+++ b/src/components/QueryEditor/VisualQueryEditor/utils/utils.test.ts
@@ -1,0 +1,203 @@
+import { QueryEditorExpressionType } from 'components/LegacyQueryEditor/editor/expressions';
+import { QueryEditorOperator, QueryEditorPropertyType } from 'schema/types';
+import {
+  getOperatorExpressionOptions,
+  getOperatorExpressionValue,
+  sanitizeOperator,
+  setOperatorExpressionName,
+  setOperatorExpressionProperty,
+  setOperatorExpressionValue,
+} from './utils';
+
+describe('setOperatorExpressionProperty', () => {
+  it('should set a property from an empty expression', () => {
+    expect(setOperatorExpressionProperty({}, 'ActivityName', QueryEditorPropertyType.String)).toEqual({
+      type: QueryEditorExpressionType.Operator,
+      property: { name: 'ActivityName', type: QueryEditorPropertyType.String },
+      operator: { name: '==', value: '' },
+    });
+  });
+
+  it('should keep the operator name if defined', () => {
+    expect(
+      setOperatorExpressionProperty(
+        { operator: { name: '!=', value: 'c' } },
+        'ActivityName',
+        QueryEditorPropertyType.String
+      )
+    ).toEqual({
+      type: QueryEditorExpressionType.Operator,
+      property: { name: 'ActivityName', type: QueryEditorPropertyType.String },
+      operator: { name: '!=', value: '' },
+    });
+  });
+
+  it('change the operator name if the new type does not support it', () => {
+    expect(
+      setOperatorExpressionProperty(
+        { operator: { name: 'startswith', value: 'c' } },
+        'ID',
+        QueryEditorPropertyType.Number
+      )
+    ).toEqual({
+      type: QueryEditorExpressionType.Operator,
+      property: { name: 'ID', type: QueryEditorPropertyType.Number },
+      operator: { name: '==', value: '' },
+    });
+  });
+});
+
+describe('setOperatorExpressionName', () => {
+  it('should set a expression name (operator)', () => {
+    expect(setOperatorExpressionName({}, '!=')).toEqual({
+      type: QueryEditorExpressionType.Operator,
+      property: { name: '', type: QueryEditorPropertyType.String },
+      operator: { name: '!=', value: '' },
+    });
+  });
+
+  it('should keep the current comparison value', () => {
+    expect(setOperatorExpressionName({ operator: { name: '==', value: 'foo' } }, '!=')).toEqual({
+      type: QueryEditorExpressionType.Operator,
+      property: { name: '', type: QueryEditorPropertyType.String },
+      operator: { name: '!=', value: 'foo' },
+    });
+  });
+
+  it('should convert a value to an array', () => {
+    expect(setOperatorExpressionName({ operator: { name: '==', value: 'foo' } }, 'in')).toEqual({
+      type: QueryEditorExpressionType.Operator,
+      property: { name: '', type: QueryEditorPropertyType.String },
+      operator: { name: 'in', value: ['foo'] },
+    });
+  });
+
+  it('should convert an array to a string', () => {
+    expect(setOperatorExpressionName({ operator: { name: 'in', value: ['foo'] } }, '!=')).toEqual({
+      type: QueryEditorExpressionType.Operator,
+      property: { name: '', type: QueryEditorPropertyType.String },
+      operator: { name: '!=', value: 'foo' },
+    });
+  });
+});
+
+describe('setOperatorExpressionValue', () => {
+  it('should set a single value', () => {
+    expect(
+      setOperatorExpressionValue(
+        { property: { type: QueryEditorPropertyType.String, name: 'ActivityName' } },
+        { value: 'foo' }
+      )
+    ).toEqual({
+      type: QueryEditorExpressionType.Operator,
+      property: { type: QueryEditorPropertyType.String, name: 'ActivityName' },
+      operator: { name: '==', value: 'foo' },
+    });
+  });
+
+  it('should keep the operator name', () => {
+    expect(
+      setOperatorExpressionValue(
+        {
+          property: { type: QueryEditorPropertyType.String, name: 'ActivityName' },
+          operator: { name: '!=', value: 'bar' },
+        },
+        { value: 'foo' }
+      )
+    ).toEqual({
+      type: QueryEditorExpressionType.Operator,
+      property: { type: QueryEditorPropertyType.String, name: 'ActivityName' },
+      operator: { name: '!=', value: 'foo' },
+    });
+  });
+
+  it('should set an array of values', () => {
+    expect(
+      setOperatorExpressionValue({ property: { type: QueryEditorPropertyType.String, name: 'ActivityName' } }, [
+        { value: 'foo' },
+        { value: 'bar' },
+      ])
+    ).toEqual({
+      type: QueryEditorExpressionType.Operator,
+      property: { type: QueryEditorPropertyType.String, name: 'ActivityName' },
+      operator: { name: '==', value: ['foo', 'bar'] },
+    });
+  });
+});
+
+describe('getOperatorExpressionValue', () => {
+  it('get the current value', () => {
+    expect(getOperatorExpressionValue('foo')).toEqual({ label: 'foo', value: 'foo' });
+  });
+
+  it('get the current value', () => {
+    const value = [
+      { label: 'foo', value: 'foo' },
+      { label: 'bar', value: 'bar' },
+    ];
+    expect(getOperatorExpressionValue(value)).toEqual(value);
+  });
+
+  it('remove quotes for single values', () => {
+    expect(getOperatorExpressionValue("'$foo'")).toEqual({ label: '$foo', value: '$foo' });
+  });
+});
+
+describe('getOperatorExpressionOptions', () => {
+  const value = [{ label: 'foo', value: 'foo' }];
+  it('get the current value', () => {
+    expect(getOperatorExpressionOptions(value)).toEqual(value);
+  });
+
+  it('parse the current single value as options', () => {
+    expect(getOperatorExpressionOptions(undefined, 'foo')).toEqual(value);
+  });
+
+  it('parse the current array value as options', () => {
+    expect(getOperatorExpressionOptions(undefined, ['foo'])).toEqual(value);
+  });
+});
+
+describe('sanitizeOperator', () => {
+  it('ignores an expression with a missing property name', () => {
+    expect(
+      sanitizeOperator({
+        operator: { name: '==', value: 'foo' },
+      })
+    ).toBeUndefined();
+  });
+
+  it('ignores an expression with a missing operator name', () => {
+    expect(
+      sanitizeOperator({
+        property: { name: 'ID', type: QueryEditorPropertyType.Number },
+        operator: { name: '', value: 'foo' },
+      })
+    ).toBeUndefined();
+  });
+
+  it('ignores an expression with a missing operator value', () => {
+    expect(
+      sanitizeOperator({
+        property: { name: 'ID', type: QueryEditorPropertyType.Number },
+        operator: { name: '==' } as QueryEditorOperator,
+      })
+    ).toBeUndefined();
+  });
+
+  it('returns a valid operator', () => {
+    const op = {
+      property: { name: 'ID', type: QueryEditorPropertyType.Number },
+      operator: { name: '==', value: 123 },
+    };
+    expect(sanitizeOperator(op)).toEqual({ type: QueryEditorExpressionType.Operator, ...op });
+  });
+
+  it('returns a valid operator (boolean)', () => {
+    const op = {
+      property: { name: 'ID', type: QueryEditorPropertyType.Boolean },
+      operator: { name: '==', value: false },
+    };
+    expect(sanitizeOperator(op)).toEqual({ type: QueryEditorExpressionType.Operator, ...op });
+  });
+});

--- a/src/components/QueryEditor/VisualQueryEditor/utils/utils.ts
+++ b/src/components/QueryEditor/VisualQueryEditor/utils/utils.ts
@@ -7,6 +7,17 @@ import { isUndefined } from 'lodash';
 import { QueryEditorOperatorValueType, QueryEditorPropertyType } from 'schema/types';
 import { isMulti, OPERATORS } from './operators';
 
+function zeroValue(type: QueryEditorPropertyType) {
+  switch (type) {
+    case QueryEditorPropertyType.String:
+      return '';
+    case QueryEditorPropertyType.Boolean:
+      return false;
+    default:
+      return 0;
+  }
+}
+
 /** Sets the left hand side (InstanceId) in an OperatorExpression
  * Accepts a partial expression to use in an editor
  */
@@ -16,13 +27,18 @@ export function setOperatorExpressionProperty(
   type: QueryEditorPropertyType
 ): QueryEditorOperatorExpression {
   let operatorName = '==';
-  if (expression.operator?.name && OPERATORS[type].map((op) => op.Operator).includes(expression.operator.name)) {
+  if (
+    expression.operator?.name &&
+    OPERATORS(type)
+      .map((op) => op.Operator)
+      .includes(expression.operator.name)
+  ) {
     operatorName = expression.operator.name;
   }
   return {
     type: QueryEditorExpressionType.Operator,
     property: { name, type },
-    operator: { name: operatorName, value: '' },
+    operator: { name: operatorName, value: zeroValue(type) },
   };
 }
 
@@ -60,7 +76,7 @@ export function setOperatorExpressionName(
  */
 export function setOperatorExpressionValue(
   expression: Partial<QueryEditorOperatorExpression>,
-  e: SelectableValue<string> | Array<SelectableValue<string>> | number
+  e: SelectableValue<string> | Array<SelectableValue<string>> | number | string
 ): QueryEditorOperatorExpression {
   let value: string | string[] | number;
   if (typeof e === 'object' && !Array.isArray(e)) {

--- a/src/components/QueryEditor/VisualQueryEditor/utils/utils.ts
+++ b/src/components/QueryEditor/VisualQueryEditor/utils/utils.ts
@@ -1,0 +1,133 @@
+import { SelectableValue, toOption } from '@grafana/data';
+import {
+  QueryEditorExpressionType,
+  QueryEditorOperatorExpression,
+} from 'components/LegacyQueryEditor/editor/expressions';
+import { isUndefined } from 'lodash';
+import { QueryEditorOperatorValueType, QueryEditorPropertyType } from 'schema/types';
+import { isMulti, OPERATORS } from './operators';
+
+/** Sets the left hand side (InstanceId) in an OperatorExpression
+ * Accepts a partial expression to use in an editor
+ */
+export function setOperatorExpressionProperty(
+  expression: Partial<QueryEditorOperatorExpression>,
+  name: string,
+  type: QueryEditorPropertyType
+): QueryEditorOperatorExpression {
+  let operatorName = '==';
+  if (expression.operator?.name && OPERATORS[type].map((op) => op.Operator).includes(expression.operator.name)) {
+    operatorName = expression.operator.name;
+  }
+  return {
+    type: QueryEditorExpressionType.Operator,
+    property: { name, type },
+    operator: { name: operatorName, value: '' },
+  };
+}
+
+/** Sets the operator ("==") in an OperatorExpression
+ * Accepts a partial expression to use in an editor
+ */
+export function setOperatorExpressionName(
+  expression: Partial<QueryEditorOperatorExpression>,
+  name: string
+): QueryEditorOperatorExpression {
+  let opValue = expression.operator?.value ?? '';
+  if (isMulti(name) && !Array.isArray(opValue)) {
+    // Handle the case in which the operator now points to an multi value
+    opValue = expression.operator?.value ? [expression.operator.value] : [];
+  } else if (!isMulti(name) && Array.isArray(opValue)) {
+    // Handle the case in which the operator now points to a single value
+    opValue = opValue.length ? opValue[0] : '';
+  }
+  return {
+    type: QueryEditorExpressionType.Operator,
+    property: expression.property ?? {
+      type: QueryEditorPropertyType.String,
+      name: '',
+    },
+    operator: {
+      ...expression.operator,
+      name,
+      value: opValue,
+    },
+  };
+}
+
+/** Sets the right hand side ("i-abc123445") in an OperatorExpression
+ * Accepts a partial expression to use in an editor
+ */
+export function setOperatorExpressionValue(
+  expression: Partial<QueryEditorOperatorExpression>,
+  e: SelectableValue<string> | Array<SelectableValue<string>> | number
+): QueryEditorOperatorExpression {
+  let value: string | string[] | number;
+  if (typeof e === 'object' && !Array.isArray(e)) {
+    value = e.value || '';
+  } else if (Array.isArray(e)) {
+    value = e.map((s) => s.value || '');
+  } else {
+    value = e;
+  }
+
+  return {
+    type: QueryEditorExpressionType.Operator,
+    property: expression.property ?? {
+      type: QueryEditorPropertyType.String,
+      name: '',
+    },
+    operator: {
+      ...expression.operator,
+      name: expression.operator?.name ?? '==',
+      value,
+    },
+  };
+}
+
+export function getOperatorExpressionValue(value?: QueryEditorOperatorValueType) {
+  return value
+    ? Array.isArray(value)
+      ? value
+      : // Remove quotes if they exist (template variable case)
+        toOption(value.toString().replace(/'/g, ''))
+    : null;
+}
+
+export function getOperatorExpressionOptions(
+  value?: Array<SelectableValue<string>>,
+  current?: QueryEditorOperatorValueType
+) {
+  const defaultOptions: Array<SelectableValue<string>> = current
+    ? Array.isArray(current)
+      ? current.map((v) => ({ label: v.toString(), value: v.toString() }))
+      : [{ label: current.toString(), value: current.toString() }]
+    : [];
+
+  return value || defaultOptions;
+}
+
+/** Given a partial operator expression, return a non-partial if it's valid, or undefined */
+export function sanitizeOperator(
+  expression: Partial<QueryEditorOperatorExpression>
+): QueryEditorOperatorExpression | undefined {
+  const key = expression.property?.name;
+  const value = expression.operator?.value;
+  const operator = expression.operator?.name;
+
+  if (key && !isUndefined(value) && operator) {
+    return {
+      type: QueryEditorExpressionType.Operator,
+      property: {
+        type: expression.property?.type ?? QueryEditorPropertyType.String,
+        name: key,
+      },
+      operator: {
+        value,
+        name: operator,
+      },
+    };
+  }
+
+  return undefined;
+}

--- a/src/schema/mapper.ts
+++ b/src/schema/mapper.ts
@@ -47,6 +47,13 @@ export const tablesToDefinition = (tables: AdxTableSchema[]): QueryEditorPropert
   }));
 };
 
+export const valueToDefinition = (name: string) => {
+  return {
+    value: name,
+    label: name.replace(new RegExp(escapeRegExp(DYNAMIC_TYPE_ARRAY_DELIMITER), 'g'), '[ ]'),
+  };
+};
+
 export const columnsToDefinition = (columns: AdxColumnSchema[]): QueryEditorPropertyDefinition[] => {
   if (!Array.isArray(columns)) {
     return [];

--- a/src/schema/types.ts
+++ b/src/schema/types.ts
@@ -16,7 +16,7 @@ export interface QueryEditorProperty {
 }
 
 export type QueryEditorOperatorType = string | boolean | number | SelectableValue<string>;
-type QueryEditorOperatorValueType = QueryEditorOperatorType | QueryEditorOperatorType[];
+export type QueryEditorOperatorValueType = QueryEditorOperatorType | QueryEditorOperatorType[];
 
 export interface QueryEditorOperator<T = QueryEditorOperatorValueType> {
   name: string;

--- a/src/types.ts
+++ b/src/types.ts
@@ -33,7 +33,7 @@ export interface AutoCompleteQuery {
   database: string;
   search: QueryEditorOperatorExpression;
   expression: QueryExpression;
-  index: string;
+  index?: string;
 }
 
 export enum EditorMode {


### PR DESCRIPTION
This PR adds the filter section to the new editor. The biggest change from the previous experience is that now, rather than selecting "AND" or "OR" conditions when adding new filters, users select a new "Filter group" (AND) or a simply a new filter (OR). This is explained in the tooltips.

This is a demo (sorry, I don't know why the cursor is not displayed :thinking:):

https://user-images.githubusercontent.com/4025665/186642991-482e3174-894c-4972-a032-5237655832af.mp4

Please give it a try and let me know if you find any issue! Or if you have any UX suggestion.

It's difficult to review such a big PR so I'll add inline comments to try to make it easier and provide focus points.
