### PR TITLE
Pre-select columns

### DIFF
--- a/src/components/QueryEditor/VisualQueryEditor/TableSection.test.tsx
+++ b/src/components/QueryEditor/VisualQueryEditor/TableSection.test.tsx
@@ -62,4 +62,36 @@ describe('TableSection', () => {
       })
     );
   });
+
+  it('should pre-select some columns for the time series format', () => {
+    const onChange = jest.fn();
+    const tableSchema = {
+      loading: false,
+      value: [
+        {
+          Name: 'time',
+          CslType: 'datetime',
+        },
+        {
+          Name: 'measure',
+          CslType: 'long',
+        },
+      ],
+    };
+    const query = {
+      ...mockQuery,
+      resultFormat: 'time_series',
+    };
+    render(<TableSection {...defaultProps} onChange={onChange} tableSchema={tableSchema} query={query} />);
+    expect(onChange).toHaveBeenCalledWith(
+      expect.objectContaining({
+        expression: expect.objectContaining({
+          columns: {
+            type: QueryEditorExpressionType.Property,
+            columns: ['time', 'measure'],
+          },
+        }),
+      })
+    );
+  });
 });

--- a/src/components/QueryEditor/VisualQueryEditor/TableSection.tsx
+++ b/src/components/QueryEditor/VisualQueryEditor/TableSection.tsx
@@ -98,7 +98,7 @@ const TableSection: React.FC<TableSectionProps> = ({
           label="Columns"
           tooltip={
             <>
-              Select a subset of columns for faster results. Time series requires a time and number values, other
+              Select a subset of columns for faster results. Time series requires both time and number values, other
               columns are rendered as{' '}
               <a
                 href="https://grafana.com/docs/grafana/latest/basics/timeseries-dimensions/"

--- a/src/components/QueryEditor/VisualQueryEditor/TableSection.tsx
+++ b/src/components/QueryEditor/VisualQueryEditor/TableSection.tsx
@@ -43,7 +43,7 @@ const TableSection: React.FC<TableSectionProps> = ({
         },
       });
     }
-  }, [table?.value, query]);
+  }, [table?.value, query, onChange]);
 
   useEffect(() => {
     if (tableSchema.value?.length) {
@@ -66,7 +66,7 @@ const TableSection: React.FC<TableSectionProps> = ({
         },
       });
     }
-  }, [tableColumns, query]);
+  }, [tableColumns, query, onChange]);
 
   return (
     <EditorRow>

--- a/src/components/QueryEditor/VisualQueryEditor/TableSection.tsx
+++ b/src/components/QueryEditor/VisualQueryEditor/TableSection.tsx
@@ -8,6 +8,8 @@ import { QueryEditorPropertyDefinition, QueryEditorPropertyType } from 'schema/t
 import { Select } from '@grafana/ui';
 import { AdxDataSource } from 'datasource';
 import { toColumnNames } from './utils/utils';
+import { uniq } from 'lodash';
+import { toPropertyType } from 'schema/mapper';
 
 type Props = QueryEditorProps<AdxDataSource, KustoQuery, AdxDataSourceOptions>;
 
@@ -29,8 +31,14 @@ const TableSection: React.FC<TableSectionProps> = ({
   const tableOptions = (tables as Array<SelectableValue<string>>).concat(templateVariableOptions);
 
   useEffect(() => {
-    if (table?.value && !query.expression.from) {
+    if (table?.value && !query.expression.from && tableSchema.value?.length) {
       // New table
+      const timeCol = tableSchema.value?.find((cc) => toPropertyType(cc.CslType) === QueryEditorPropertyType.DateTime);
+      const valCol = tableSchema.value?.find((cc) => toPropertyType(cc.CslType) === QueryEditorPropertyType.Number);
+      const cols: string[] = [];
+      if (timeCol && valCol) {
+        cols.push(timeCol.Name, valCol.Name);
+      }
       onChange({
         ...query,
         expression: {
@@ -38,6 +46,10 @@ const TableSection: React.FC<TableSectionProps> = ({
           from: {
             type: QueryEditorExpressionType.Property,
             property: { type: QueryEditorPropertyType.String, name: table.value },
+          },
+          columns: {
+            type: QueryEditorExpressionType.Property,
+            columns: cols,
           },
         },
       });
@@ -55,6 +67,7 @@ const TableSection: React.FC<TableSectionProps> = ({
             options={tableOptions}
             allowCustomValue
             onChange={({ value }) => {
+              // TODO: recalculate cols
               onChange({
                 ...query,
                 expression: {
@@ -68,27 +81,185 @@ const TableSection: React.FC<TableSectionProps> = ({
             }}
           />
         </EditorField>
-        <EditorField label="Columns" tooltip={'Select a subset of columns for faster queries'}>
-          <Select
-            aria-label="Columns"
-            isMulti
-            value={query.expression.columns?.columns ? query.expression.columns.columns : []}
-            options={toColumnNames(tableSchema.value || []).map((c) => ({ label: c, value: c }))}
-            placeholder="All"
-            onChange={(e) => {
-              onChange({
-                ...query,
-                expression: {
-                  ...query.expression,
-                  columns: {
-                    type: QueryEditorExpressionType.Property,
-                    columns: e.map((e) => e.value),
+        {query.resultFormat === 'time_series' ? (
+          <>
+            <EditorField label="Time column">
+              <Select
+                aria-label="Time column"
+                // TODO: Make columns to include the type
+                value={
+                  query.expression.columns?.columns
+                    ? query.expression.columns?.columns.find((c) => {
+                        return tableSchema.value?.find(
+                          (cc) => cc.Name === c && toPropertyType(cc.CslType) === QueryEditorPropertyType.DateTime
+                        );
+                      })
+                    : null
+                }
+                options={uniq(
+                  tableSchema.value
+                    // TODO: Add support for nested values
+                    ?.filter(
+                      (c) => toPropertyType(c.CslType) === QueryEditorPropertyType.DateTime && !c.Name.includes('[')
+                    )
+                    .map((c) => c.Name)
+                ).map((c) => ({ label: c, value: c }))}
+                placeholder="Choose"
+                onChange={(e) => {
+                  const previousIndex = query.expression.columns?.columns?.findIndex((c) => {
+                    return tableSchema.value?.find(
+                      (cc) => cc.Name === c && toPropertyType(cc.CslType) === QueryEditorPropertyType.DateTime
+                    );
+                  });
+                  const newColumns = [...(query.expression.columns?.columns || [])];
+                  if (previousIndex !== undefined && previousIndex > -1) {
+                    newColumns[previousIndex] = e.value || '';
+                  } else {
+                    newColumns.push(e.value || '');
+                  }
+                  onChange({
+                    ...query,
+                    expression: {
+                      ...query.expression,
+                      columns: {
+                        type: QueryEditorExpressionType.Property,
+                        columns: newColumns,
+                      },
+                    },
+                  });
+                }}
+              />
+            </EditorField>
+            <EditorField label="Value column">
+              <Select
+                aria-label="Value column"
+                // TODO: Make columns to include the type
+                value={
+                  query.expression.columns?.columns
+                    ? query.expression.columns?.columns.find((c) => {
+                        return tableSchema.value?.find(
+                          (cc) => cc.Name === c && toPropertyType(cc.CslType) === QueryEditorPropertyType.Number
+                        );
+                      })
+                    : null
+                }
+                options={uniq(
+                  tableSchema.value
+                    // TODO: Add support for nested values
+                    ?.filter(
+                      (c) => toPropertyType(c.CslType) === QueryEditorPropertyType.Number && !c.Name.includes('[')
+                    )
+                    .map((c) => c.Name)
+                ).map((c) => ({ label: c, value: c }))}
+                placeholder="Choose"
+                onChange={(e) => {
+                  const previousIndex = query.expression.columns?.columns?.findIndex((c) => {
+                    return tableSchema.value?.find(
+                      (cc) => cc.Name === c && toPropertyType(cc.CslType) === QueryEditorPropertyType.Number
+                    );
+                  });
+                  const newColumns = [...(query.expression.columns?.columns || [])];
+                  if (previousIndex !== undefined && previousIndex > -1) {
+                    newColumns[previousIndex] = e.value || '';
+                  } else {
+                    newColumns.push(e.value || '');
+                  }
+                  onChange({
+                    ...query,
+                    expression: {
+                      ...query.expression,
+                      columns: {
+                        type: QueryEditorExpressionType.Property,
+                        columns: newColumns,
+                      },
+                    },
+                  });
+                }}
+              />
+            </EditorField>
+            <EditorField label="Other dimensions" optional>
+              <Select
+                aria-label="Other dimensions"
+                isMulti
+                // TODO: Make columns to include the type
+                value={
+                  query.expression.columns?.columns
+                    ? query.expression.columns?.columns.filter((c) => {
+                        return tableSchema.value?.find(
+                          (cc) =>
+                            cc.Name === c &&
+                            toPropertyType(cc.CslType) !== QueryEditorPropertyType.Number &&
+                            toPropertyType(cc.CslType) !== QueryEditorPropertyType.DateTime
+                        );
+                      })
+                    : undefined
+                }
+                options={uniq(
+                  tableSchema.value
+                    ?.filter(
+                      (c) =>
+                        toPropertyType(c.CslType) !== QueryEditorPropertyType.Number &&
+                        toPropertyType(c.CslType) !== QueryEditorPropertyType.DateTime
+                    )
+                    .map((c) => c.Name.split('[')[0])
+                ).map((c) => ({ label: c, value: c }))}
+                placeholder="Choose"
+                onChange={(e) => {
+                  const valueCol = query.expression.columns?.columns?.find((c) => {
+                    return tableSchema.value?.find(
+                      (cc) => cc.Name === c && toPropertyType(cc.CslType) === QueryEditorPropertyType.Number
+                    );
+                  });
+                  const timeCol = query.expression.columns?.columns?.find((c) => {
+                    return tableSchema.value?.find(
+                      (cc) => cc.Name === c && toPropertyType(cc.CslType) === QueryEditorPropertyType.DateTime
+                    );
+                  });
+                  const newColumns: string[] = [];
+                  if (timeCol) {
+                    newColumns.push(timeCol);
+                  }
+                  if (valueCol) {
+                    newColumns.push(valueCol);
+                  }
+                  newColumns.push(...e.map((e) => e.value));
+                  onChange({
+                    ...query,
+                    expression: {
+                      ...query.expression,
+                      columns: {
+                        type: QueryEditorExpressionType.Property,
+                        columns: newColumns,
+                      },
+                    },
+                  });
+                }}
+              />
+            </EditorField>
+          </>
+        ) : (
+          <EditorField label="Columns" tooltip={'Select a subset of columns for faster queries'}>
+            <Select
+              aria-label="Columns"
+              isMulti
+              value={query.expression.columns?.columns ? query.expression.columns.columns : []}
+              options={toColumnNames(tableSchema.value || []).map((c) => ({ label: c, value: c }))}
+              placeholder="All"
+              onChange={(e) => {
+                onChange({
+                  ...query,
+                  expression: {
+                    ...query.expression,
+                    columns: {
+                      type: QueryEditorExpressionType.Property,
+                      columns: e.map((e) => e.value),
+                    },
                   },
-                },
-              });
-            }}
-          />
-        </EditorField>
+                });
+              }}
+            />
+          </EditorField>
+        )}
       </EditorFieldGroup>
     </EditorRow>
   );

--- a/src/components/QueryEditor/VisualQueryEditor/utils/utils.ts
+++ b/src/components/QueryEditor/VisualQueryEditor/utils/utils.ts
@@ -253,17 +253,23 @@ export function defaultTimeSeriesColumns(expression: QueryExpression, tableColum
     });
   }
 
-  const timeCols = tableColumns
-    .filter((cc) => toPropertyType(cc.CslType) === QueryEditorPropertyType.DateTime)
-    .map((c) => c.Name);
+  const timeCols = tableColumns.reduce<string[]>((cols, col) => {
+    if (toPropertyType(col.CslType) === QueryEditorPropertyType.DateTime) {
+      cols.push(col.Name);
+    }
+    return cols;
+  }, []);
   if (timeCols.length && intersection(res, timeCols).length === 0) {
     // No time column in use, add the first one
     res.push(timeCols[0]);
   }
 
-  const valCols = tableColumns
-    .filter((cc) => toPropertyType(cc.CslType) === QueryEditorPropertyType.Number)
-    .map((c) => c.Name);
+  const valCols = tableColumns.reduce<string[]>((cols, col) => {
+    if (toPropertyType(col.CslType) === QueryEditorPropertyType.Number) {
+      cols.push(col.Name);
+    }
+    return cols;
+  }, []);
   if (valCols.length && intersection(res, valCols).length === 0) {
     // No value column in use, add the first one
     res.push(valCols[0]);


### PR DESCRIPTION
Follow up of https://github.com/grafana/azure-data-explorer-datasource/pull/474 (will be kept as a draft until that PR is merged).

To avoid as much as possible the crash of the browser when using the query builder, this PR pre-selects two columns when writing a new query (it doesn't affect existing queries). This affects only the "Time series" format. There is some more information in the tooltip about time series format.

[Screencast from 26-09-22 17:46:13.webm](https://user-images.githubusercontent.com/4025665/192322104-bfe27115-2a6b-4a2e-9c23-f6a5571cb49c.webm)


