### PR TITLE
Fix default loading

### DIFF
--- a/src/components/QueryEditor/QueryHeader.test.tsx
+++ b/src/components/QueryEditor/QueryHeader.test.tsx
@@ -55,6 +55,14 @@ describe('QueryEditor', () => {
         },
       },
     };
+
+    it('should select a database by default', async () => {
+      const onChange = jest.fn();
+      render(<QueryHeader {...defaultProps} schema={schema} onChange={onChange} />);
+      await waitFor(() => screen.getByText('foo'));
+      expect(onChange).toHaveBeenCalledWith(expect.objectContaining({ database: 'foo' }));
+    });
+
     it('should render with the default database selected', async () => {
       const ds = mockDatasource();
       ds.getDefaultOrFirstDatabase = jest.fn().mockResolvedValue('bar');

--- a/src/components/QueryEditor/QueryHeader.tsx
+++ b/src/components/QueryEditor/QueryHeader.tsx
@@ -52,6 +52,12 @@ export const QueryHeader = (props: QueryEditorHeaderProps) => {
   };
 
   useEffect(() => {
+    if (!query.database && database) {
+      onChange({ ...query, database });
+    }
+  }, [query, database, onChange]);
+
+  useEffect(() => {
     if (rawMode) {
       setFormats(EDITOR_FORMATS.concat(adxTimeFormat));
     } else {


### PR DESCRIPTION
Noticed that when creating a new query (with the new editor), this error appears:

![Screenshot from 2022-09-12 11-54-15](https://user-images.githubusercontent.com/4025665/189625447-ab509d16-137e-49da-b429-23c8832496df.png)

It was because the default database was not being stored in the query object.