### PR TITLE
Add data source to feature tracking

### DIFF
--- a/src/module.ts
+++ b/src/module.ts
@@ -1,13 +1,13 @@
 import { DataSourcePlugin, DashboardLoadedEvent } from '@grafana/data';
 import ConfigEditor from 'components/ConfigEditor';
-import { getAppEvents } from '@grafana/runtime';
+import { getAppEvents, getDataSourceSrv } from '@grafana/runtime';
 import pluginJson from './plugin.json';
 
 import { AdxDataSource } from './datasource';
 import { QueryEditor } from './components/QueryEditor';
-import { AdxDataSourceOptions, AdxDataSourceSecureOptions, FormatOptions, KustoQuery } from './types';
+import { AdxDataSourceOptions, AdxDataSourceSecureOptions, KustoQuery } from './types';
 import EditorHelp from 'components/QueryEditor/EditorHelp';
-import { trackADXMonitorDashboardLoaded } from 'tracking';
+import { analyzeQueries, trackADXMonitorDashboardLoaded } from 'tracking';
 
 export const plugin = new DataSourcePlugin<AdxDataSource, KustoQuery, AdxDataSourceOptions, AdxDataSourceSecureOptions>(
   AdxDataSource
@@ -21,37 +21,16 @@ getAppEvents().subscribe<DashboardLoadedEvent<KustoQuery>>(
   DashboardLoadedEvent,
   ({ payload: { dashboardId, orgId, grafanaVersion, queries } }) => {
     const adxQueries = queries[pluginJson.id]?.filter((q) => !q.hide);
-    if (adxQueries && adxQueries.length > 0) {
+    if (!adxQueries?.length) {
       return;
     }
-    const counters = {
-      table_queries: 0,
-      time_series_queries: 0,
-      adx_time_series_queries: 0,
-      query_builder_queries: 0,
-      raw_queries: 0,
-    };
-    adxQueries.forEach((query) => {
-      switch (query.resultFormat) {
-        case FormatOptions.table:
-          counters.table_queries++;
-          break;
-        case FormatOptions.timeSeries:
-          counters.time_series_queries++;
-          break;
-        case FormatOptions.adxTimeSeries:
-          counters.adx_time_series_queries++;
-          break;
-      }
-      query.rawMode ? counters.raw_queries++ : counters.query_builder_queries++;
-    });
 
     trackADXMonitorDashboardLoaded({
       adx_plugin_version: pluginJson.info.version,
       grafana_version: grafanaVersion,
       dashboard_id: dashboardId,
       org_id: orgId,
-      ...counters,
+      ...analyzeQueries(adxQueries, getDataSourceSrv()),
     });
   }
 );

--- a/src/tracking.test.ts
+++ b/src/tracking.test.ts
@@ -1,0 +1,65 @@
+import { analyzeQueries } from 'tracking';
+import { EditorMode, FormatOptions, KustoQuery } from 'types';
+
+describe('analyzeQueries', () => {
+  [
+    {
+      description: 'should count 1 table query',
+      queries: [{ resultFormat: FormatOptions.table }],
+      expectedCounters: { table_queries: 1, time_series_queries: 0, adx_time_series_queries: 0 },
+    },
+    {
+      description: 'should count 1 time series query',
+      queries: [{ resultFormat: FormatOptions.timeSeries }],
+      expectedCounters: { table_queries: 0, time_series_queries: 1, adx_time_series_queries: 0 },
+    },
+    {
+      description: 'should count 1 adx time series query',
+      queries: [{ resultFormat: FormatOptions.adxTimeSeries }],
+      expectedCounters: { table_queries: 0, time_series_queries: 0, adx_time_series_queries: 1 },
+    },
+    {
+      description: 'should count 1 raw query',
+      queries: [{ rawMode: true }],
+      expectedCounters: { raw_queries: 1, query_builder_queries: 0 },
+    },
+    {
+      description: 'should count 1 query builder query',
+      queries: [{ rawMode: false }],
+      expectedCounters: { raw_queries: 0, query_builder_queries: 1 },
+    },
+    {
+      description: 'should count data source features',
+      queries: [{ rawMode: false }],
+      dsSettings: {
+        jsonData: {
+          onBehalfOf: true,
+          queryTimeout: 10,
+          dynamicCaching: true,
+          dataConsistency: 'weakconsistency',
+          defaultEditorMode: EditorMode.Raw,
+          useSchemaMapping: true,
+        },
+      },
+      expectedCounters: {
+        on_behalf_of_queries: 1,
+        queries_with_custom_timeout: 1,
+        dynamic_caching_queries: 1,
+        weak_data_consistency_queries: 1,
+        queries_with_default_raw_editor: 1,
+        queries_with_managed_schema: 1,
+      },
+    },
+  ].forEach((t) => {
+    it(t.description, () => {
+      expect(
+        analyzeQueries(
+          t.queries as KustoQuery[],
+          {
+            getInstanceSettings: () => t.dsSettings || {},
+          } as any
+        )
+      ).toMatchObject(t.expectedCounters);
+    });
+  });
+});

--- a/src/tracking.ts
+++ b/src/tracking.ts
@@ -1,4 +1,6 @@
-import { reportInteraction } from '@grafana/runtime';
+import { DataSourceInstanceSettings } from '@grafana/data';
+import { DataSourceSrv, reportInteraction } from '@grafana/runtime';
+import { AdxDataSourceOptions, EditorMode, FormatOptions, KustoQuery } from 'types';
 
 /**
  * Loaded the first time a dashboard containing ADX queries is loaded (not on every render)
@@ -13,15 +15,12 @@ import { reportInteraction } from '@grafana/runtime';
  * Changelog:
  * - 4.1.7: Initial version
  */
-export const trackADXMonitorDashboardLoaded = (props: ADXMonitorDashboardLoadedProps) => {
+export const trackADXMonitorDashboardLoaded = (props: ADXDashboardLoadedProps) => {
+  console.log('ADXMonitorDashboardLoaded', props);
   reportInteraction('grafana_ds_adx_dashboard_loaded', props);
 };
 
-export type ADXMonitorDashboardLoadedProps = {
-  adx_plugin_version?: string;
-  grafana_version?: string;
-  dashboard_id: string;
-  org_id?: number;
+export type ADXCounters = {
   /** number of queries using the "Table" format  */
   table_queries: number;
   /** number of queries using the "Time Series" format  */
@@ -32,4 +31,84 @@ export type ADXMonitorDashboardLoadedProps = {
   query_builder_queries: number;
   /** number of queries using the Kusto editor  */
   raw_queries: number;
+  /** number of queries using On-Behalf-Of authentication */
+  on_behalf_of_queries: number;
+  /** number of queries using a timeout different than the default */
+  queries_with_custom_timeout: number;
+  /** number of queries using ADX dynamic caching */
+  dynamic_caching_queries: number;
+  /** number of queries using weak data consistency (not default) */
+  weak_data_consistency_queries: number;
+  /** number of queries using the Kusto editor by default (not default) */
+  queries_with_default_raw_editor: number;
+  /** number of queries using a custom schema mapping */
+  queries_with_managed_schema: number;
+};
+
+export interface ADXDashboardLoadedProps extends ADXCounters {
+  adx_plugin_version?: string;
+  grafana_version?: string;
+  dashboard_id: string;
+  org_id?: number;
+}
+
+export const analyzeQueries = (queries: KustoQuery[], datasourceSrv: DataSourceSrv): ADXCounters => {
+  const counters = {
+    table_queries: 0,
+    time_series_queries: 0,
+    adx_time_series_queries: 0,
+    query_builder_queries: 0,
+    raw_queries: 0,
+    on_behalf_of_queries: 0,
+    queries_with_custom_timeout: 0,
+    dynamic_caching_queries: 0,
+    weak_data_consistency_queries: 0,
+    queries_with_default_raw_editor: 0,
+    queries_with_managed_schema: 0,
+  };
+
+  const datasources: { [key: string]: DataSourceInstanceSettings<Partial<AdxDataSourceOptions>> | undefined } = {};
+  queries.forEach((query) => {
+    // Query features
+    switch (query.resultFormat) {
+      case FormatOptions.table:
+        counters.table_queries++;
+        break;
+      case FormatOptions.timeSeries:
+        counters.time_series_queries++;
+        break;
+      case FormatOptions.adxTimeSeries:
+        counters.adx_time_series_queries++;
+        break;
+    }
+    query.rawMode ? counters.raw_queries++ : counters.query_builder_queries++;
+
+    // Data source features
+    let dsSettings = datasources[JSON.stringify(query.datasource)];
+    if (!dsSettings) {
+      datasources[JSON.stringify(query.datasource)] = datasourceSrv.getInstanceSettings(query.datasource);
+    }
+    if (dsSettings) {
+      if (dsSettings.jsonData?.onBehalfOf) {
+        counters.on_behalf_of_queries++;
+      }
+      if (dsSettings.jsonData?.queryTimeout) {
+        counters.queries_with_custom_timeout++;
+      }
+      if (dsSettings.jsonData?.dynamicCaching) {
+        counters.dynamic_caching_queries++;
+      }
+      if (dsSettings.jsonData?.dataConsistency === 'weakconsistency') {
+        counters.weak_data_consistency_queries++;
+      }
+      if (dsSettings.jsonData?.defaultEditorMode === EditorMode.Raw) {
+        counters.queries_with_default_raw_editor++;
+      }
+      if (dsSettings.jsonData?.useSchemaMapping) {
+        counters.queries_with_managed_schema++;
+      }
+    }
+  });
+
+  return counters;
 };

--- a/src/tracking.ts
+++ b/src/tracking.ts
@@ -85,7 +85,8 @@ export const analyzeQueries = (queries: KustoQuery[], datasourceSrv: DataSourceS
     // Data source features
     let dsSettings = datasources[JSON.stringify(query.datasource)];
     if (!dsSettings) {
-      datasources[JSON.stringify(query.datasource)] = datasourceSrv.getInstanceSettings(query.datasource);
+      dsSettings = datasourceSrv.getInstanceSettings(query.datasource);
+      datasources[JSON.stringify(query.datasource)] = dsSettings;
     }
     if (dsSettings) {
       if (dsSettings.jsonData?.onBehalfOf) {

--- a/src/tracking.ts
+++ b/src/tracking.ts
@@ -16,7 +16,6 @@ import { AdxDataSourceOptions, EditorMode, FormatOptions, KustoQuery } from 'typ
  * - 4.1.7: Initial version
  */
 export const trackADXMonitorDashboardLoaded = (props: ADXDashboardLoadedProps) => {
-  console.log('ADXMonitorDashboardLoaded', props);
   reportInteraction('grafana_ds_adx_dashboard_loaded', props);
 };
 


### PR DESCRIPTION
Closes #485

Add the rest of features that we can to track based on its relevant data source configuration. There is no issue getting the data source settings at that time (it's even synchronous so that simplifies things).

The code that counted queries was getting bulky so I moved to its own function and added some tests. 