### PR TITLE
New editor: Improve filter style

### DIFF
--- a/src/components/QueryEditor/VisualQueryEditor/FilterItem.test.tsx
+++ b/src/components/QueryEditor/VisualQueryEditor/FilterItem.test.tsx
@@ -15,6 +15,7 @@ const defaultProps = {
   templateVariableOptions: {},
   onChange: jest.fn(),
   onDelete: jest.fn(),
+  filtersLength: 0,
 };
 
 describe('FilterItem', () => {

--- a/src/components/QueryEditor/VisualQueryEditor/FilterItem.tsx
+++ b/src/components/QueryEditor/VisualQueryEditor/FilterItem.tsx
@@ -1,16 +1,14 @@
 import React from 'react';
 import { useAsyncFn } from 'react-use';
+import { css } from '@emotion/css';
 
-import { SelectableValue, toOption } from '@grafana/data';
-import { Input, Select } from '@grafana/ui';
+import { GrafanaTheme2, SelectableValue, toOption } from '@grafana/data';
+import { Input, Label, Select, useStyles2 } from '@grafana/ui';
 import { AccessoryButton, InputGroup } from '@grafana/experimental';
 
 import { AdxDataSource } from '../../../datasource';
 import { AdxColumnSchema, KustoQuery } from '../../../types';
-import {
-  QueryEditorExpressionType,
-  QueryEditorOperatorExpression,
-} from 'components/LegacyQueryEditor/editor/expressions';
+import { QueryEditorExpressionType } from 'components/LegacyQueryEditor/editor/expressions';
 import {
   getOperatorExpressionOptions,
   getOperatorExpressionValue,
@@ -21,19 +19,22 @@ import {
 import { isMulti, toOperatorOptions } from './utils/operators';
 import { columnsToDefinition, valueToDefinition } from 'schema/mapper';
 import { QueryEditorPropertyType } from 'schema/types';
+import { FilterExpression } from './KQLFilter';
 
 interface FilterItemProps {
   datasource: AdxDataSource;
   query: KustoQuery;
-  filter: Partial<QueryEditorOperatorExpression>;
+  filter: Partial<FilterExpression>;
   columns: AdxColumnSchema[] | undefined;
   templateVariableOptions: SelectableValue<string>;
-  onChange: (item: QueryEditorOperatorExpression) => void;
+  onChange: (item: FilterExpression) => void;
   onDelete: () => void;
+  filtersLength: number;
 }
 
 const FilterItem: React.FC<FilterItemProps> = (props) => {
-  const { datasource, query, filter, onChange, onDelete, columns, templateVariableOptions } = props;
+  const { datasource, query, filter, onChange, onDelete, columns, templateVariableOptions, filtersLength } = props;
+  const styles = useStyles2(getStyles);
 
   const loadValues = async () => {
     if (!filter.property?.name) {
@@ -120,8 +121,18 @@ const FilterItem: React.FC<FilterItemProps> = (props) => {
         />
       </div>
       <AccessoryButton aria-label="remove" icon="times" variant="secondary" onClick={onDelete} />
+      {Number(filter.index) < filtersLength - 1 ? <Label className={styles.orLabel}>OR</Label> : null}
     </InputGroup>
   );
+};
+
+const getStyles = (theme: GrafanaTheme2) => {
+  return {
+    orLabel: css({
+      paddingTop: '9px',
+      paddingLeft: '14px',
+    }),
+  };
 };
 
 export default FilterItem;

--- a/src/components/QueryEditor/VisualQueryEditor/FilterSection.test.tsx
+++ b/src/components/QueryEditor/VisualQueryEditor/FilterSection.test.tsx
@@ -18,7 +18,7 @@ const defaultProps = {
 };
 
 describe('FilterSection', () => {
-  it('should render a filter group per where expression', () => {
+  it('should join filter groups with an AND label', () => {
     const query = {
       ...mockQuery,
       expression: {
@@ -57,7 +57,7 @@ describe('FilterSection', () => {
       },
     };
     render(<FilterSection {...defaultProps} query={query} />);
-    expect(screen.getAllByText('Filter group')).toHaveLength(2);
+    expect(screen.getByText('AND')).toBeInTheDocument();
   });
 
   it('should add a filter group', () => {

--- a/src/components/QueryEditor/VisualQueryEditor/FilterSection.tsx
+++ b/src/components/QueryEditor/VisualQueryEditor/FilterSection.tsx
@@ -1,5 +1,5 @@
-import { QueryEditorProps, SelectableValue } from '@grafana/data';
-import { Button } from '@grafana/ui';
+import { GrafanaTheme2, QueryEditorProps, SelectableValue } from '@grafana/data';
+import { Button, Label, useStyles2 } from '@grafana/ui';
 import { EditorField, EditorFieldGroup, EditorRow } from '@grafana/experimental';
 import { QueryEditorExpressionType } from 'components/LegacyQueryEditor/editor/expressions';
 import { AdxDataSource } from 'datasource';
@@ -7,6 +7,7 @@ import React from 'react';
 import { AsyncState } from 'react-use/lib/useAsyncFn';
 import { AdxColumnSchema, AdxDataSourceOptions, KustoQuery } from 'types';
 import KQLFilter from './KQLFilter';
+import { css } from '@emotion/css';
 
 type Props = QueryEditorProps<AdxDataSource, KustoQuery, AdxDataSourceOptions>;
 
@@ -23,56 +24,71 @@ const FilterSection: React.FC<FilterSectionProps> = ({
   tableSchema,
   templateVariableOptions,
 }) => {
+  const styles = useStyles2(getStyles);
+
   return (
     <>
-      {query.expression.where.expressions.map((_, i) => (
-        <EditorRow key={`filter-${i}`}>
-          <EditorFieldGroup>
-            <EditorField
-              label="Filter group"
-              optional={true}
-              tooltip="Any of the conditions of the group should return true"
-            >
-              <KQLFilter
-                index={i}
-                query={query}
-                onChange={onChange}
-                datasource={datasource}
-                columns={tableSchema.value}
-                templateVariableOptions={templateVariableOptions}
-              />
-            </EditorField>
-          </EditorFieldGroup>
-        </EditorRow>
-      ))}
       <EditorRow>
         <EditorFieldGroup>
-          <EditorField label="Add filter group" optional={true} tooltip="All filter groups should return true">
-            <Button
-              variant="secondary"
-              icon="plus"
-              onClick={() => {
-                const expr = query.expression.where.expressions.concat({
-                  type: QueryEditorExpressionType.Or,
-                  expressions: [{ type: QueryEditorExpressionType.Or, expressions: [] }],
-                });
-                onChange({
-                  ...query,
-                  expression: {
-                    ...query.expression,
-                    where: {
-                      ...query.expression.where,
-                      expressions: expr,
+          <EditorField label="Filters" optional={true}>
+            <>
+              {query.expression.where.expressions.length ? (
+                <div className={styles.filters}>
+                  {query.expression.where.expressions.map((_, i) => (
+                    <div key={`filter${i}`}>
+                      <KQLFilter
+                        index={i}
+                        query={query}
+                        onChange={onChange}
+                        datasource={datasource}
+                        columns={tableSchema.value}
+                        templateVariableOptions={templateVariableOptions}
+                      />
+                      {i < query.expression.where.expressions.length - 1 ? (
+                        <Label className={styles.andLabel}>AND</Label>
+                      ) : null}
+                    </div>
+                  ))}
+                </div>
+              ) : null}
+              <Button
+                variant="secondary"
+                onClick={() => {
+                  const expr = query.expression.where.expressions.concat({
+                    type: QueryEditorExpressionType.Or,
+                    expressions: [{ type: QueryEditorExpressionType.Or, expressions: [] }],
+                  });
+                  onChange({
+                    ...query,
+                    expression: {
+                      ...query.expression,
+                      where: {
+                        ...query.expression.where,
+                        expressions: expr,
+                      },
                     },
-                  },
-                });
-              }}
-            />
+                  });
+                }}
+              >
+                Add group
+              </Button>
+            </>
           </EditorField>
         </EditorFieldGroup>
       </EditorRow>
     </>
   );
+};
+
+const getStyles = (theme: GrafanaTheme2) => {
+  return {
+    andLabel: css({
+      margin: '8px',
+    }),
+    filters: css({
+      marginBottom: '8px',
+    }),
+  };
 };
 
 export default FilterSection;

--- a/src/components/QueryEditor/VisualQueryEditor/KQLFilter.tsx
+++ b/src/components/QueryEditor/VisualQueryEditor/KQLFilter.tsx
@@ -38,7 +38,9 @@ const KQLFilter: React.FC<KQLFilterProps> = ({
 }) => {
   // Each expression is a group of several OR statements
   const expressions = (query.expression.where.expressions[index] as QueryEditorArrayExpression)?.expressions;
-  const [filters, setFilters] = useState<FilterExpression[]>(expressions.map((e, i) => ({ ...e, index: i })));
+  const [filters, setFilters] = useState<FilterExpression[]>(
+    expressions ? expressions.map((e, i) => ({ ...e, index: i })) : []
+  );
 
   useEffect(() => {
     if (!filters.length && expressions?.length) {

--- a/src/components/QueryEditor/VisualQueryEditor/KQLFilter.tsx
+++ b/src/components/QueryEditor/VisualQueryEditor/KQLFilter.tsx
@@ -37,14 +37,14 @@ const KQLFilter: React.FC<KQLFilterProps> = ({
   templateVariableOptions,
 }) => {
   // Each expression is a group of several OR statements
-  const expressions = (query.expression.where.expressions[index] as QueryEditorArrayExpression)?.expressions;
-  const [filters, setFilters] = useState<FilterExpression[]>(
-    expressions ? expressions.map((e, i) => ({ ...e, index: i })) : []
-  );
+  const expressions: FilterExpression[] = (
+    query.expression.where.expressions[index] as QueryEditorArrayExpression
+  )?.expressions.map((e, i) => ({ ...e, index: i }));
+  const [filters, setFilters] = useState<FilterExpression[]>(expressions);
 
   useEffect(() => {
     if (!filters.length && expressions?.length) {
-      setFilters(expressions.map((e, i) => ({ ...e, index: i })));
+      setFilters(expressions);
     }
   }, [filters.length, expressions]);
 

--- a/src/components/QueryEditor/VisualQueryEditor/utils/utils.test.ts
+++ b/src/components/QueryEditor/VisualQueryEditor/utils/utils.test.ts
@@ -14,17 +14,18 @@ import {
 
 describe('setOperatorExpressionProperty', () => {
   it('should set a property from an empty expression', () => {
-    expect(setOperatorExpressionProperty({}, 'ActivityName', QueryEditorPropertyType.String)).toEqual({
+    expect(setOperatorExpressionProperty({ index: 0 }, 'ActivityName', QueryEditorPropertyType.String)).toEqual({
       type: QueryEditorExpressionType.Operator,
       property: { name: 'ActivityName', type: QueryEditorPropertyType.String },
       operator: { name: '==', value: '' },
+      index: 0,
     });
   });
 
   it('should keep the operator name if defined', () => {
     expect(
       setOperatorExpressionProperty(
-        { operator: { name: '!=', value: 'c' } },
+        { operator: { name: '!=', value: 'c' }, index: 0 },
         'ActivityName',
         QueryEditorPropertyType.String
       )
@@ -32,13 +33,14 @@ describe('setOperatorExpressionProperty', () => {
       type: QueryEditorExpressionType.Operator,
       property: { name: 'ActivityName', type: QueryEditorPropertyType.String },
       operator: { name: '!=', value: '' },
+      index: 0,
     });
   });
 
   it('change the operator name if the new type does not support it', () => {
     expect(
       setOperatorExpressionProperty(
-        { operator: { name: 'startswith', value: 'c' } },
+        { operator: { name: 'startswith', value: 'c' }, index: 0 },
         'ID',
         QueryEditorPropertyType.Number
       )
@@ -46,40 +48,45 @@ describe('setOperatorExpressionProperty', () => {
       type: QueryEditorExpressionType.Operator,
       property: { name: 'ID', type: QueryEditorPropertyType.Number },
       operator: { name: '==', value: 0 },
+      index: 0,
     });
   });
 });
 
 describe('setOperatorExpressionName', () => {
   it('should set a expression name (operator)', () => {
-    expect(setOperatorExpressionName({}, '!=')).toEqual({
+    expect(setOperatorExpressionName({ index: 0 }, '!=')).toEqual({
       type: QueryEditorExpressionType.Operator,
       property: { name: '', type: QueryEditorPropertyType.String },
       operator: { name: '!=', value: '' },
+      index: 0,
     });
   });
 
   it('should keep the current comparison value', () => {
-    expect(setOperatorExpressionName({ operator: { name: '==', value: 'foo' } }, '!=')).toEqual({
+    expect(setOperatorExpressionName({ operator: { name: '==', value: 'foo' }, index: 0 }, '!=')).toEqual({
       type: QueryEditorExpressionType.Operator,
       property: { name: '', type: QueryEditorPropertyType.String },
       operator: { name: '!=', value: 'foo' },
+      index: 0,
     });
   });
 
   it('should convert a value to an array', () => {
-    expect(setOperatorExpressionName({ operator: { name: '==', value: 'foo' } }, 'in')).toEqual({
+    expect(setOperatorExpressionName({ operator: { name: '==', value: 'foo' }, index: 0 }, 'in')).toEqual({
       type: QueryEditorExpressionType.Operator,
       property: { name: '', type: QueryEditorPropertyType.String },
       operator: { name: 'in', value: ['foo'] },
+      index: 0,
     });
   });
 
   it('should convert an array to a string', () => {
-    expect(setOperatorExpressionName({ operator: { name: 'in', value: ['foo'] } }, '!=')).toEqual({
+    expect(setOperatorExpressionName({ operator: { name: 'in', value: ['foo'] }, index: 0 }, '!=')).toEqual({
       type: QueryEditorExpressionType.Operator,
       property: { name: '', type: QueryEditorPropertyType.String },
       operator: { name: '!=', value: 'foo' },
+      index: 0,
     });
   });
 });
@@ -88,13 +95,14 @@ describe('setOperatorExpressionValue', () => {
   it('should set a single value', () => {
     expect(
       setOperatorExpressionValue(
-        { property: { type: QueryEditorPropertyType.String, name: 'ActivityName' } },
+        { property: { type: QueryEditorPropertyType.String, name: 'ActivityName' }, index: 0 },
         { value: 'foo' }
       )
     ).toEqual({
       type: QueryEditorExpressionType.Operator,
       property: { type: QueryEditorPropertyType.String, name: 'ActivityName' },
       operator: { name: '==', value: 'foo' },
+      index: 0,
     });
   });
 
@@ -104,6 +112,7 @@ describe('setOperatorExpressionValue', () => {
         {
           property: { type: QueryEditorPropertyType.String, name: 'ActivityName' },
           operator: { name: '!=', value: 'bar' },
+          index: 0,
         },
         { value: 'foo' }
       )
@@ -111,19 +120,21 @@ describe('setOperatorExpressionValue', () => {
       type: QueryEditorExpressionType.Operator,
       property: { type: QueryEditorPropertyType.String, name: 'ActivityName' },
       operator: { name: '!=', value: 'foo' },
+      index: 0,
     });
   });
 
   it('should set an array of values', () => {
     expect(
-      setOperatorExpressionValue({ property: { type: QueryEditorPropertyType.String, name: 'ActivityName' } }, [
-        { value: 'foo' },
-        { value: 'bar' },
-      ])
+      setOperatorExpressionValue(
+        { property: { type: QueryEditorPropertyType.String, name: 'ActivityName' }, index: 0 },
+        [{ value: 'foo' }, { value: 'bar' }]
+      )
     ).toEqual({
       type: QueryEditorExpressionType.Operator,
       property: { type: QueryEditorPropertyType.String, name: 'ActivityName' },
       operator: { name: '==', value: ['foo', 'bar'] },
+      index: 0,
     });
   });
 });

--- a/src/components/QueryEditor/VisualQueryEditor/utils/utils.ts
+++ b/src/components/QueryEditor/VisualQueryEditor/utils/utils.ts
@@ -43,7 +43,7 @@ export function setOperatorExpressionProperty(
     type: QueryEditorExpressionType.Operator,
     property: { name, type },
     operator: { name: operatorName, value: zeroValue(type) },
-    index: expression.index!,
+    index: Number(expression.index),
   };
 }
 
@@ -70,7 +70,7 @@ export function setOperatorExpressionName(expression: Partial<FilterExpression>,
       name,
       value: opValue,
     },
-    index: expression.index!,
+    index: Number(expression.index),
   };
 }
 
@@ -101,7 +101,7 @@ export function setOperatorExpressionValue(
       name: expression.operator?.name ?? '==',
       value,
     },
-    index: expression.index!,
+    index: Number(expression.index),
   };
 }
 

--- a/src/components/QueryEditor/VisualQueryEditor/utils/utils.ts
+++ b/src/components/QueryEditor/VisualQueryEditor/utils/utils.ts
@@ -8,6 +8,7 @@ import {
 import { isUndefined } from 'lodash';
 import { QueryEditorOperatorValueType, QueryEditorPropertyType } from 'schema/types';
 import { AggregateFunctions } from '../AggregateItem';
+import { FilterExpression } from '../KQLFilter';
 import { isMulti, OPERATORS } from './operators';
 
 function zeroValue(type: QueryEditorPropertyType) {
@@ -25,10 +26,10 @@ function zeroValue(type: QueryEditorPropertyType) {
  * Accepts a partial expression to use in an editor
  */
 export function setOperatorExpressionProperty(
-  expression: Partial<QueryEditorOperatorExpression>,
+  expression: Partial<FilterExpression>,
   name: string,
   type: QueryEditorPropertyType
-): QueryEditorOperatorExpression {
+): FilterExpression {
   let operatorName = '==';
   if (
     expression.operator?.name &&
@@ -42,16 +43,14 @@ export function setOperatorExpressionProperty(
     type: QueryEditorExpressionType.Operator,
     property: { name, type },
     operator: { name: operatorName, value: zeroValue(type) },
+    index: expression.index!,
   };
 }
 
 /** Sets the operator ("==") in an OperatorExpression
  * Accepts a partial expression to use in an editor
  */
-export function setOperatorExpressionName(
-  expression: Partial<QueryEditorOperatorExpression>,
-  name: string
-): QueryEditorOperatorExpression {
+export function setOperatorExpressionName(expression: Partial<FilterExpression>, name: string): FilterExpression {
   let opValue = expression.operator?.value ?? '';
   if (isMulti(name) && !Array.isArray(opValue)) {
     // Handle the case in which the operator now points to an multi value
@@ -71,6 +70,7 @@ export function setOperatorExpressionName(
       name,
       value: opValue,
     },
+    index: expression.index!,
   };
 }
 
@@ -78,9 +78,9 @@ export function setOperatorExpressionName(
  * Accepts a partial expression to use in an editor
  */
 export function setOperatorExpressionValue(
-  expression: Partial<QueryEditorOperatorExpression>,
+  expression: Partial<FilterExpression>,
   e: SelectableValue<string> | Array<SelectableValue<string>> | number | string
-): QueryEditorOperatorExpression {
+): FilterExpression {
   let value: string | string[] | number;
   if (typeof e === 'object' && !Array.isArray(e)) {
     value = e.value || '';
@@ -101,6 +101,7 @@ export function setOperatorExpressionValue(
       name: expression.operator?.name ?? '==',
       value,
     },
+    index: expression.index!,
   };
 }
 


### PR DESCRIPTION
My goal here is to improve how filters are created using the query builder. I guess it's important to know what's in the legacy editor at the moment since this is what users are use to:

https://user-images.githubusercontent.com/4025665/191294984-f0247f82-a0bc-4768-b5e8-47f3027d1505.mp4

As you can see, when adding filters, the builder ask to choose between "OR", which adds a new condition, and "AND", which addds a new `where` clause.

From that, the new UI is currently as follows:

https://user-images.githubusercontent.com/4025665/191295189-945bcb07-2d0a-4752-8f1d-cc88a603a3cb.mp4

But that has some problems:

 - The "Add filter group" is represented as a section but it's mostly serving as a button.
 - It may not be clear for uses what's the relation between a filter group and a inline filter (OR / AND logic).

To address that I am suggesting the following:

https://user-images.githubusercontent.com/4025665/191295151-fbafbcb3-ab8b-4cc3-b24d-a773c69d548f.mp4

 - Only one section, with a button to add new "groups"
 - Specify in the UI what's the relation between filters (OR / AND)
 - (con) Now the "Filters" section breaks the homogeneus style but it's probably worth it.

Thoughts? @diegoadams @catherineymgui