### PR TITLE
Add run button

### DIFF
--- a/src/components/QueryEditor/QueryEditor.tsx
+++ b/src/components/QueryEditor/QueryEditor.tsx
@@ -45,6 +45,7 @@ export const QueryEditor: React.FC<Props> = (props) => {
         datasource={datasource}
         dirty={dirty}
         setDirty={setDirty}
+        onRunQuery={onRunQuery}
       />
       {query.rawMode ? (
         <RawQueryEditor

--- a/src/components/QueryEditor/QueryHeader.test.tsx
+++ b/src/components/QueryEditor/QueryHeader.test.tsx
@@ -102,7 +102,7 @@ describe('QueryEditor', () => {
       const onRunQuery = jest.fn();
       render(<QueryHeader {...defaultProps} schema={schema} onRunQuery={onRunQuery} />);
       await waitFor(() => screen.getByText('foo'));
-      screen.getByRole('button').click();
+      screen.getByText('Run query').click();
       expect(onRunQuery).toHaveBeenCalledTimes(1);
     });
   });

--- a/src/components/QueryEditor/QueryHeader.test.tsx
+++ b/src/components/QueryEditor/QueryHeader.test.tsx
@@ -34,6 +34,7 @@ const defaultProps = {
   schema: defaultSchema,
   dirty: false,
   setDirty: jest.fn(),
+  onRunQuery: jest.fn(),
 };
 
 describe('QueryEditor', () => {
@@ -95,6 +96,14 @@ describe('QueryEditor', () => {
       b.click();
       expect(onChange).toHaveBeenCalledWith(expect.objectContaining({ rawMode: false }));
       expect(setDirty).toHaveBeenCalledWith(false);
+    });
+
+    it('runs a query', async () => {
+      const onRunQuery = jest.fn();
+      render(<QueryHeader {...defaultProps} schema={schema} onRunQuery={onRunQuery} />);
+      await waitFor(() => screen.getByText('foo'));
+      screen.getByRole('button').click();
+      expect(onRunQuery).toHaveBeenCalledTimes(1);
     });
   });
 

--- a/src/components/QueryEditor/QueryHeader.tsx
+++ b/src/components/QueryEditor/QueryHeader.tsx
@@ -101,8 +101,8 @@ export const QueryHeader = (props: QueryEditorHeaderProps) => {
         }}
       />
       <FlexItem grow={1} />
-      <Button variant="primary" icon="play" size="sm" onClick={() => onRunQuery()}>
-        Run
+      <Button variant="primary" icon="play" size="sm" onClick={onRunQuery}>
+        Run query
       </Button>
       <RadioButtonGroup
         size="sm"

--- a/src/components/QueryEditor/QueryHeader.tsx
+++ b/src/components/QueryEditor/QueryHeader.tsx
@@ -1,6 +1,6 @@
 import React, { useMemo, useState, useEffect } from 'react';
 
-import { ConfirmModal, RadioButtonGroup } from '@grafana/ui';
+import { Button, ConfirmModal, RadioButtonGroup } from '@grafana/ui';
 import { EditorHeader, FlexItem, InlineSelect } from '@grafana/experimental';
 
 import { AdxSchema, EditorMode, KustoQuery } from '../../types';
@@ -18,6 +18,7 @@ export interface QueryEditorHeaderProps {
   dirty: boolean;
   setDirty: (b: boolean) => void;
   onChange: (value: KustoQuery) => void;
+  onRunQuery: () => void;
 }
 
 const EDITOR_MODES = [
@@ -36,7 +37,7 @@ const adxTimeFormat: SelectableValue<string> = {
 };
 
 export const QueryHeader = (props: QueryEditorHeaderProps) => {
-  const { query, onChange, schema, datasource, dirty, setDirty } = props;
+  const { query, onChange, schema, datasource, dirty, setDirty, onRunQuery } = props;
   const { rawMode } = query;
   const databases = useDatabaseOptions(schema.value);
   const database = useSelectedDatabase(databases, props.query, datasource);
@@ -100,6 +101,9 @@ export const QueryHeader = (props: QueryEditorHeaderProps) => {
         }}
       />
       <FlexItem grow={1} />
+      <Button variant="primary" icon="play" size="sm" onClick={() => onRunQuery()}>
+        Run
+      </Button>
       <RadioButtonGroup
         size="sm"
         options={EDITOR_MODES}

--- a/src/components/QueryEditor/RawQueryEditor.tsx
+++ b/src/components/QueryEditor/RawQueryEditor.tsx
@@ -31,7 +31,6 @@ export const RawQueryEditor: React.FC<RawQueryEditorProps> = (props) => {
       ...props.query,
       query: kql,
     });
-    props.onRunQuery();
   };
 
   const { query, schema } = props;

--- a/src/components/QueryEditor/RawQueryEditor.tsx
+++ b/src/components/QueryEditor/RawQueryEditor.tsx
@@ -26,11 +26,13 @@ export const RawQueryEditor: React.FC<RawQueryEditorProps> = (props) => {
   const [variables] = useState(getTemplateSrv().getVariables());
 
   const onRawQueryChange = (kql: string) => {
-    props.setDirty();
-    props.onChange({
-      ...props.query,
-      query: kql,
-    });
+    if (kql !== props.query.query) {
+      props.setDirty();
+      props.onChange({
+        ...props.query,
+        query: kql,
+      });
+    }
   };
 
   const { query, schema } = props;


### PR DESCRIPTION
Adding a "Run" button to run queries both in the query builder and the raw editor (removed the onBlur behavior there):

![Screenshot from 2022-09-12 12-35-33](https://user-images.githubusercontent.com/4025665/189633395-04540809-9a94-4834-bfc9-ada3aa1feaa7.png)

Unrealted but added to this PR: avoid showing the confirmation modal changing from raw to builder if the query has not changed.