### PR TITLE
New editor: Add column selector

### DIFF
--- a/src/KustoExpressionParser.test.ts
+++ b/src/KustoExpressionParser.test.ts
@@ -200,6 +200,18 @@ describe('KustoExpressionParser', () => {
   });
 
   describe('toQuery', () => {
+    it('should parse expression with columns', () => {
+      const expression = createQueryExpression({
+        from: createProperty('StormEvents'),
+        columns: {
+          type: QueryEditorExpressionType.Property,
+          columns: ['foo', 'bar'],
+        },
+      });
+
+      expect(parser.toQuery(expression)).toEqual('StormEvents' + '\n| project foo, bar');
+    });
+
     it('should parse expression with where equal to string value', () => {
       const expression = createQueryExpression({
         from: createProperty('StormEvents'),
@@ -207,6 +219,18 @@ describe('KustoExpressionParser', () => {
       });
 
       expect(parser.toQuery(expression)).toEqual('StormEvents' + "\n| where eventType == 'ThunderStorm'");
+    });
+
+    it('should parse expression with columns with spaces', () => {
+      const expression = createQueryExpression({
+        from: createProperty('StormEvents'),
+        columns: {
+          type: QueryEditorExpressionType.Property,
+          columns: ['foo bar'],
+        },
+      });
+
+      expect(parser.toQuery(expression)).toEqual('StormEvents' + '\n| project ["foo bar"]');
     });
 
     it('should parse where operator with a space', () => {
@@ -379,6 +403,25 @@ describe('KustoExpressionParser', () => {
           '\n| where isActive == true' +
           `\n| order by StartTime asc`
       );
+    });
+
+    it('should parse expression without a time filter if the selected columns does not include the time column', () => {
+      const expression = createQueryExpression({
+        from: createProperty('StormEvents'),
+        columns: {
+          type: QueryEditorExpressionType.Property,
+          columns: ['foo'],
+        },
+      });
+
+      const tableSchema: AdxColumnSchema[] = [
+        {
+          Name: 'StartTime',
+          CslType: 'datetime',
+        },
+      ];
+
+      expect(parser.toQuery(expression, tableSchema)).toEqual('StormEvents' + '\n| project foo');
     });
 
     it('should parse expression with time filter when schema contains multiple time columns', () => {

--- a/src/components/LegacyQueryEditor/editor/expressions.ts
+++ b/src/components/LegacyQueryEditor/editor/expressions.ts
@@ -38,6 +38,10 @@ export interface QueryEditorGroupByExpression extends QueryEditorExpression {
   interval?: QueryEditorProperty;
 }
 
+export interface QueryEditorColumnsExpression extends QueryEditorExpression {
+  columns?: string[];
+}
+
 export interface QueryEditorArrayExpression extends QueryEditorExpression {
   expressions: QueryEditorExpression[] | QueryEditorArrayExpression[];
 }

--- a/src/components/QueryEditor/VisualQueryEditor.test.tsx
+++ b/src/components/QueryEditor/VisualQueryEditor.test.tsx
@@ -1,9 +1,10 @@
-import { render, screen, waitFor } from '@testing-library/react';
+import { render, screen, waitFor, within } from '@testing-library/react';
 import React from 'react';
 import { VisualQueryEditor } from './VisualQueryEditor';
 import { mockDatasource, mockQuery } from '../__fixtures__/Datasource';
 import { QueryEditorPropertyType } from 'schema/types';
 import { QueryEditorExpressionType } from 'components/LegacyQueryEditor/editor/expressions';
+import { openMenu } from 'react-select-event';
 
 jest.mock('@grafana/runtime', () => {
   const original = jest.requireActual('@grafana/runtime');
@@ -35,6 +36,10 @@ const schema = {
           OrderedColumns: [
             {
               Name: 'foobar',
+              CslType: 'string',
+            },
+            {
+              Name: 'barfoo',
               CslType: 'string',
             },
           ],
@@ -71,5 +76,48 @@ describe('VisualQueryEditor', () => {
         }),
       })
     );
+  });
+
+  it('selecting a column should remove the rest from other selectors', async () => {
+    const datasource = mockDatasource();
+    const onChange = jest.fn();
+    datasource.getSchema = jest.fn().mockResolvedValue(schema);
+    const { rerender } = render(
+      <VisualQueryEditor {...defaultProps} datasource={datasource} database="foo" schema={schema} onChange={onChange} />
+    );
+    await waitFor(() => screen.getByText('bar'));
+    const sel = screen.getByLabelText('Columns');
+    openMenu(sel);
+    screen.getByText('foobar').click();
+    expect(onChange).toHaveBeenCalledWith(
+      expect.objectContaining({
+        expression: expect.objectContaining({
+          columns: {
+            columns: ['foobar'],
+            type: QueryEditorExpressionType.Property,
+          },
+        }),
+      })
+    );
+    // simulate update
+    rerender(
+      <VisualQueryEditor
+        {...defaultProps}
+        datasource={datasource}
+        database="foo"
+        schema={schema}
+        onChange={onChange}
+        query={onChange.mock.calls[onChange.mock.calls.length - 1][0]}
+      />
+    );
+    // Add a section
+    const as = screen.getByTestId('aggregate-section');
+    within(as).getByRole('button').click();
+    const selCol = within(as).getByLabelText('column');
+    openMenu(selCol);
+    // The column is now displayed in the both selectors
+    expect(screen.getAllByText('foobar')).toHaveLength(2);
+    // But the other column is not
+    expect(screen.queryByText('barfoo')).not.toBeInTheDocument();
   });
 });

--- a/src/components/QueryEditor/VisualQueryEditor.tsx
+++ b/src/components/QueryEditor/VisualQueryEditor.tsx
@@ -48,7 +48,7 @@ export const VisualQueryEditor: React.FC<VisualQueryEditorProps> = (props) => {
   }, [tableSchema.value, query.expression?.columns]);
 
   useEffect(() => {
-    if (tableSchema.value) {
+    if (tableSchema.value?.length) {
       onChange({
         ...query,
         query: parseExpression(query.expression, tableSchema.value),

--- a/src/components/QueryEditor/VisualQueryEditor.tsx
+++ b/src/components/QueryEditor/VisualQueryEditor.tsx
@@ -54,6 +54,8 @@ export const VisualQueryEditor: React.FC<VisualQueryEditorProps> = (props) => {
         query: parseExpression(query.expression, tableSchema.value),
       });
     }
+    // We are only interested on re-parsing if the expression changes
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [query.expression, tableSchema.value]);
 
   if (!schema) {

--- a/src/components/QueryEditor/VisualQueryEditor.tsx
+++ b/src/components/QueryEditor/VisualQueryEditor.tsx
@@ -1,19 +1,20 @@
 import { QueryEditorProps, SelectableValue } from '@grafana/data';
 import { getTemplateSrv } from '@grafana/runtime';
-import { Alert, Select } from '@grafana/ui';
-import { EditorField, EditorFieldGroup, EditorRow, EditorRows } from '@grafana/experimental';
-import { QueryEditorExpressionType } from 'components/LegacyQueryEditor/editor/expressions';
+import { Alert } from '@grafana/ui';
+import { EditorRows } from '@grafana/experimental';
 import { AdxDataSource } from 'datasource';
-import React, { useMemo } from 'react';
+import React, { useMemo, useState, useEffect } from 'react';
 import { useAsync } from 'react-use';
 import { AdxSchemaResolver } from 'schema/AdxSchemaResolver';
-import { QueryEditorPropertyDefinition, QueryEditorPropertyType } from 'schema/types';
-import { AdxDataSourceOptions, AdxSchema, defaultQuery, KustoQuery } from 'types';
+import { QueryEditorPropertyDefinition } from 'schema/types';
+import { AdxColumnSchema, AdxDataSourceOptions, AdxSchema, KustoQuery } from 'types';
 import FilterSection from './VisualQueryEditor/FilterSection';
 import AggregateSection from './VisualQueryEditor/AggregateSection';
 import GroupBySection from './VisualQueryEditor/GroupBySection';
 import KQLPreview from './VisualQueryEditor/KQLPreview';
 import Timeshift from './VisualQueryEditor/Timeshift';
+import TableSection from './VisualQueryEditor/TableSection';
+import { filterColumns } from './VisualQueryEditor/utils/utils';
 
 type Props = QueryEditorProps<AdxDataSource, KustoQuery, AdxDataSourceOptions>;
 
@@ -25,12 +26,11 @@ interface VisualQueryEditorProps extends Props {
 
 export const VisualQueryEditor: React.FC<VisualQueryEditorProps> = (props) => {
   const templateSrv = getTemplateSrv();
-  const { schema, database, datasource, query, onChange, templateVariableOptions } = props;
+  const { schema, database, datasource, query, onChange } = props;
   const { id: datasourceId, parseExpression, getSchemaMapper } = datasource;
   const databaseName = templateSrv.replace(database);
   const tables = useTableOptions(schema, databaseName, datasource);
   const table = useSelectedTable(tables, query, datasource);
-  const tableOptions = (tables as Array<SelectableValue<string>>).concat(templateVariableOptions);
   const tableName = getTemplateSrv().replace(table?.value ?? '');
   const tableMapping = getSchemaMapper().getMappingByValue(table?.value);
   const tableSchema = useAsync(async () => {
@@ -39,24 +39,22 @@ export const VisualQueryEditor: React.FC<VisualQueryEditorProps> = (props) => {
     }
 
     const name = tableMapping?.value ?? tableName;
-    const schema = await getTableSchema(datasource, databaseName, name);
-    const expression = query.expression ?? defaultQuery.expression;
-    const newExpression = {
-      ...expression,
-      from: {
-        type: QueryEditorExpressionType.Property,
-        property: { type: QueryEditorPropertyType.String, name: table.value },
-      },
-    };
-
-    onChange({
-      ...query,
-      expression: newExpression,
-      query: parseExpression(newExpression, schema),
-    });
-
-    return schema;
+    return await getTableSchema(datasource, databaseName, name);
   }, [datasourceId, databaseName, tableName, tableMapping?.value]);
+  const [tableColumns, setTableColumns] = useState<AdxColumnSchema[]>([]);
+
+  useEffect(() => {
+    setTableColumns(filterColumns(tableSchema.value, query.expression?.columns) || []);
+  }, [tableSchema.value, query.expression?.columns]);
+
+  useEffect(() => {
+    if (tableSchema.value) {
+      onChange({
+        ...query,
+        query: parseExpression(query.expression, tableSchema.value),
+      });
+    }
+  }, [query.expression, tableSchema.value]);
 
   if (!schema) {
     return null;
@@ -72,35 +70,11 @@ export const VisualQueryEditor: React.FC<VisualQueryEditorProps> = (props) => {
       {!tableSchema.loading && tableSchema.value?.length === 0 && (
         <Alert severity="warning" title="Table schema loaded successfully but without any columns" />
       )}
-      <EditorRow>
-        <EditorFieldGroup>
-          <EditorField label="Table" width={16}>
-            <Select
-              aria-label="Table"
-              isLoading={tableSchema.loading}
-              value={table}
-              options={tableOptions}
-              allowCustomValue
-              onChange={({ value }) => {
-                onChange({
-                  ...query,
-                  expression: {
-                    ...defaultQuery.expression,
-                    from: {
-                      type: QueryEditorExpressionType.Property,
-                      property: { type: QueryEditorPropertyType.String, name: value },
-                    },
-                  },
-                });
-              }}
-            />
-          </EditorField>
-        </EditorFieldGroup>
-      </EditorRow>
-      <FilterSection {...props} tableSchema={tableSchema} />
-      <AggregateSection {...props} tableSchema={tableSchema} />
-      <GroupBySection {...props} tableSchema={tableSchema} />
-      <Timeshift {...props} tableSchema={tableSchema} />
+      <TableSection {...props} tableSchema={tableSchema} tables={tables} table={table} />
+      <FilterSection {...props} columns={tableColumns} />
+      <AggregateSection {...props} columns={tableColumns} />
+      <GroupBySection {...props} columns={tableColumns} />
+      <Timeshift {...props} />
       <KQLPreview query={props.query.query} />
     </EditorRows>
   );

--- a/src/components/QueryEditor/VisualQueryEditor/AggregateSection.test.tsx
+++ b/src/components/QueryEditor/VisualQueryEditor/AggregateSection.test.tsx
@@ -11,15 +11,7 @@ const defaultProps = {
   datasource: mockDatasource(),
   query: mockQuery,
   templateVariableOptions: {},
-  tableSchema: {
-    loading: false,
-    value: [
-      {
-        Name: 'foo',
-        CslType: 'string',
-      },
-    ],
-  },
+  columns: [{ Name: 'foo', CslType: 'string' }],
   database: 'db',
   onChange: jest.fn(),
   onRunQuery: jest.fn(),

--- a/src/components/QueryEditor/VisualQueryEditor/AggregateSection.tsx
+++ b/src/components/QueryEditor/VisualQueryEditor/AggregateSection.tsx
@@ -7,7 +7,6 @@ import {
 } from 'components/LegacyQueryEditor/editor/expressions';
 import { AdxDataSource } from 'datasource';
 import React, { useState, useEffect } from 'react';
-import { AsyncState } from 'react-use/lib/useAsyncFn';
 import { AdxColumnSchema, AdxDataSourceOptions, KustoQuery } from 'types';
 import { QueryEditorPropertyType } from 'schema/types';
 import { sanitizeAggregate } from './utils/utils';
@@ -16,7 +15,7 @@ import AggregateItem from './AggregateItem';
 type Props = QueryEditorProps<AdxDataSource, KustoQuery, AdxDataSourceOptions>;
 
 interface AggregateSectionProps extends Props {
-  tableSchema: AsyncState<AdxColumnSchema[]>;
+  columns: AdxColumnSchema[];
   database: string;
   templateVariableOptions: SelectableValue<string>;
 }
@@ -24,7 +23,7 @@ interface AggregateSectionProps extends Props {
 const AggregateSection: React.FC<AggregateSectionProps> = ({
   query,
   datasource,
-  tableSchema,
+  columns,
   templateVariableOptions,
   onChange: onQueryChange,
 }) => {
@@ -64,24 +63,23 @@ const AggregateSection: React.FC<AggregateSectionProps> = ({
     onQueryChange({
       ...query,
       expression: newExpression,
-      query: datasource.parseExpression(newExpression, tableSchema.value),
     });
   };
 
   return (
-    <>
+    <div data-testid="aggregate-section">
       <EditorRow>
         <EditorFieldGroup>
           <EditorField label="Aggregate" optional={true}>
             <EditorList
               items={aggregates}
               onChange={onChange}
-              renderItem={makeRenderAggregate(datasource, query, tableSchema.value, templateVariableOptions)}
+              renderItem={makeRenderAggregate(datasource, query, columns, templateVariableOptions)}
             />
           </EditorField>
         </EditorFieldGroup>
       </EditorRow>
-    </>
+    </div>
   );
 };
 

--- a/src/components/QueryEditor/VisualQueryEditor/FilterSection.test.tsx
+++ b/src/components/QueryEditor/VisualQueryEditor/FilterSection.test.tsx
@@ -9,9 +9,7 @@ const defaultProps = {
   datasource: mockDatasource(),
   query: mockQuery,
   templateVariableOptions: {},
-  tableSchema: {
-    loading: false,
-  },
+  columns: [{ Name: 'foo', CslType: 'string' }],
   database: 'db',
   onChange: jest.fn(),
   onRunQuery: jest.fn(),

--- a/src/components/QueryEditor/VisualQueryEditor/FilterSection.tsx
+++ b/src/components/QueryEditor/VisualQueryEditor/FilterSection.tsx
@@ -4,14 +4,13 @@ import { EditorField, EditorFieldGroup, EditorRow } from '@grafana/experimental'
 import { QueryEditorExpressionType } from 'components/LegacyQueryEditor/editor/expressions';
 import { AdxDataSource } from 'datasource';
 import React from 'react';
-import { AsyncState } from 'react-use/lib/useAsyncFn';
 import { AdxColumnSchema, AdxDataSourceOptions, KustoQuery } from 'types';
 import KQLFilter from './KQLFilter';
 
 type Props = QueryEditorProps<AdxDataSource, KustoQuery, AdxDataSourceOptions>;
 
 interface FilterSectionProps extends Props {
-  tableSchema: AsyncState<AdxColumnSchema[]>;
+  columns: AdxColumnSchema[];
   database: string;
   templateVariableOptions: SelectableValue<string>;
 }
@@ -20,7 +19,7 @@ const FilterSection: React.FC<FilterSectionProps> = ({
   query,
   onChange,
   datasource,
-  tableSchema,
+  columns,
   templateVariableOptions,
 }) => {
   return (
@@ -38,7 +37,7 @@ const FilterSection: React.FC<FilterSectionProps> = ({
                 query={query}
                 onChange={onChange}
                 datasource={datasource}
-                columns={tableSchema.value}
+                columns={columns}
                 templateVariableOptions={templateVariableOptions}
               />
             </EditorField>

--- a/src/components/QueryEditor/VisualQueryEditor/GroupBySection.test.tsx
+++ b/src/components/QueryEditor/VisualQueryEditor/GroupBySection.test.tsx
@@ -10,15 +10,7 @@ const defaultProps = {
   datasource: mockDatasource(),
   query: mockQuery,
   templateVariableOptions: {},
-  tableSchema: {
-    loading: false,
-    value: [
-      {
-        Name: 'foo',
-        CslType: 'string',
-      },
-    ],
-  },
+  columns: [{ Name: 'foo', CslType: 'string' }],
   database: 'db',
   onChange: jest.fn(),
   onRunQuery: jest.fn(),

--- a/src/components/QueryEditor/VisualQueryEditor/GroupBySection.tsx
+++ b/src/components/QueryEditor/VisualQueryEditor/GroupBySection.tsx
@@ -7,7 +7,6 @@ import {
 } from 'components/LegacyQueryEditor/editor/expressions';
 import { AdxDataSource } from 'datasource';
 import React, { useState, useEffect } from 'react';
-import { AsyncState } from 'react-use/lib/useAsyncFn';
 import { AdxColumnSchema, AdxDataSourceOptions, KustoQuery } from 'types';
 import { QueryEditorPropertyType } from 'schema/types';
 import { sanitizeGroupBy } from './utils/utils';
@@ -16,7 +15,7 @@ import GroupByItem from './GroupByItem';
 type Props = QueryEditorProps<AdxDataSource, KustoQuery, AdxDataSourceOptions>;
 
 interface GroupBySectionProps extends Props {
-  tableSchema: AsyncState<AdxColumnSchema[]>;
+  columns: AdxColumnSchema[];
   database: string;
   templateVariableOptions: SelectableValue<string>;
 }
@@ -24,7 +23,7 @@ interface GroupBySectionProps extends Props {
 const GroupBySection: React.FC<GroupBySectionProps> = ({
   query,
   datasource,
-  tableSchema,
+  columns,
   templateVariableOptions,
   onChange: onQueryChange,
 }) => {
@@ -63,7 +62,6 @@ const GroupBySection: React.FC<GroupBySectionProps> = ({
     onQueryChange({
       ...query,
       expression: newExpression,
-      query: datasource.parseExpression(newExpression, tableSchema.value),
     });
   };
 
@@ -75,7 +73,7 @@ const GroupBySection: React.FC<GroupBySectionProps> = ({
             <EditorList
               items={groupBys}
               onChange={onChange}
-              renderItem={makeRenderGroupBy(query, tableSchema.value, templateVariableOptions)}
+              renderItem={makeRenderGroupBy(query, columns, templateVariableOptions)}
             />
           </EditorField>
         </EditorFieldGroup>

--- a/src/components/QueryEditor/VisualQueryEditor/TableSection.test.tsx
+++ b/src/components/QueryEditor/VisualQueryEditor/TableSection.test.tsx
@@ -1,0 +1,65 @@
+import { render, screen } from '@testing-library/react';
+import { QueryEditorExpressionType } from 'components/LegacyQueryEditor/editor/expressions';
+import { mockDatasource, mockQuery } from 'components/__fixtures__/Datasource';
+import React from 'react';
+import { openMenu } from 'react-select-event';
+import { QueryEditorPropertyType } from 'schema/types';
+import TableSection from './TableSection';
+
+const defaultProps = {
+  datasource: mockDatasource(),
+  query: mockQuery,
+  templateVariableOptions: {},
+  tables: [{ label: 'mytable', value: 'mytable', type: QueryEditorPropertyType.String }],
+  tableSchema: {
+    loading: false,
+    value: [
+      {
+        Name: 'foo',
+        CslType: 'string',
+      },
+    ],
+  },
+  onChange: jest.fn(),
+  onRunQuery: jest.fn(),
+};
+
+describe('TableSection', () => {
+  it('should select a table', () => {
+    const onChange = jest.fn();
+    render(<TableSection {...defaultProps} onChange={onChange} />);
+    // Select a table
+    const sel = screen.getByLabelText('Table');
+    openMenu(sel);
+    screen.getByText('mytable').click();
+    expect(onChange).toHaveBeenCalledWith(
+      expect.objectContaining({
+        expression: expect.objectContaining({
+          from: {
+            type: QueryEditorExpressionType.Property,
+            property: { type: QueryEditorPropertyType.String, name: 'mytable' },
+          },
+        }),
+      })
+    );
+  });
+
+  it('should select a column', () => {
+    const onChange = jest.fn();
+    render(<TableSection {...defaultProps} onChange={onChange} />);
+    // Select a table
+    const sel = screen.getByLabelText('Columns');
+    openMenu(sel);
+    screen.getByText('foo').click();
+    expect(onChange).toHaveBeenCalledWith(
+      expect.objectContaining({
+        expression: expect.objectContaining({
+          columns: {
+            type: QueryEditorExpressionType.Property,
+            columns: ['foo'],
+          },
+        }),
+      })
+    );
+  });
+});

--- a/src/components/QueryEditor/VisualQueryEditor/TableSection.tsx
+++ b/src/components/QueryEditor/VisualQueryEditor/TableSection.tsx
@@ -7,7 +7,7 @@ import { AdxColumnSchema, AdxDataSourceOptions, defaultQuery, KustoQuery } from 
 import { QueryEditorPropertyDefinition, QueryEditorPropertyType } from 'schema/types';
 import { Select } from '@grafana/ui';
 import { AdxDataSource } from 'datasource';
-import { uniq } from 'lodash';
+import { toColumnNames } from './utils/utils';
 
 type Props = QueryEditorProps<AdxDataSource, KustoQuery, AdxDataSourceOptions>;
 
@@ -73,7 +73,7 @@ const TableSection: React.FC<TableSectionProps> = ({
             aria-label="Columns"
             isMulti
             value={query.expression.columns?.columns ? query.expression.columns.columns : []}
-            options={uniq(tableSchema.value?.map((c) => c.Name.split('[')[0])).map((c) => ({ label: c, value: c }))}
+            options={toColumnNames(tableSchema.value || []).map((c) => ({ label: c, value: c }))}
             placeholder="All"
             onChange={(e) => {
               onChange({

--- a/src/components/QueryEditor/VisualQueryEditor/TableSection.tsx
+++ b/src/components/QueryEditor/VisualQueryEditor/TableSection.tsx
@@ -1,0 +1,97 @@
+import { QueryEditorProps, SelectableValue } from '@grafana/data';
+import { EditorField, EditorFieldGroup, EditorRow } from '@grafana/experimental';
+import { QueryEditorExpressionType } from 'components/LegacyQueryEditor/editor/expressions';
+import React, { useEffect } from 'react';
+import { AsyncState } from 'react-use/lib/useAsyncFn';
+import { AdxColumnSchema, AdxDataSourceOptions, defaultQuery, KustoQuery } from 'types';
+import { QueryEditorPropertyDefinition, QueryEditorPropertyType } from 'schema/types';
+import { Select } from '@grafana/ui';
+import { AdxDataSource } from 'datasource';
+import { uniq } from 'lodash';
+
+type Props = QueryEditorProps<AdxDataSource, KustoQuery, AdxDataSourceOptions>;
+
+interface TableSectionProps extends Props {
+  tables: QueryEditorPropertyDefinition[];
+  tableSchema: AsyncState<AdxColumnSchema[]>;
+  templateVariableOptions: SelectableValue<string>;
+  table?: SelectableValue<string>;
+}
+
+const TableSection: React.FC<TableSectionProps> = ({
+  tables,
+  table,
+  query,
+  tableSchema,
+  templateVariableOptions,
+  onChange,
+}) => {
+  const tableOptions = (tables as Array<SelectableValue<string>>).concat(templateVariableOptions);
+
+  useEffect(() => {
+    if (table?.value && !query.expression.from) {
+      // New table
+      onChange({
+        ...query,
+        expression: {
+          ...query.expression,
+          from: {
+            type: QueryEditorExpressionType.Property,
+            property: { type: QueryEditorPropertyType.String, name: table.value },
+          },
+        },
+      });
+    }
+  });
+
+  return (
+    <EditorRow>
+      <EditorFieldGroup>
+        <EditorField label="Table">
+          <Select
+            aria-label="Table"
+            isLoading={tableSchema.loading}
+            value={table}
+            options={tableOptions}
+            allowCustomValue
+            onChange={({ value }) => {
+              onChange({
+                ...query,
+                expression: {
+                  ...defaultQuery.expression,
+                  from: {
+                    type: QueryEditorExpressionType.Property,
+                    property: { type: QueryEditorPropertyType.String, name: value || '' },
+                  },
+                },
+              });
+            }}
+          />
+        </EditorField>
+        <EditorField label="Columns" tooltip={'Select a subset of columns for faster queries'}>
+          <Select
+            aria-label="Columns"
+            isMulti
+            value={query.expression.columns?.columns ? query.expression.columns.columns : []}
+            options={uniq(tableSchema.value?.map((c) => c.Name.split('[')[0])).map((c) => ({ label: c, value: c }))}
+            placeholder="All"
+            onChange={(e) => {
+              onChange({
+                ...query,
+                expression: {
+                  ...query.expression,
+                  columns: {
+                    type: QueryEditorExpressionType.Property,
+                    columns: e.map((e) => e.value),
+                  },
+                },
+              });
+            }}
+          />
+        </EditorField>
+      </EditorFieldGroup>
+    </EditorRow>
+  );
+};
+
+export default TableSection;

--- a/src/components/QueryEditor/VisualQueryEditor/Timeshift.tsx
+++ b/src/components/QueryEditor/VisualQueryEditor/Timeshift.tsx
@@ -3,21 +3,17 @@ import React, { useState } from 'react';
 import { Button, Select } from '@grafana/ui';
 import { AccessoryButton, EditorField, EditorFieldGroup, EditorRow, InputGroup } from '@grafana/experimental';
 
-import { AdxColumnSchema, KustoQuery } from '../../../types';
+import { KustoQuery } from '../../../types';
 import { QueryEditorExpressionType } from 'components/LegacyQueryEditor/editor/expressions';
 import { QueryEditorPropertyType } from 'schema/types';
-import { AdxDataSource } from 'datasource';
-import { AsyncState } from 'react-use/lib/useAsyncFn';
 
 interface TimeshiftProps {
-  datasource: AdxDataSource;
   query: KustoQuery;
-  tableSchema: AsyncState<AdxColumnSchema[]>;
   onChange: (query: KustoQuery) => void;
 }
 
 const Timeshift: React.FC<TimeshiftProps> = (props) => {
-  const { datasource, query, onChange, tableSchema } = props;
+  const { query, onChange } = props;
   const [displaySelect, setDisplaySelect] = useState(false);
   const onChangeValue = (value?: string) => {
     const newExpression = {
@@ -33,7 +29,6 @@ const Timeshift: React.FC<TimeshiftProps> = (props) => {
     onChange({
       ...query,
       expression: newExpression,
-      query: datasource.parseExpression(newExpression, tableSchema.value),
     });
   };
 

--- a/src/components/QueryEditor/VisualQueryEditor/utils/utils.ts
+++ b/src/components/QueryEditor/VisualQueryEditor/utils/utils.ts
@@ -1,5 +1,6 @@
 import { SelectableValue, toOption } from '@grafana/data';
 import {
+  QueryEditorColumnsExpression,
   QueryEditorExpressionType,
   QueryEditorGroupByExpression,
   QueryEditorOperatorExpression,
@@ -7,6 +8,7 @@ import {
 } from 'components/LegacyQueryEditor/editor/expressions';
 import { isUndefined } from 'lodash';
 import { QueryEditorOperatorValueType, QueryEditorPropertyType } from 'schema/types';
+import { AdxColumnSchema } from 'types';
 import { AggregateFunctions } from '../AggregateItem';
 import { isMulti, OPERATORS } from './operators';
 
@@ -194,4 +196,15 @@ export function sanitizeGroupBy(expression: QueryEditorGroupByExpression): Query
   }
 
   return undefined;
+}
+
+export function filterColumns(
+  tableSchema?: AdxColumnSchema[],
+  expression?: QueryEditorColumnsExpression
+): AdxColumnSchema[] | undefined {
+  return expression?.columns?.length
+    ? // filter columns with the same name or under the same dynamic column
+      // e.g. MyCol or MyCol["Inner"]
+      tableSchema?.filter((c) => expression?.columns?.includes(c.Name.split('[')[0]))
+    : tableSchema;
 }

--- a/src/components/QueryEditor/VisualQueryEditor/utils/utils.ts
+++ b/src/components/QueryEditor/VisualQueryEditor/utils/utils.ts
@@ -6,7 +6,7 @@ import {
   QueryEditorOperatorExpression,
   QueryEditorReduceExpression,
 } from 'components/LegacyQueryEditor/editor/expressions';
-import { isUndefined } from 'lodash';
+import { isUndefined, uniq } from 'lodash';
 import { QueryEditorOperatorValueType, QueryEditorPropertyType } from 'schema/types';
 import { AdxColumnSchema } from 'types';
 import { AggregateFunctions } from '../AggregateItem';
@@ -199,6 +199,17 @@ export function sanitizeGroupBy(expression: QueryEditorGroupByExpression): Query
   return undefined;
 }
 
+// extract the column name, ignoring inner objects for dynamic columns
+// e.g. MyCol["Inner"] => MyCol
+export function toColumnName(column: AdxColumnSchema) {
+  return column.Name.split('[')[0];
+}
+
+export function toColumnNames(columns: AdxColumnSchema[]) {
+  return uniq(columns.map((c) => toColumnName(c)));
+}
+
+// return columns defined in the expression (if any)
 export function filterColumns(
   tableSchema?: AdxColumnSchema[],
   expression?: QueryEditorColumnsExpression
@@ -206,6 +217,6 @@ export function filterColumns(
   return expression?.columns?.length
     ? // filter columns with the same name or under the same dynamic column
       // e.g. MyCol or MyCol["Inner"]
-      tableSchema?.filter((c) => expression?.columns?.includes(c.Name.split('[')[0]))
+      tableSchema?.filter((c) => expression?.columns?.includes(toColumnName(c)))
     : tableSchema;
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -2,6 +2,7 @@ import { DataQuery, DataSourceJsonData, DataSourceSettings } from '@grafana/data
 
 import {
   QueryEditorArrayExpression,
+  QueryEditorColumnsExpression,
   QueryEditorExpressionType,
   QueryEditorOperatorExpression,
   QueryEditorPropertyExpression,
@@ -11,6 +12,7 @@ const packageJson = require('../package.json');
 
 export interface QueryExpression {
   from?: QueryEditorPropertyExpression;
+  columns?: QueryEditorColumnsExpression;
   where: QueryEditorArrayExpression;
   reduce: QueryEditorArrayExpression;
   groupBy: QueryEditorArrayExpression;


### PR DESCRIPTION
The goal of this PR is to give a final solution (or at least start it) for #436

Now, people can select a subset of columns so only those fields will be processed. This is highly useful when using the time series format (as explained in #436). If some colums are selected, there rest are removed from the possible suggestions in the rest of fields:

![Peek 2022-09-19 16-21](https://user-images.githubusercontent.com/4025665/191043850-139a1e91-1270-49d5-bbab-bcc6163c480d.gif)

## UX open question

In #436 we discussed, that since the "Time series" format was selected by default, it would be nice to automatically select two columns so people don't find that issue: one for a time column and one for numeric value. The workaround was to select "Table" by default but I started to implemented the suggested behavior. I stoped going that way because I am not sure it's the best approach:

 - It assumes that the user is planning to use the time series visualization. That could have been mostly the case in the past but now there are many possible visualization so doing that assumption seems incorrect.
 - It would potentially choose the wrong columns. In that case, the user would need to _delete_ things from the default query and add new items (rather than seeing everything at first glance).
 - If the column does not have a timestamp and a numeric value, choosing the "time series" format by default would be wrong.
 - If the user start adding columns, without noticing the "time series" format (or without knowing the effect), it's more likely that they will hit the issue described in #436.

Because of that, I think the current behavior is more friendly (selecting all columns, with the table format) but let me know if you have any thoughts there!
