### PR TITLE
New editor: Fix default query

### DIFF
--- a/src/components/QueryEditor/QueryHeader.test.tsx
+++ b/src/components/QueryEditor/QueryHeader.test.tsx
@@ -57,6 +57,13 @@ describe('QueryEditor', () => {
       },
     };
 
+    it('should select a format by default', async () => {
+      const onChange = jest.fn();
+      render(<QueryHeader {...defaultProps} schema={schema} onChange={onChange} />);
+      await waitFor(() => screen.getByText('foo'));
+      expect(onChange).toHaveBeenCalledWith(expect.objectContaining({ resultFormat: 'table' }));
+    });
+
     it('should select a database by default', async () => {
       const onChange = jest.fn();
       render(<QueryHeader {...defaultProps} schema={schema} onChange={onChange} />);

--- a/src/components/QueryEditor/QueryHeader.tsx
+++ b/src/components/QueryEditor/QueryHeader.tsx
@@ -67,6 +67,9 @@ export const QueryHeader = (props: QueryEditorHeaderProps) => {
   }, [rawMode]);
 
   useEffect(() => {
+    if (!query.resultFormat) {
+      onChange({ ...query, resultFormat: 'table' });
+    }
     if (query.resultFormat === adxTimeFormat.value && !formats.includes(adxTimeFormat)) {
       // Fallback to Time Series since time_series_adx_series is not available
       onChange({ ...query, resultFormat: 'time_series' });

--- a/src/components/QueryEditor/VisualQueryEditor.test.tsx
+++ b/src/components/QueryEditor/VisualQueryEditor.test.tsx
@@ -2,6 +2,8 @@ import { render, screen, waitFor } from '@testing-library/react';
 import React from 'react';
 import { VisualQueryEditor } from './VisualQueryEditor';
 import { mockDatasource, mockQuery } from '../__fixtures__/Datasource';
+import { QueryEditorPropertyType } from 'schema/types';
+import { QueryEditorExpressionType } from 'components/LegacyQueryEditor/editor/expressions';
 
 jest.mock('@grafana/runtime', () => {
   const original = jest.requireActual('@grafana/runtime');
@@ -53,8 +55,21 @@ describe('VisualQueryEditor', () => {
 
   it('should render the VisualQueryEditor with a schema', async () => {
     const datasource = mockDatasource();
+    const onChange = jest.fn();
     datasource.getSchema = jest.fn().mockResolvedValue(schema);
-    render(<VisualQueryEditor {...defaultProps} datasource={datasource} database="foo" schema={schema} />);
+    render(
+      <VisualQueryEditor {...defaultProps} datasource={datasource} database="foo" schema={schema} onChange={onChange} />
+    );
     await waitFor(() => screen.getByText('bar'));
+    expect(onChange).toHaveBeenCalledWith(
+      expect.objectContaining({
+        expression: expect.objectContaining({
+          from: {
+            property: { name: 'bar', type: QueryEditorPropertyType.String },
+            type: QueryEditorExpressionType.Property,
+          },
+        }),
+      })
+    );
   });
 });

--- a/src/components/QueryEditor/VisualQueryEditor.tsx
+++ b/src/components/QueryEditor/VisualQueryEditor.tsx
@@ -38,19 +38,18 @@ export const VisualQueryEditor: React.FC<VisualQueryEditorProps> = (props) => {
     const name = tableMapping?.value ?? tableName;
     const schema = await getTableSchema(datasource, databaseName, name);
     const expression = query.expression ?? defaultQuery.expression;
+    const newExpression = {
+      ...expression,
+      from: {
+        type: QueryEditorExpressionType.Property,
+        property: { type: QueryEditorPropertyType.String, name: table.value },
+      },
+    };
 
     onChange({
       ...query,
-      query: parseExpression(
-        {
-          ...expression,
-          from: {
-            type: QueryEditorExpressionType.Property,
-            property: { type: QueryEditorPropertyType.String, name: table.value },
-          },
-        },
-        schema
-      ),
+      expression: newExpression,
+      query: parseExpression(newExpression, schema),
     });
 
     return schema;


### PR DESCRIPTION
From: https://github.com/grafana/azure-data-explorer-datasource/pull/464#issuecomment-1245180594

Ref: https://github.com/grafana/azure-data-explorer-datasource/issues/391

Save the default format and table in the query. This fixes the following error:

![Screenshot from 2022-09-13 11-58-30](https://user-images.githubusercontent.com/4025665/189882853-456eaf4c-e705-4d9b-ac42-007bb51a2513.png)

