### PR TITLE
Refactor: define join element rather than indexes in the FilterList

### DIFF
--- a/src/components/QueryEditor/VisualQueryEditor/FilterItem.test.tsx
+++ b/src/components/QueryEditor/VisualQueryEditor/FilterItem.test.tsx
@@ -15,7 +15,6 @@ const defaultProps = {
   templateVariableOptions: {},
   onChange: jest.fn(),
   onDelete: jest.fn(),
-  filtersLength: 0,
 };
 
 describe('FilterItem', () => {
@@ -32,7 +31,9 @@ describe('FilterItem', () => {
     openMenu(sel);
     screen.getByText('foo').click();
     expect(onChange).toHaveBeenCalledWith(
-      expect.objectContaining({ property: { name: 'foo', type: QueryEditorPropertyType.String } })
+      expect.objectContaining({
+        expression: expect.objectContaining({ property: { name: 'foo', type: QueryEditorPropertyType.String } }),
+      })
     );
   });
 
@@ -42,7 +43,9 @@ describe('FilterItem', () => {
     const sel = screen.getByLabelText('operator');
     openMenu(sel);
     screen.getByText('!=').click();
-    expect(onChange).toHaveBeenCalledWith(expect.objectContaining({ operator: { name: '!=', value: '' } }));
+    expect(onChange).toHaveBeenCalledWith(
+      expect.objectContaining({ expression: expect.objectContaining({ operator: { name: '!=', value: '' } }) })
+    );
   });
 
   it('should select a value', async () => {
@@ -54,7 +57,9 @@ describe('FilterItem', () => {
     const sel = screen.getByLabelText('column value');
     openMenu(sel);
     (await screen.findByText('foo')).click();
-    expect(onChange).toHaveBeenCalledWith(expect.objectContaining({ operator: { name: '==', value: 'foo' } }));
+    expect(onChange).toHaveBeenCalledWith(
+      expect.objectContaining({ expression: expect.objectContaining({ operator: { name: '==', value: 'foo' } }) })
+    );
   });
 
   it('should select a template variable', async () => {
@@ -79,7 +84,9 @@ describe('FilterItem', () => {
     openMenu(sel);
     (await screen.findByText('Template Variables')).click();
     (await screen.findByText('$foo')).click();
-    expect(onChange).toHaveBeenCalledWith(expect.objectContaining({ operator: { name: '==', value: "'$foo'" } }));
+    expect(onChange).toHaveBeenCalledWith(
+      expect.objectContaining({ expression: expect.objectContaining({ operator: { name: '==', value: "'$foo'" } }) })
+    );
   });
 
   it('type a numeric value', async () => {
@@ -90,7 +97,9 @@ describe('FilterItem', () => {
     render(<FilterItem {...defaultProps} datasource={datasource} onChange={onChange} filter={filter} />);
     const input = screen.getByLabelText('column number value');
     userEvent.type(input, '1');
-    expect(onChange).toHaveBeenCalledWith(expect.objectContaining({ operator: { name: '==', value: 1 } }));
+    expect(onChange).toHaveBeenCalledWith(
+      expect.objectContaining({ expression: expect.objectContaining({ operator: { name: '==', value: 1 } }) })
+    );
   });
 
   it('type a datetime value', async () => {
@@ -101,6 +110,8 @@ describe('FilterItem', () => {
     render(<FilterItem {...defaultProps} datasource={datasource} onChange={onChange} filter={filter} />);
     const input = screen.getByLabelText('column datetime value');
     userEvent.type(input, '1');
-    expect(onChange).toHaveBeenCalledWith(expect.objectContaining({ operator: { name: '==', value: '1' } }));
+    expect(onChange).toHaveBeenCalledWith(
+      expect.objectContaining({ expression: expect.objectContaining({ operator: { name: '==', value: '1' } }) })
+    );
   });
 });

--- a/src/components/QueryEditor/VisualQueryEditor/FilterItem.tsx
+++ b/src/components/QueryEditor/VisualQueryEditor/FilterItem.tsx
@@ -21,7 +21,7 @@ import {
 import { isMulti, toOperatorOptions } from './utils/operators';
 import { columnsToDefinition, valueToDefinition } from 'schema/mapper';
 import { QueryEditorPropertyType } from 'schema/types';
-import { FilterItem } from './KQLFilter';
+import { FilterListItem } from './KQLFilter';
 
 interface FilterItemProps {
   datasource: AdxDataSource;
@@ -29,7 +29,7 @@ interface FilterItemProps {
   filter: Partial<QueryEditorOperatorExpression>;
   columns: AdxColumnSchema[] | undefined;
   templateVariableOptions: SelectableValue<string>;
-  onChange: (item: FilterItem) => void;
+  onChange: (item: FilterListItem) => void;
   onDelete: () => void;
 }
 

--- a/src/components/QueryEditor/VisualQueryEditor/KQLFilter.tsx
+++ b/src/components/QueryEditor/VisualQueryEditor/KQLFilter.tsx
@@ -26,18 +26,20 @@ interface KQLFilterProps {
   onChange: (query: KustoQuery) => void;
 }
 
-export interface FilterItem {
+export interface FilterListItem {
   type: string;
   expression?: QueryEditorOperatorExpression;
 }
 
-function expressionsToFilterItems(expressions?: QueryEditorExpression[] | QueryEditorArrayExpression[]): FilterItem[] {
-  const f: FilterItem[] = expressions?.map((e) => ({ type: 'expression', expression: e })) || [];
-  const c: FilterItem[] = fill(Array(Math.max(f.length - 1, 0)), { type: 'condition' });
+function expressionsToFilterItems(
+  expressions?: QueryEditorExpression[] | QueryEditorArrayExpression[]
+): FilterListItem[] {
+  const f: FilterListItem[] = expressions?.map((e) => ({ type: 'expression', expression: e })) || [];
+  const c: FilterListItem[] = fill(Array(Math.max(f.length - 1, 0)), { type: 'condition' });
   return compact(zip(f, c).flat());
 }
 
-function sanitizeFilterItemList(list: FilterItem[]): FilterItem[] {
+function sanitizeFilterItemList(list: FilterListItem[]): FilterListItem[] {
   const exprs = list.filter((item) => item.type === 'expression').map((item) => item.expression!);
   return expressionsToFilterItems(exprs);
 }
@@ -60,9 +62,9 @@ const KQLFilter: React.FC<KQLFilterProps> = ({
     }
   }, [filters.length, expressions]);
 
-  const onChange = (newItems: Array<Partial<FilterItem>>) => {
+  const onChange = (newItems: Array<Partial<FilterListItem>>) => {
     // As new (empty object) items come in, with need to make sure they have the correct type
-    const cleaned: FilterItem[] = sanitizeFilterItemList(
+    const cleaned: FilterListItem[] = sanitizeFilterItemList(
       newItems.map((v, i) => {
         if (!v.type || v.type === 'expression') {
           return {
@@ -119,7 +121,7 @@ function makeRenderFilter(
   columns: AdxColumnSchema[] | undefined,
   templateVariableOptions: SelectableValue<string>
 ) {
-  function renderFilter(item: Partial<FilterItem>, onChange: (item: FilterItem) => void, onDelete: () => void) {
+  function renderFilter(item: Partial<FilterListItem>, onChange: (item: FilterListItem) => void, onDelete: () => void) {
     if (item.type === 'condition') {
       return <Label style={{ paddingTop: '9px' }}>OR</Label>;
     }

--- a/src/components/QueryEditor/VisualQueryEditor/KQLFilter.tsx
+++ b/src/components/QueryEditor/VisualQueryEditor/KQLFilter.tsx
@@ -14,6 +14,8 @@ import {
 import { QueryEditorPropertyType } from 'schema/types';
 import { sanitizeOperator } from './utils/utils';
 import FilterItem from './FilterItem';
+import { Label } from '@grafana/ui';
+import { compact, fill, zip } from 'lodash';
 
 interface KQLFilterProps {
   index: number;
@@ -24,8 +26,20 @@ interface KQLFilterProps {
   onChange: (query: KustoQuery) => void;
 }
 
-export interface FilterExpression extends QueryEditorOperatorExpression {
-  index: number;
+export interface FilterItem {
+  type: string;
+  expression?: QueryEditorOperatorExpression;
+}
+
+function expressionsToFilterItems(expressions?: QueryEditorExpression[] | QueryEditorArrayExpression[]): FilterItem[] {
+  const f: FilterItem[] = expressions?.map((e) => ({ type: 'expression', expression: e })) || [];
+  const c: FilterItem[] = fill(Array(Math.max(f.length - 1, 0)), { type: 'condition' });
+  return compact(zip(f, c).flat());
+}
+
+function sanitizeFilterItemList(list: FilterItem[]): FilterItem[] {
+  const exprs = list.filter((item) => item.type === 'expression').map((item) => item.expression!);
+  return expressionsToFilterItems(exprs);
 }
 
 const KQLFilter: React.FC<KQLFilterProps> = ({
@@ -37,32 +51,37 @@ const KQLFilter: React.FC<KQLFilterProps> = ({
   templateVariableOptions,
 }) => {
   // Each expression is a group of several OR statements
-  const expressions: FilterExpression[] = (
-    query.expression.where.expressions[index] as QueryEditorArrayExpression
-  )?.expressions.map((e, i) => ({ ...e, index: i }));
-  const [filters, setFilters] = useState<FilterExpression[]>(expressions);
+  const expressions = (query.expression.where.expressions[index] as QueryEditorArrayExpression)?.expressions;
+  const [filters, setFilters] = useState(expressionsToFilterItems(expressions));
 
   useEffect(() => {
     if (!filters.length && expressions?.length) {
-      setFilters(expressions);
+      setFilters(expressionsToFilterItems(expressions));
     }
   }, [filters.length, expressions]);
 
-  const onChange = (newItems: Array<Partial<QueryEditorOperatorExpression>>) => {
+  const onChange = (newItems: Array<Partial<FilterItem>>) => {
     // As new (empty object) items come in, with need to make sure they have the correct type
-    const cleaned = newItems.map(
-      (v, i): FilterExpression => ({
-        type: QueryEditorExpressionType.Operator,
-        property: v.property ?? { type: QueryEditorPropertyType.String, name: '' },
-        operator: v.operator ?? { name: '==', value: '' },
-        index: i,
+    const cleaned: FilterItem[] = sanitizeFilterItemList(
+      newItems.map((v, i) => {
+        if (!v.type || v.type === 'expression') {
+          return {
+            type: 'expression',
+            expression: {
+              type: QueryEditorExpressionType.Operator,
+              property: v.expression?.property ?? { type: QueryEditorPropertyType.String, name: '' },
+              operator: v.expression?.operator ?? { name: '==', value: '' },
+            },
+          };
+        }
+        return { type: 'condition' };
       })
     );
     setFilters(cleaned);
 
     // Only save valid and complete filters into the query state
     const validExpressions: QueryEditorOperatorExpression[] = [];
-    for (const operatorExpression of cleaned) {
+    for (const operatorExpression of cleaned.filter((v) => v.expression).map((v) => v.expression!)) {
       const validated = sanitizeOperator(operatorExpression);
       if (validated) {
         validExpressions.push(validated);
@@ -87,7 +106,7 @@ const KQLFilter: React.FC<KQLFilterProps> = ({
     <EditorList
       items={filters}
       onChange={onChange}
-      renderItem={makeRenderFilter(datasource, query, columns, templateVariableOptions, filters.length)}
+      renderItem={makeRenderFilter(datasource, query, columns, templateVariableOptions)}
     />
   );
 };
@@ -98,24 +117,21 @@ function makeRenderFilter(
   datasource: AdxDataSource,
   query: KustoQuery,
   columns: AdxColumnSchema[] | undefined,
-  templateVariableOptions: SelectableValue<string>,
-  filtersLength: number
+  templateVariableOptions: SelectableValue<string>
 ) {
-  function renderFilter(
-    item: Partial<QueryEditorExpression>,
-    onChange: (item: QueryEditorExpression) => void,
-    onDelete: () => void
-  ) {
+  function renderFilter(item: Partial<FilterItem>, onChange: (item: FilterItem) => void, onDelete: () => void) {
+    if (item.type === 'condition') {
+      return <Label style={{ paddingTop: '9px' }}>OR</Label>;
+    }
     return (
       <FilterItem
         datasource={datasource}
         query={query}
-        filter={item}
+        filter={item.expression!}
         onChange={onChange}
         onDelete={onDelete}
         columns={columns}
         templateVariableOptions={templateVariableOptions}
-        filtersLength={filtersLength}
       />
     );
   }

--- a/src/components/QueryEditor/VisualQueryEditor/utils/utils.test.ts
+++ b/src/components/QueryEditor/VisualQueryEditor/utils/utils.test.ts
@@ -14,18 +14,17 @@ import {
 
 describe('setOperatorExpressionProperty', () => {
   it('should set a property from an empty expression', () => {
-    expect(setOperatorExpressionProperty({ index: 0 }, 'ActivityName', QueryEditorPropertyType.String)).toEqual({
+    expect(setOperatorExpressionProperty({}, 'ActivityName', QueryEditorPropertyType.String)).toEqual({
       type: QueryEditorExpressionType.Operator,
       property: { name: 'ActivityName', type: QueryEditorPropertyType.String },
       operator: { name: '==', value: '' },
-      index: 0,
     });
   });
 
   it('should keep the operator name if defined', () => {
     expect(
       setOperatorExpressionProperty(
-        { operator: { name: '!=', value: 'c' }, index: 0 },
+        { operator: { name: '!=', value: 'c' } },
         'ActivityName',
         QueryEditorPropertyType.String
       )
@@ -33,14 +32,13 @@ describe('setOperatorExpressionProperty', () => {
       type: QueryEditorExpressionType.Operator,
       property: { name: 'ActivityName', type: QueryEditorPropertyType.String },
       operator: { name: '!=', value: '' },
-      index: 0,
     });
   });
 
   it('change the operator name if the new type does not support it', () => {
     expect(
       setOperatorExpressionProperty(
-        { operator: { name: 'startswith', value: 'c' }, index: 0 },
+        { operator: { name: 'startswith', value: 'c' } },
         'ID',
         QueryEditorPropertyType.Number
       )
@@ -48,45 +46,40 @@ describe('setOperatorExpressionProperty', () => {
       type: QueryEditorExpressionType.Operator,
       property: { name: 'ID', type: QueryEditorPropertyType.Number },
       operator: { name: '==', value: 0 },
-      index: 0,
     });
   });
 });
 
 describe('setOperatorExpressionName', () => {
   it('should set a expression name (operator)', () => {
-    expect(setOperatorExpressionName({ index: 0 }, '!=')).toEqual({
+    expect(setOperatorExpressionName({}, '!=')).toEqual({
       type: QueryEditorExpressionType.Operator,
       property: { name: '', type: QueryEditorPropertyType.String },
       operator: { name: '!=', value: '' },
-      index: 0,
     });
   });
 
   it('should keep the current comparison value', () => {
-    expect(setOperatorExpressionName({ operator: { name: '==', value: 'foo' }, index: 0 }, '!=')).toEqual({
+    expect(setOperatorExpressionName({ operator: { name: '==', value: 'foo' } }, '!=')).toEqual({
       type: QueryEditorExpressionType.Operator,
       property: { name: '', type: QueryEditorPropertyType.String },
       operator: { name: '!=', value: 'foo' },
-      index: 0,
     });
   });
 
   it('should convert a value to an array', () => {
-    expect(setOperatorExpressionName({ operator: { name: '==', value: 'foo' }, index: 0 }, 'in')).toEqual({
+    expect(setOperatorExpressionName({ operator: { name: '==', value: 'foo' } }, 'in')).toEqual({
       type: QueryEditorExpressionType.Operator,
       property: { name: '', type: QueryEditorPropertyType.String },
       operator: { name: 'in', value: ['foo'] },
-      index: 0,
     });
   });
 
   it('should convert an array to a string', () => {
-    expect(setOperatorExpressionName({ operator: { name: 'in', value: ['foo'] }, index: 0 }, '!=')).toEqual({
+    expect(setOperatorExpressionName({ operator: { name: 'in', value: ['foo'] } }, '!=')).toEqual({
       type: QueryEditorExpressionType.Operator,
       property: { name: '', type: QueryEditorPropertyType.String },
       operator: { name: '!=', value: 'foo' },
-      index: 0,
     });
   });
 });
@@ -95,14 +88,13 @@ describe('setOperatorExpressionValue', () => {
   it('should set a single value', () => {
     expect(
       setOperatorExpressionValue(
-        { property: { type: QueryEditorPropertyType.String, name: 'ActivityName' }, index: 0 },
+        { property: { type: QueryEditorPropertyType.String, name: 'ActivityName' } },
         { value: 'foo' }
       )
     ).toEqual({
       type: QueryEditorExpressionType.Operator,
       property: { type: QueryEditorPropertyType.String, name: 'ActivityName' },
       operator: { name: '==', value: 'foo' },
-      index: 0,
     });
   });
 
@@ -112,7 +104,6 @@ describe('setOperatorExpressionValue', () => {
         {
           property: { type: QueryEditorPropertyType.String, name: 'ActivityName' },
           operator: { name: '!=', value: 'bar' },
-          index: 0,
         },
         { value: 'foo' }
       )
@@ -120,21 +111,19 @@ describe('setOperatorExpressionValue', () => {
       type: QueryEditorExpressionType.Operator,
       property: { type: QueryEditorPropertyType.String, name: 'ActivityName' },
       operator: { name: '!=', value: 'foo' },
-      index: 0,
     });
   });
 
   it('should set an array of values', () => {
     expect(
-      setOperatorExpressionValue(
-        { property: { type: QueryEditorPropertyType.String, name: 'ActivityName' }, index: 0 },
-        [{ value: 'foo' }, { value: 'bar' }]
-      )
+      setOperatorExpressionValue({ property: { type: QueryEditorPropertyType.String, name: 'ActivityName' } }, [
+        { value: 'foo' },
+        { value: 'bar' },
+      ])
     ).toEqual({
       type: QueryEditorExpressionType.Operator,
       property: { type: QueryEditorPropertyType.String, name: 'ActivityName' },
       operator: { name: '==', value: ['foo', 'bar'] },
-      index: 0,
     });
   });
 });

--- a/src/components/QueryEditor/VisualQueryEditor/utils/utils.ts
+++ b/src/components/QueryEditor/VisualQueryEditor/utils/utils.ts
@@ -10,7 +10,6 @@ import { isUndefined, uniq } from 'lodash';
 import { QueryEditorOperatorValueType, QueryEditorPropertyType } from 'schema/types';
 import { AdxColumnSchema } from 'types';
 import { AggregateFunctions } from '../AggregateItem';
-import { FilterExpression } from '../KQLFilter';
 import { isMulti, OPERATORS } from './operators';
 
 function zeroValue(type: QueryEditorPropertyType) {
@@ -28,10 +27,10 @@ function zeroValue(type: QueryEditorPropertyType) {
  * Accepts a partial expression to use in an editor
  */
 export function setOperatorExpressionProperty(
-  expression: Partial<FilterExpression>,
+  expression: Partial<QueryEditorOperatorExpression>,
   name: string,
   type: QueryEditorPropertyType
-): FilterExpression {
+): QueryEditorOperatorExpression {
   let operatorName = '==';
   if (
     expression.operator?.name &&
@@ -45,14 +44,16 @@ export function setOperatorExpressionProperty(
     type: QueryEditorExpressionType.Operator,
     property: { name, type },
     operator: { name: operatorName, value: zeroValue(type) },
-    index: Number(expression.index),
   };
 }
 
 /** Sets the operator ("==") in an OperatorExpression
  * Accepts a partial expression to use in an editor
  */
-export function setOperatorExpressionName(expression: Partial<FilterExpression>, name: string): FilterExpression {
+export function setOperatorExpressionName(
+  expression: Partial<QueryEditorOperatorExpression>,
+  name: string
+): QueryEditorOperatorExpression {
   let opValue = expression.operator?.value ?? '';
   if (isMulti(name) && !Array.isArray(opValue)) {
     // Handle the case in which the operator now points to an multi value
@@ -72,7 +73,6 @@ export function setOperatorExpressionName(expression: Partial<FilterExpression>,
       name,
       value: opValue,
     },
-    index: Number(expression.index),
   };
 }
 
@@ -80,9 +80,9 @@ export function setOperatorExpressionName(expression: Partial<FilterExpression>,
  * Accepts a partial expression to use in an editor
  */
 export function setOperatorExpressionValue(
-  expression: Partial<FilterExpression>,
+  expression: Partial<QueryEditorOperatorExpression>,
   e: SelectableValue<string> | Array<SelectableValue<string>> | number | string
-): FilterExpression {
+): QueryEditorOperatorExpression {
   let value: string | string[] | number;
   if (typeof e === 'object' && !Array.isArray(e)) {
     value = e.value || '';
@@ -103,7 +103,6 @@ export function setOperatorExpressionValue(
       name: expression.operator?.name ?? '==',
       value,
     },
-    index: Number(expression.index),
   };
 }
 


### PR DESCRIPTION
Applying the suggestion at https://github.com/grafana/grafana/pull/55664#issuecomment-1256027871

Rather than adding the `index` to the List type and conditionally render the "OR" label within an Item, this PR adds the `type` of a list item, which is either an `expression` or a `condition` ("OR" label in this case).

I don't necessarily like this option better, mostly because the code is a bit messing to insert (or remove) "conditions" between "expressions", but leaving this here for reference.