### PR TITLE
Refactor: move away from useEffect onChange

### DIFF
--- a/src/components/LegacyQueryEditor/editor/components/groupBy/QueryEditorGroupBy.tsx
+++ b/src/components/LegacyQueryEditor/editor/components/groupBy/QueryEditorGroupBy.tsx
@@ -41,30 +41,28 @@ export const QueryEditorGroupBy: React.FC<Props> = (props) => {
           name: intervals[0].value,
         });
       }
+      onChange({
+        type: QueryEditorExpressionType.GroupBy,
+        property,
+        interval,
+      });
     },
-    [setField, intervals]
+    [setField, onChange, interval, intervals]
   );
 
   const onChangeInterval = useCallback(
     (property: QueryEditorProperty) => {
       setInterval(property);
+      if (field) {
+        onChange({
+          type: QueryEditorExpressionType.GroupBy,
+          property: field,
+          interval: property,
+        });
+      }
     },
-    [setInterval]
+    [setInterval, field, onChange]
   );
-
-  /* eslint-disable react-hooks/exhaustive-deps */
-  useEffect(() => {
-    if (field) {
-      const payload: QueryEditorGroupByExpression = {
-        type: QueryEditorExpressionType.GroupBy,
-        property: field,
-        interval,
-      };
-
-      onChange(payload); // adding onChange to dependency array below causes maximum call depth error
-    }
-  }, [field, interval]);
-  /* eslint-enable react-hooks/exhaustive-deps */
 
   return (
     <div className={styles.container}>

--- a/src/components/LegacyQueryEditor/editor/components/reduce/QueryEditorReduce.tsx
+++ b/src/components/LegacyQueryEditor/editor/components/reduce/QueryEditorReduce.tsx
@@ -58,38 +58,46 @@ export const QueryEditorReduce: React.FC<Props> = (props) => {
           type: QueryEditorPropertyType.Function,
         });
       }
+
+      if (reduce) {
+        onChange({
+          type: QueryEditorExpressionType.Reduce,
+          property,
+          reduce,
+          parameters,
+        });
+      }
     },
-    [setField, value, functions]
+    [setField, value, functions, reduce, parameters, onChange]
   );
 
   const onChangeReduce = useCallback(
     (property: QueryEditorProperty) => {
       setReduce(property);
+      onChange({
+        type: QueryEditorExpressionType.Reduce,
+        property,
+        reduce: property,
+        parameters,
+      });
     },
-    [setReduce]
+    [setReduce, parameters, onChange]
   );
 
   const onChangeParameter = useCallback(
     (expression: QueryEditorFunctionParameterExpression[]) => {
       setParameters(expression);
+      if (reduce && field) {
+        onChange({
+          type: QueryEditorExpressionType.Reduce,
+          property: field,
+          reduce,
+          parameters: expression,
+        });
+      }
     },
-    [setParameters]
+    [setParameters, reduce, field, onChange]
   );
-
-  /* eslint-disable react-hooks/exhaustive-deps */
-  useEffect(() => {
-    if (field && reduce) {
-      const payload: QueryEditorReduceExpression = {
-        type: QueryEditorExpressionType.Reduce,
-        property: field,
-        reduce,
-        parameters: parameters,
-      };
-
-      onChange(payload); // adding onChange to dependency array below causes maximum call depth error
-    }
-  }, [field, reduce, parameters]);
-  /* eslint-enable react-hooks/exhaustive-deps */
 
   const reduceParameters: QueryEditorFunctionParameter[] = getParameters(reduce, props.functions);
 


### PR DESCRIPTION
In Dashboard and Explore views this pattern was fine. However, Alerting uses a [different approach to state management ](https://github.com/grafana/grafana/blob/main/public/app/features/alerting/unified/components/rule-editor/query-and-alert-condition/Query.tsx#L51)which made this pattern result in an infinite loop of state updates. Instead of having a `useEffect` that computes new state and fires `onChange` with that state, I wrapped each state change in it's own change handler to avoid the infinite loop presented by `useEffect` + `onChange`.

Closes #469 