### PR TITLE
New editor: fix clean up when changing table

### DIFF
--- a/src/components/QueryEditor/QueryHeader.test.tsx
+++ b/src/components/QueryEditor/QueryHeader.test.tsx
@@ -5,7 +5,7 @@ import { openMenu } from 'react-select-event';
 
 import { mockDatasource, mockQuery } from '../__fixtures__/Datasource';
 import { AsyncState } from 'react-use/lib/useAsyncFn';
-import { AdxSchema } from 'types';
+import { AdxSchema, defaultQuery } from 'types';
 
 jest.mock('@grafana/runtime', () => {
   const original = jest.requireActual('@grafana/runtime');
@@ -85,7 +85,9 @@ describe('QueryEditor', () => {
       const sel = screen.getByLabelText('Database:');
       openMenu(sel);
       screen.getByText('bar').click();
-      expect(onChange).toHaveBeenCalledWith(expect.objectContaining({ database: 'bar' }));
+      expect(onChange).toHaveBeenCalledWith(
+        expect.objectContaining({ database: 'bar', expression: defaultQuery.expression })
+      );
     });
 
     it('should show a warning if switching from raw mode', async () => {

--- a/src/components/QueryEditor/QueryHeader.tsx
+++ b/src/components/QueryEditor/QueryHeader.tsx
@@ -3,7 +3,7 @@ import React, { useMemo, useState, useEffect } from 'react';
 import { Button, ConfirmModal, RadioButtonGroup } from '@grafana/ui';
 import { EditorHeader, FlexItem, InlineSelect } from '@grafana/experimental';
 
-import { AdxSchema, EditorMode, KustoQuery } from '../../types';
+import { AdxSchema, defaultQuery, EditorMode, KustoQuery } from '../../types';
 import { AsyncState } from 'react-use/lib/useAsyncFn';
 import { AdxDataSource } from 'datasource';
 import { QueryEditorPropertyDefinition } from 'schema/types';
@@ -98,7 +98,7 @@ export const QueryHeader = (props: QueryEditorHeaderProps) => {
         value={database}
         isLoading={schema.loading}
         onChange={({ value }) => {
-          onChange({ ...query, database: value! });
+          onChange({ ...query, database: value!, expression: defaultQuery.expression });
         }}
       />
       <InlineSelect

--- a/src/components/QueryEditor/VisualQueryEditor/AggregateSection.test.tsx
+++ b/src/components/QueryEditor/VisualQueryEditor/AggregateSection.test.tsx
@@ -63,4 +63,34 @@ describe('AggregateSection', () => {
       })
     );
   });
+
+  it('cleans up the when the table changes', () => {
+    const query = {
+      ...defaultProps.query,
+      expression: {
+        ...defaultProps.query.expression,
+        from: {
+          type: QueryEditorExpressionType.Property,
+          property: { type: QueryEditorPropertyType.String, name: 'mytable' },
+        },
+        reduce: {
+          expressions: [
+            {
+              parameters: undefined,
+              property: { name: 'foo', type: QueryEditorPropertyType.String },
+              reduce: { name: AggregateFunctions.Avg, type: QueryEditorPropertyType.String },
+              type: QueryEditorExpressionType.Reduce,
+            },
+          ],
+          type: QueryEditorExpressionType.And,
+        },
+      },
+    };
+    const { rerender } = render(<AggregateSection {...defaultProps} query={query} />);
+    expect(screen.getByText('foo')).toBeInTheDocument();
+    query.expression.from!.property.name = 'other';
+    query.expression.reduce.expressions = [];
+    rerender(<AggregateSection {...defaultProps} query={query} />);
+    expect(screen.queryByText('foo')).not.toBeInTheDocument();
+  });
 });

--- a/src/components/QueryEditor/VisualQueryEditor/AggregateSection.tsx
+++ b/src/components/QueryEditor/VisualQueryEditor/AggregateSection.tsx
@@ -30,12 +30,22 @@ const AggregateSection: React.FC<AggregateSectionProps> = ({
 }) => {
   const expressions = query.expression.reduce.expressions;
   const [aggregates, setAggregates] = useState(expressions);
+  const [currentTable, setCurrentTable] = useState(query.expression.from?.property.name);
 
   useEffect(() => {
     if (!aggregates.length && expressions?.length) {
       setAggregates(expressions);
     }
   }, [aggregates.length, expressions]);
+
+  useEffect(() => {
+    // New table
+    if (currentTable !== query.expression.from?.property.name) {
+      // Reset state
+      setAggregates([]);
+      setCurrentTable(query.expression.from?.property.name);
+    }
+  }, [currentTable, query.expression.from?.property.name]);
 
   const onChange = (newItems: Array<Partial<QueryEditorReduceExpression>>) => {
     const cleaned = newItems.map(

--- a/src/components/QueryEditor/VisualQueryEditor/GroupBySection.test.tsx
+++ b/src/components/QueryEditor/VisualQueryEditor/GroupBySection.test.tsx
@@ -49,4 +49,32 @@ describe('GroupBySection', () => {
       })
     );
   });
+
+  it('cleans up the when the table changes', () => {
+    const query = {
+      ...defaultProps.query,
+      expression: {
+        ...defaultProps.query.expression,
+        from: {
+          type: QueryEditorExpressionType.Property,
+          property: { type: QueryEditorPropertyType.String, name: 'mytable' },
+        },
+        groupBy: {
+          expressions: [
+            {
+              property: { name: 'foo', type: QueryEditorPropertyType.String },
+              type: QueryEditorExpressionType.GroupBy,
+            },
+          ],
+          type: QueryEditorExpressionType.And,
+        },
+      },
+    };
+    const { rerender } = render(<GroupBySection {...defaultProps} query={query} />);
+    expect(screen.getByText('foo')).toBeInTheDocument();
+    query.expression.from!.property.name = 'other';
+    query.expression.groupBy.expressions = [];
+    rerender(<GroupBySection {...defaultProps} query={query} />);
+    expect(screen.queryByText('foo')).not.toBeInTheDocument();
+  });
 });

--- a/src/components/QueryEditor/VisualQueryEditor/GroupBySection.tsx
+++ b/src/components/QueryEditor/VisualQueryEditor/GroupBySection.tsx
@@ -30,12 +30,22 @@ const GroupBySection: React.FC<GroupBySectionProps> = ({
 }) => {
   const expressions = query.expression.groupBy.expressions;
   const [groupBys, setGroupBys] = useState(expressions);
+  const [currentTable, setCurrentTable] = useState(query.expression.from?.property.name);
 
   useEffect(() => {
     if (!groupBys.length && expressions?.length) {
       setGroupBys(expressions);
     }
   }, [groupBys.length, expressions]);
+
+  useEffect(() => {
+    // New table
+    if (currentTable !== query.expression.from?.property.name) {
+      // Reset state
+      setGroupBys([]);
+      setCurrentTable(query.expression.from?.property.name);
+    }
+  }, [currentTable, query.expression.from?.property.name]);
 
   const onChange = (newItems: Array<Partial<QueryEditorGroupByExpression>>) => {
     const cleaned = newItems.map(


### PR DESCRIPTION
Fix the editor to clean up the rest of fields when the table or the database changes

![Peek 2022-09-15 17-00](https://user-images.githubusercontent.com/4025665/190438298-01b2ac46-6578-4cff-849c-50c8b80e45ac.gif)

![Peek 2022-09-15 17-01](https://user-images.githubusercontent.com/4025665/190438366-c12f19ba-447d-4304-ad9f-112e2890d1eb.gif)
