### PR TITLE
fix: autocomplete now works with dynamic values

### DIFF
--- a/src/KustoExpressionParser.test.ts
+++ b/src/KustoExpressionParser.test.ts
@@ -197,6 +197,35 @@ describe('KustoExpressionParser', () => {
           '\n| take 251'
       );
     });
+
+    it('should parse expression with summarize function in an array', () => {
+      const expression = createQueryExpression({
+        from: createProperty('StormEvents'),
+        where: createArray([createOperator('foo["`indexer`"]', '==', '')]),
+      });
+      const acQuery: AutoCompleteQuery = {
+        expression,
+        search: createOperator('column["`indexer`"]', 'isnotempty', ''),
+        index: '0',
+        database: 'StormEvents',
+      };
+
+      const tableSchema: AdxColumnSchema[] = [
+        {
+          Name: 'Modes["`indexer`"]',
+          CslType: 'string',
+          isDynamic: true,
+        },
+      ];
+      expect(parser.toAutoCompleteQuery(acQuery, tableSchema)).toEqual(
+        'StormEvents' +
+          '\n| mv-expand array_1 = column' +
+          '\n| where isnotempty(array_1)' +
+          '\n| take 50000' +
+          '\n| distinct array_1' +
+          '\n| take 251'
+      );
+    });
   });
 
   describe('toQuery', () => {

--- a/src/KustoExpressionParser.ts
+++ b/src/KustoExpressionParser.ts
@@ -57,7 +57,7 @@ export class KustoExpressionParser {
     }
 
     //query.index is used by the legacy query editor
-    //isDynamicArray keeps the old behavior of the legacy query editor for non dynamic arrays
+    //!isDynamicArray is needed for when the legacy query editor is used with a non-dynamic value and we need to replace by index
     if (query.index && !isDynamicArray) {
       const where = replaceByIndex(query.index, query.expression.where, query.search);
       this.appendWhere(context, where, parts, 'where');

--- a/src/KustoExpressionParser.ts
+++ b/src/KustoExpressionParser.ts
@@ -44,7 +44,6 @@ export class KustoExpressionParser {
 
     const parts: string[] = [];
     const expandParts: string[] = [];
-    const isDynamicArray = query.search.property.name.includes(DYNAMIC_TYPE_ARRAY_DELIMITER);
     const name: string = this.addExpanPartsdIfNeeded(query.search.property.name, expandParts);
     const column = context.castIfDynamic(name, query.search.property.name);
     this.appendProperty(context, query.expression.from, parts);
@@ -57,8 +56,7 @@ export class KustoExpressionParser {
     }
 
     //query.index is used by the legacy query editor
-    //!isDynamicArray is needed for when the legacy query editor is used with a non-dynamic value and we need to replace by index
-    if (query.index && !isDynamicArray) {
+    if (query.index) {
       const where = replaceByIndex(query.index, query.expression.where, query.search);
       this.appendWhere(context, where, parts, 'where');
     } else {


### PR DESCRIPTION
This should work for both old and new editors.

![fixed-auto](https://user-images.githubusercontent.com/1048831/193494924-6eaf145b-5f63-42fc-8ba8-fa107f81040e.gif)


Closes #453 