### PR TITLE
Refactor expression types

### DIFF
--- a/src/KustoExpressionParser.test.ts
+++ b/src/KustoExpressionParser.test.ts
@@ -5,11 +5,12 @@ import {
   QueryEditorPropertyExpression,
   QueryEditorOperatorExpression,
   QueryEditorExpressionType,
-  QueryEditorArrayExpression,
-  QueryEditorExpression,
   QueryEditorReduceExpression,
   QueryEditorGroupByExpression,
   QueryEditorFunctionParameterExpression,
+  QueryEditorReduceExpressionArray,
+  QueryEditorGroupByExpressionArray,
+  QueryEditorWhereArrayExpression,
 } from './components/LegacyQueryEditor/editor/expressions';
 import { AdxColumnSchema, AutoCompleteQuery, defaultQuery, QueryExpression } from 'types';
 
@@ -26,7 +27,7 @@ describe('KustoExpressionParser', () => {
     it('should parse expression with isnotempty function', () => {
       const expression = createQueryExpression({
         from: createProperty('StormEvents'),
-        where: createArray([createOperator('eventType', '==', '')]),
+        where: createWhereArray([createOperator('eventType', '==', '')]),
       });
 
       const acQuery: AutoCompleteQuery = {
@@ -44,7 +45,7 @@ describe('KustoExpressionParser', () => {
     it('should parse expression and exclude current filter index', () => {
       const expression = createQueryExpression({
         from: createProperty('StormEvents'),
-        where: createArray([createOperator('eventType', '==', 'ThunderStorm'), createOperator('state', '==', '')]),
+        where: createWhereArray([createOperator('eventType', '==', 'ThunderStorm'), createOperator('state', '==', '')]),
       });
 
       const acQuery: AutoCompleteQuery = {
@@ -67,9 +68,9 @@ describe('KustoExpressionParser', () => {
     it('should parse expression and exclude current filter index when nested', () => {
       const expression = createQueryExpression({
         from: createProperty('StormEvents'),
-        where: createArray([
+        where: createWhereArray([
           createOperator('eventType', '==', 'ThunderStorm'),
-          createArray(
+          createWhereArray(
             [createOperator('state', '==', ''), createOperator('eventType', '==', 'Ligthning')],
             QueryEditorExpressionType.Or
           ),
@@ -96,9 +97,9 @@ describe('KustoExpressionParser', () => {
     it('should parse expression and with search column being dynamic', () => {
       const expression = createQueryExpression({
         from: createProperty('StormEvents'),
-        where: createArray([
+        where: createWhereArray([
           createOperator('eventType', '==', 'ThunderStorm'),
-          createArray(
+          createWhereArray(
             [createOperator('column["type"]', '==', ''), createOperator('eventType', '==', 'Ligthning')],
             QueryEditorExpressionType.Or
           ),
@@ -133,9 +134,9 @@ describe('KustoExpressionParser', () => {
     it('should parse expression and use default time value as time filter', () => {
       const expression = createQueryExpression({
         from: createProperty('StormEvents'),
-        where: createArray([
+        where: createWhereArray([
           createOperator('eventType', '==', 'ThunderStorm'),
-          createArray(
+          createWhereArray(
             [createOperator('column["type"]', '==', ''), createOperator('eventType', '==', 'Ligthning')],
             QueryEditorExpressionType.Or
           ),
@@ -175,7 +176,7 @@ describe('KustoExpressionParser', () => {
     it('should parse expression and exclude current filter with spaces', () => {
       const expression = createQueryExpression({
         from: createProperty('StormEvents'),
-        where: createArray([
+        where: createWhereArray([
           createOperator('event type', '==', 'ThunderStorm'),
           createOperator('state name', '==', ''),
         ]),
@@ -201,7 +202,7 @@ describe('KustoExpressionParser', () => {
     it('should parse expression with summarize function in an array', () => {
       const expression = createQueryExpression({
         from: createProperty('StormEvents'),
-        where: createArray([createOperator('foo["`indexer`"]', '==', '')]),
+        where: createWhereArray([createOperator('foo["`indexer`"]', '==', '')]),
       });
       const acQuery: AutoCompleteQuery = {
         expression,
@@ -244,7 +245,7 @@ describe('KustoExpressionParser', () => {
     it('should parse expression with where equal to string value', () => {
       const expression = createQueryExpression({
         from: createProperty('StormEvents'),
-        where: createArray([createOperator('eventType', '==', 'ThunderStorm')]),
+        where: createWhereArray([createOperator('eventType', '==', 'ThunderStorm')]),
       });
 
       expect(parser.toQuery(expression)).toEqual('StormEvents' + "\n| where eventType == 'ThunderStorm'");
@@ -265,7 +266,7 @@ describe('KustoExpressionParser', () => {
     it('should parse where operator with a space', () => {
       const expression = createQueryExpression({
         from: createProperty('StormEvents'),
-        where: createArray([createOperator('event type', '==', 'ThunderStorm')]),
+        where: createWhereArray([createOperator('event type', '==', 'ThunderStorm')]),
       });
 
       expect(parser.toQuery(expression)).toEqual('StormEvents' + '\n| where ["event type"] == \'ThunderStorm\'');
@@ -274,7 +275,7 @@ describe('KustoExpressionParser', () => {
     it('should parse reduce expression with a space', () => {
       const expression = createQueryExpression({
         from: createProperty('StormEvents'),
-        reduce: createArray([createReduce('reduce thing', 'none')]),
+        reduce: createReduceArray([createReduce('reduce thing', 'none')]),
       });
 
       expect(parser.toQuery(expression)).toEqual('StormEvents' + '\n| project ["reduce thing"]');
@@ -283,7 +284,7 @@ describe('KustoExpressionParser', () => {
     it('should parse reduce with a function expression with a space', () => {
       const expression = createQueryExpression({
         from: createProperty('StormEvents'),
-        reduce: createArray([createReduce('reduce thing 2', 'sum')]),
+        reduce: createReduceArray([createReduce('reduce thing 2', 'sum')]),
       });
 
       expect(parser.toQuery(expression)).toEqual('StormEvents' + '\n| summarize sum(["reduce thing 2"])');
@@ -292,7 +293,7 @@ describe('KustoExpressionParser', () => {
     it('should parse reduce with a function expression with a space and a dynamic column', () => {
       const expression = createQueryExpression({
         from: createProperty('StormEvents'),
-        reduce: createArray([createReduce('reduce thing', 'sum')]),
+        reduce: createReduceArray([createReduce('reduce thing', 'sum')]),
       });
 
       const tableSchema: AdxColumnSchema[] = [
@@ -311,9 +312,9 @@ describe('KustoExpressionParser', () => {
     it('should parse a expression with spaces in multiple places', () => {
       const expression = createQueryExpression({
         from: createProperty('StormEvents'),
-        where: createArray([createOperator('event type', '==', 'ThunderStorm')]),
-        reduce: createArray([createReduce('reduce thing', 'sum')]),
-        groupBy: createArray([createGroupBy('Start Time', '1h')]),
+        where: createWhereArray([createOperator('event type', '==', 'ThunderStorm')]),
+        reduce: createReduceArray([createReduce('reduce thing', 'sum')]),
+        groupBy: createGroupByArray([createGroupBy('Start Time', '1h')]),
       });
 
       expect(parser.toQuery(expression)).toEqual(
@@ -336,7 +337,7 @@ describe('KustoExpressionParser', () => {
     it('should parse expression with where equal to boolean value', () => {
       const expression = createQueryExpression({
         from: createProperty('StormEvents'),
-        where: createArray([createOperator('isActive', '==', true)]),
+        where: createWhereArray([createOperator('isActive', '==', true)]),
       });
 
       expect(parser.toQuery(expression)).toEqual('StormEvents' + '\n| where isActive == true');
@@ -345,7 +346,7 @@ describe('KustoExpressionParser', () => {
     it('should parse expression with where equal to numeric value', () => {
       const expression = createQueryExpression({
         from: createProperty('StormEvents'),
-        where: createArray([createOperator('count', '==', 10)]),
+        where: createWhereArray([createOperator('count', '==', 10)]),
       });
 
       expect(parser.toQuery(expression)).toEqual('StormEvents' + '\n| where count == 10');
@@ -354,7 +355,7 @@ describe('KustoExpressionParser', () => {
     it('should parse expression with where in numeric values', () => {
       const expression = createQueryExpression({
         from: createProperty('StormEvents'),
-        where: createArray([createOperator('count', 'in', [10, 20])]),
+        where: createWhereArray([createOperator('count', 'in', [10, 20])]),
       });
 
       expect(parser.toQuery(expression)).toEqual('StormEvents' + '\n| where count in (10, 20)');
@@ -363,7 +364,7 @@ describe('KustoExpressionParser', () => {
     it('should parse expression with where in string values', () => {
       const expression = createQueryExpression({
         from: createProperty('StormEvents'),
-        where: createArray([createOperator('events', 'in', ['triggered', 'closed'])]),
+        where: createWhereArray([createOperator('events', 'in', ['triggered', 'closed'])]),
       });
 
       expect(parser.toQuery(expression)).toEqual('StormEvents' + "\n| where events in ('triggered', 'closed')");
@@ -372,7 +373,7 @@ describe('KustoExpressionParser', () => {
     it('should parse expression with multiple where filters', () => {
       const expression = createQueryExpression({
         from: createProperty('StormEvents'),
-        where: createArray([
+        where: createWhereArray([
           createOperator('isActive', '==', true),
           createOperator('events', 'in', ['triggered', 'closed']),
         ]),
@@ -386,10 +387,10 @@ describe('KustoExpressionParser', () => {
     it('should parse expression with multiple where filters with nested or', () => {
       const expression = createQueryExpression({
         from: createProperty('StormEvents'),
-        where: createArray([
+        where: createWhereArray([
           createOperator('isActive', '==', true),
           createOperator('events', 'in', ['triggered', 'closed']),
-          createArray(
+          createWhereArray(
             [createOperator('state', '==', 'TEXAS'), createOperator('state', '==', 'FLORIDA')],
             QueryEditorExpressionType.Or
           ),
@@ -407,7 +408,7 @@ describe('KustoExpressionParser', () => {
     it('should parse expression with empty where filter', () => {
       const expression = createQueryExpression({
         from: createProperty('StormEvents'),
-        where: createArray([createOperator('isActive', '==', '')]),
+        where: createWhereArray([createOperator('isActive', '==', '')]),
       });
 
       expect(parser.toQuery(expression)).toEqual('StormEvents' + "\n| where isActive == ''");
@@ -416,7 +417,7 @@ describe('KustoExpressionParser', () => {
     it('should parse expression with time filter when schema contains time column', () => {
       const expression = createQueryExpression({
         from: createProperty('StormEvents'),
-        where: createArray([createOperator('isActive', '==', true)]),
+        where: createWhereArray([createOperator('isActive', '==', true)]),
       });
 
       const tableSchema: AdxColumnSchema[] = [
@@ -456,7 +457,7 @@ describe('KustoExpressionParser', () => {
     it('should parse expression with time filter when schema contains multiple time columns', () => {
       const expression = createQueryExpression({
         from: createProperty('StormEvents'),
-        where: createArray([createOperator('isActive', '==', true)]),
+        where: createWhereArray([createOperator('isActive', '==', true)]),
       });
 
       const tableSchema: AdxColumnSchema[] = [
@@ -481,7 +482,7 @@ describe('KustoExpressionParser', () => {
     it('should parse expression with time filter when schema contains dynamic time columns', () => {
       const expression = createQueryExpression({
         from: createProperty('StormEvents'),
-        where: createArray([createOperator('isActive', '==', true)]),
+        where: createWhereArray([createOperator('isActive', '==', true)]),
       });
 
       const tableSchema: AdxColumnSchema[] = [
@@ -503,7 +504,7 @@ describe('KustoExpressionParser', () => {
     it('should parse expression with time filter when schema contains combination of dynamic time columns and regular', () => {
       const expression = createQueryExpression({
         from: createProperty('StormEvents'),
-        where: createArray([createOperator('isActive', '==', true)]),
+        where: createWhereArray([createOperator('isActive', '==', true)]),
       });
 
       const tableSchema: AdxColumnSchema[] = [
@@ -529,7 +530,7 @@ describe('KustoExpressionParser', () => {
     it('should parse expression with when filter on dynamic column', () => {
       const expression = createQueryExpression({
         from: createProperty('StormEvents'),
-        where: createArray([createOperator('column["isActive"]', '==', true)]),
+        where: createWhereArray([createOperator('column["isActive"]', '==', true)]),
       });
 
       expect(parser.toQuery(expression)).toEqual('StormEvents' + '\n| where column["isActive"] == true');
@@ -538,8 +539,8 @@ describe('KustoExpressionParser', () => {
     it('should parse expression with summarize of sum(active)', () => {
       const expression = createQueryExpression({
         from: createProperty('StormEvents'),
-        where: createArray([createOperator('column["isActive"]', '==', true)]),
-        reduce: createArray([createReduce('active', 'sum')]),
+        where: createWhereArray([createOperator('column["isActive"]', '==', true)]),
+        reduce: createReduceArray([createReduce('active', 'sum')]),
       });
 
       expect(parser.toQuery(expression)).toEqual(
@@ -550,8 +551,8 @@ describe('KustoExpressionParser', () => {
     it('should parse expression with summarize of count', () => {
       const expression = createQueryExpression({
         from: createProperty('StormEvents'),
-        where: createArray([createOperator('column["isActive"]', '==', true)]),
-        reduce: createArray([createReduce('active', 'count')]),
+        where: createWhereArray([createOperator('column["isActive"]', '==', true)]),
+        reduce: createReduceArray([createReduce('active', 'count')]),
       });
 
       expect(parser.toQuery(expression)).toEqual(
@@ -562,8 +563,8 @@ describe('KustoExpressionParser', () => {
     it('should parse expression with summarize of count', () => {
       const expression = createQueryExpression({
         from: createProperty('StormEvents'),
-        where: createArray([createOperator('column["isActive"]', '==', true)]),
-        reduce: createArray([createReduce('', 'count')]),
+        where: createWhereArray([createOperator('column["isActive"]', '==', true)]),
+        reduce: createReduceArray([createReduce('', 'count')]),
       });
 
       expect(parser.toQuery(expression)).toEqual(
@@ -574,8 +575,8 @@ describe('KustoExpressionParser', () => {
     it('should parse expression with summarize of multiple count', () => {
       const expression = createQueryExpression({
         from: createProperty('StormEvents'),
-        where: createArray([createOperator('column["isActive"]', '==', true)]),
-        reduce: createArray([createReduce('active', 'count'), createReduce('total', 'count')]),
+        where: createWhereArray([createOperator('column["isActive"]', '==', true)]),
+        reduce: createReduceArray([createReduce('active', 'count'), createReduce('total', 'count')]),
       });
 
       expect(parser.toQuery(expression)).toEqual(
@@ -586,8 +587,8 @@ describe('KustoExpressionParser', () => {
     it('should parse expression with summarize of sum on dynamic column', () => {
       const expression = createQueryExpression({
         from: createProperty('StormEvents'),
-        where: createArray([createOperator('column["isActive"]', '==', true)]),
-        reduce: createArray([createReduce('column["level"]["active"]', 'sum')]),
+        where: createWhereArray([createOperator('column["isActive"]', '==', true)]),
+        reduce: createReduceArray([createReduce('column["level"]["active"]', 'sum')]),
       });
 
       const tableSchema: AdxColumnSchema[] = [
@@ -606,8 +607,8 @@ describe('KustoExpressionParser', () => {
     it('should parse expression with project when no group by and no reduce functions', () => {
       const expression = createQueryExpression({
         from: createProperty('StormEvents'),
-        where: createArray([createOperator('column["isActive"]', '==', true)]),
-        reduce: createArray([createReduce('column["level"]["active"]', 'none'), createReduce('active', 'none')]),
+        where: createWhereArray([createOperator('column["isActive"]', '==', true)]),
+        reduce: createReduceArray([createReduce('column["level"]["active"]', 'none'), createReduce('active', 'none')]),
       });
 
       const tableSchema: AdxColumnSchema[] = [
@@ -633,8 +634,8 @@ describe('KustoExpressionParser', () => {
     it('should parse expression with summarize when no group by and mixed none and reduce functions', () => {
       const expression = createQueryExpression({
         from: createProperty('StormEvents'),
-        where: createArray([createOperator('column["isActive"]', '==', true)]),
-        reduce: createArray([createReduce('column["level"]["active"]', 'sum'), createReduce('active', 'none')]),
+        where: createWhereArray([createOperator('column["isActive"]', '==', true)]),
+        reduce: createReduceArray([createReduce('column["level"]["active"]', 'sum'), createReduce('active', 'none')]),
       });
 
       const tableSchema: AdxColumnSchema[] = [
@@ -660,9 +661,9 @@ describe('KustoExpressionParser', () => {
     it('should parse expression to summarize and bin size when it has group by and reduce functions', () => {
       const expression = createQueryExpression({
         from: createProperty('StormEvents'),
-        where: createArray([createOperator('column["isActive"]', '==', true)]),
-        reduce: createArray([createReduce('column["level"]["active"]', 'sum')]),
-        groupBy: createArray([createGroupBy('StartTime', '1h')]),
+        where: createWhereArray([createOperator('column["isActive"]', '==', true)]),
+        reduce: createReduceArray([createReduce('column["level"]["active"]', 'sum')]),
+        groupBy: createGroupByArray([createGroupBy('StartTime', '1h')]),
       });
 
       const tableSchema: AdxColumnSchema[] = [
@@ -689,8 +690,8 @@ describe('KustoExpressionParser', () => {
     it('should parse expression to summarize and bin size when it has group by', () => {
       const expression = createQueryExpression({
         from: createProperty('StormEvents'),
-        where: createArray([createOperator('column["isActive"]', '==', true)]),
-        groupBy: createArray([createGroupBy('StartTime', '1h')]),
+        where: createWhereArray([createOperator('column["isActive"]', '==', true)]),
+        groupBy: createGroupByArray([createGroupBy('StartTime', '1h')]),
       });
 
       const tableSchema: AdxColumnSchema[] = [
@@ -717,8 +718,8 @@ describe('KustoExpressionParser', () => {
     it('should parse expression to summarize and bin size when it has group by multiple fields', () => {
       const expression = createQueryExpression({
         from: createProperty('StormEvents'),
-        where: createArray([createOperator('column["isActive"]', '==', true)]),
-        groupBy: createArray([createGroupBy('StartTime', '1h'), createGroupBy('type')]),
+        where: createWhereArray([createOperator('column["isActive"]', '==', true)]),
+        groupBy: createGroupByArray([createGroupBy('StartTime', '1h'), createGroupBy('type')]),
       });
 
       const tableSchema: AdxColumnSchema[] = [
@@ -745,8 +746,8 @@ describe('KustoExpressionParser', () => {
     it('should parse expression and replace default time column with group by time if available', () => {
       const expression = createQueryExpression({
         from: createProperty('StormEvents'),
-        where: createArray([createOperator('column["isActive"]', '==', true)]),
-        groupBy: createArray([createGroupBy('EndTime', '1h'), createGroupBy('type')]),
+        where: createWhereArray([createOperator('column["isActive"]', '==', true)]),
+        groupBy: createGroupByArray([createGroupBy('EndTime', '1h'), createGroupBy('type')]),
       });
 
       const tableSchema: AdxColumnSchema[] = [
@@ -777,8 +778,8 @@ describe('KustoExpressionParser', () => {
     it('should parse expression and replace default time column with group by as dynamic column', () => {
       const expression = createQueryExpression({
         from: createProperty('StormEvents'),
-        where: createArray([createOperator('column["isActive"]', '==', true)]),
-        groupBy: createArray([createGroupBy('column["EndTime"]', '1h'), createGroupBy('type')]),
+        where: createWhereArray([createOperator('column["isActive"]', '==', true)]),
+        groupBy: createGroupByArray([createGroupBy('column["EndTime"]', '1h'), createGroupBy('type')]),
       });
 
       const tableSchema: AdxColumnSchema[] = [
@@ -810,8 +811,8 @@ describe('KustoExpressionParser', () => {
     it('should parse expression and summarize by dynamic column', () => {
       const expression = createQueryExpression({
         from: createProperty('StormEvents'),
-        where: createArray([createOperator('column["isActive"]', '==', true)]),
-        groupBy: createArray([createGroupBy('column["type"]')]),
+        where: createWhereArray([createOperator('column["isActive"]', '==', true)]),
+        groupBy: createGroupByArray([createGroupBy('column["type"]')]),
       });
 
       const tableSchema: AdxColumnSchema[] = [
@@ -855,8 +856,8 @@ describe('KustoExpressionParser', () => {
 
       const expression = createQueryExpression({
         from: createProperty('StormEvents'),
-        where: createArray([createOperator('column["country"]', '==', '$country')]),
-        groupBy: createArray([createGroupBy('column["type"]')]),
+        where: createWhereArray([createOperator('column["country"]', '==', '$country')]),
+        groupBy: createGroupByArray([createGroupBy('column["type"]')]),
       });
 
       const tableSchema: AdxColumnSchema[] = [
@@ -900,8 +901,10 @@ describe('KustoExpressionParser', () => {
 
       const expression = createQueryExpression({
         from: createProperty('StormEvents'),
-        where: createArray([createOperator('column["country"]', '==', { label: '$country', value: `'$country'` })]),
-        groupBy: createArray([createGroupBy('column["type"]')]),
+        where: createWhereArray([
+          createOperator('column["country"]', '==', { label: '$country', value: `'$country'` }),
+        ]),
+        groupBy: createGroupByArray([createGroupBy('column["type"]')]),
       });
 
       const tableSchema: AdxColumnSchema[] = [
@@ -927,8 +930,8 @@ describe('KustoExpressionParser', () => {
     it('should parse expression with summarize function that takes a parameter', () => {
       const expression = createQueryExpression({
         from: createProperty('StormEvents'),
-        where: createArray([createOperator('column["country"]', '==', 'sweden')]),
-        reduce: createArray([createReduceWithParameter('amount', 'percentile', [1])]),
+        where: createWhereArray([createOperator('column["country"]', '==', 'sweden')]),
+        reduce: createReduceArray([createReduceWithParameter('amount', 'percentile', [1])]),
       });
 
       const tableSchema: AdxColumnSchema[] = [
@@ -954,8 +957,8 @@ describe('KustoExpressionParser', () => {
     it('should parse expression with summarize function that takes multiple parameter', () => {
       const expression = createQueryExpression({
         from: createProperty('StormEvents'),
-        where: createArray([createOperator('column["country"]', '==', 'sweden')]),
-        reduce: createArray([createReduceWithParameter('amount', 'percentile', [1, 2])]),
+        where: createWhereArray([createOperator('column["country"]', '==', 'sweden')]),
+        reduce: createReduceArray([createReduceWithParameter('amount', 'percentile', [1, 2])]),
       });
 
       const tableSchema: AdxColumnSchema[] = [
@@ -981,8 +984,8 @@ describe('KustoExpressionParser', () => {
     it('should parse expression with summarize function that takes a parameter', () => {
       const expression = createQueryExpression({
         from: createProperty('StormEvents'),
-        where: createArray([createOperator('column["country"]', '==', 'sweden')]),
-        reduce: createArray([createReduceWithParameter('amount', 'percentile', [1])]),
+        where: createWhereArray([createOperator('column["country"]', '==', 'sweden')]),
+        reduce: createReduceArray([createReduceWithParameter('amount', 'percentile', [1])]),
       });
 
       const tableSchema: AdxColumnSchema[] = [
@@ -1008,8 +1011,8 @@ describe('KustoExpressionParser', () => {
     it('should parse expression with summarize function that takes multiple parameter of different types', () => {
       const expression = createQueryExpression({
         from: createProperty('StormEvents'),
-        where: createArray([createOperator('column["country"]', '==', 'sweden')]),
-        reduce: createArray([createReduceWithParameter('amount', 'percentile', [1, '2'])]),
+        where: createWhereArray([createOperator('column["country"]', '==', 'sweden')]),
+        reduce: createReduceArray([createReduceWithParameter('amount', 'percentile', [1, '2'])]),
       });
 
       const tableSchema: AdxColumnSchema[] = [
@@ -1035,7 +1038,7 @@ describe('KustoExpressionParser', () => {
     it('should parse expression with summarize function in an array', () => {
       const expression = createQueryExpression({
         from: createProperty('StormEvents'),
-        reduce: createArray([createReduceWithParameter('column["`indexer`"]', 'percentile', [1, '2'])]),
+        reduce: createReduceArray([createReduceWithParameter('column["`indexer`"]', 'percentile', [1, '2'])]),
       });
 
       const tableSchema: AdxColumnSchema[] = [
@@ -1061,7 +1064,7 @@ describe('KustoExpressionParser', () => {
     it('should parse expression with summarize function in a nested array', () => {
       const expression = createQueryExpression({
         from: createProperty('StormEvents'),
-        reduce: createArray([
+        reduce: createReduceArray([
           createReduceWithParameter('column["`indexer`"]["foo"]["`indexer`"]', 'percentile', [1, '2']),
         ]),
       });
@@ -1090,7 +1093,7 @@ describe('KustoExpressionParser', () => {
     it('should parse expression with timeshift', () => {
       const expression = createQueryExpression({
         from: createProperty('StormEvents'),
-        where: createArray([createOperator('country', '==', 'sweden')]),
+        where: createWhereArray([createOperator('country', '==', 'sweden')]),
         timeshift: createProperty('2d'),
       });
 
@@ -1113,7 +1116,7 @@ describe('KustoExpressionParser', () => {
     it('should parse expression with timeshift without any time column', () => {
       const expression = createQueryExpression({
         from: createProperty('StormEvents'),
-        where: createArray([createOperator('country', '==', 'sweden')]),
+        where: createWhereArray([createOperator('country', '==', 'sweden')]),
         timeshift: createProperty('2d'),
       });
 
@@ -1123,7 +1126,7 @@ describe('KustoExpressionParser', () => {
     it('should parse expression with timeshift without any valid timeshift value', () => {
       const expression = createQueryExpression({
         from: createProperty('StormEvents'),
-        where: createArray([createOperator('country', '==', 'sweden')]),
+        where: createWhereArray([createOperator('country', '==', 'sweden')]),
         timeshift: createProperty('100timmar'),
       });
 
@@ -1145,7 +1148,7 @@ describe('KustoExpressionParser', () => {
     it('should parse expression with isnotempty operator', () => {
       const expression = createQueryExpression({
         from: createProperty('StormEvents'),
-        where: createArray([createOperator('country', 'isnotempty', '')]),
+        where: createWhereArray([createOperator('country', 'isnotempty', '')]),
       });
 
       const tableSchema: AdxColumnSchema[] = [
@@ -1166,9 +1169,9 @@ describe('KustoExpressionParser', () => {
     it('should parse expression with empty where array', () => {
       const expression = createQueryExpression({
         from: createProperty('StormEvents'),
-        where: createArray([]),
-        reduce: createArray([createReduce('country', 'dcount')]),
-        groupBy: createArray([createGroupBy('continents')]),
+        where: createWhereArray([]),
+        reduce: createReduceArray([createReduce('country', 'dcount')]),
+        groupBy: createGroupByArray([createGroupBy('continents')]),
       });
 
       const tableSchema: AdxColumnSchema[] = [
@@ -1186,9 +1189,9 @@ describe('KustoExpressionParser', () => {
     it('should parse expression with where array containg empty or', () => {
       const expression = createQueryExpression({
         from: createProperty('StormEvents'),
-        where: createArray([createArray([], QueryEditorExpressionType.Or)]),
-        reduce: createArray([createReduce('country', 'dcount')]),
-        groupBy: createArray([createGroupBy('continents')]),
+        where: createWhereArray([createWhereArray([], QueryEditorExpressionType.Or)]),
+        reduce: createReduceArray([createReduce('country', 'dcount')]),
+        groupBy: createGroupByArray([createGroupBy('continents')]),
       });
 
       const tableSchema: AdxColumnSchema[] = [
@@ -1206,9 +1209,9 @@ describe('KustoExpressionParser', () => {
     it('should parse expression with where array containg empty operators', () => {
       const expression = createQueryExpression({
         from: createProperty('StormEvents'),
-        where: createArray([createOperator('', '', '')]),
-        reduce: createArray([createReduce('country', 'dcount')]),
-        groupBy: createArray([createGroupBy('continents')]),
+        where: createWhereArray([createOperator('', '', '')]),
+        reduce: createReduceArray([createReduce('country', 'dcount')]),
+        groupBy: createGroupByArray([createGroupBy('continents')]),
       });
 
       const tableSchema: AdxColumnSchema[] = [
@@ -1226,9 +1229,9 @@ describe('KustoExpressionParser', () => {
     it('should parse expression with schema mappings for function', () => {
       const expression = createQueryExpression({
         from: createProperty('StormEvents($__from, $__to)'),
-        where: createArray([createOperator('', '', '')]),
-        reduce: createArray([createReduce('country', 'dcount')]),
-        groupBy: createArray([createGroupBy('continents')]),
+        where: createWhereArray([createOperator('', '', '')]),
+        reduce: createReduceArray([createReduce('country', 'dcount')]),
+        groupBy: createGroupByArray([createGroupBy('continents')]),
       });
 
       const tableSchema: AdxColumnSchema[] = [
@@ -1248,7 +1251,7 @@ describe('KustoExpressionParser', () => {
     it('should parse expression with a grouped array', () => {
       const expression = createQueryExpression({
         from: createProperty('StormEvents'),
-        groupBy: createArray([createGroupBy('column["`indexer`"]')]),
+        groupBy: createGroupByArray([createGroupBy('column["`indexer`"]')]),
       });
 
       const tableSchema: AdxColumnSchema[] = [
@@ -1274,7 +1277,7 @@ describe('KustoExpressionParser', () => {
     it('should parse expression with a grouped nested array', () => {
       const expression = createQueryExpression({
         from: createProperty('StormEvents'),
-        groupBy: createArray([createGroupBy('column["`indexer`"]["foo"]["`indexer`"]')]),
+        groupBy: createGroupByArray([createGroupBy('column["`indexer`"]["foo"]["`indexer`"]')]),
       });
 
       const tableSchema: AdxColumnSchema[] = [
@@ -1301,7 +1304,7 @@ describe('KustoExpressionParser', () => {
     it('should parse expression with an array', () => {
       const expression = createQueryExpression({
         from: createProperty('StormEvents'),
-        where: createArray(
+        where: createWhereArray(
           [createOperator(`eventType${DYNAMIC_TYPE_ARRAY_DELIMITER}`, '==', 'ThunderStorm')],
           QueryEditorExpressionType.Or
         ),
@@ -1318,7 +1321,7 @@ describe('KustoExpressionParser', () => {
     it('should parse expression with an array and other "or" operators', () => {
       const expression = createQueryExpression({
         from: createProperty('StormEvents'),
-        where: createArray(
+        where: createWhereArray(
           [
             createOperator(`eventType${DYNAMIC_TYPE_ARRAY_DELIMITER}`, '==', 'ThunderStorm'),
             createOperator(`foo`, '==', 'bar'),
@@ -1338,7 +1341,7 @@ describe('KustoExpressionParser', () => {
     it('should parse expression with nested arrays', () => {
       const expression = createQueryExpression({
         from: createProperty('StormEvents'),
-        where: createArray(
+        where: createWhereArray(
           [
             createOperator(
               `eventType${DYNAMIC_TYPE_ARRAY_DELIMITER}["obj"]${DYNAMIC_TYPE_ARRAY_DELIMITER}`,
@@ -1362,7 +1365,7 @@ describe('KustoExpressionParser', () => {
     it('should parse expression with an array and other "or" operators', () => {
       const expression = createQueryExpression({
         from: createProperty('StormEvents'),
-        where: createArray(
+        where: createWhereArray(
           [
             createOperator(
               `eventType${DYNAMIC_TYPE_ARRAY_DELIMITER}["obj"]${DYNAMIC_TYPE_ARRAY_DELIMITER}`,
@@ -1486,10 +1489,30 @@ const valueToPropertyType = (value: any): QueryEditorPropertyType => {
   }
 };
 
-const createArray = (
-  expressions: QueryEditorExpression[],
+const createWhereArray = (
+  expressions: Array<QueryEditorOperatorExpression | QueryEditorWhereArrayExpression>,
   type: QueryEditorExpressionType = QueryEditorExpressionType.And
-): QueryEditorArrayExpression => {
+): QueryEditorWhereArrayExpression => {
+  return {
+    type,
+    expressions,
+  };
+};
+
+const createReduceArray = (
+  expressions: QueryEditorReduceExpression[],
+  type: QueryEditorExpressionType = QueryEditorExpressionType.And
+): QueryEditorReduceExpressionArray => {
+  return {
+    type,
+    expressions,
+  };
+};
+
+const createGroupByArray = (
+  expressions: QueryEditorGroupByExpression[],
+  type: QueryEditorExpressionType = QueryEditorExpressionType.And
+): QueryEditorGroupByExpressionArray => {
   return {
     type,
     expressions,

--- a/src/KustoExpressionParser.test.ts
+++ b/src/KustoExpressionParser.test.ts
@@ -11,6 +11,7 @@ import {
   QueryEditorReduceExpressionArray,
   QueryEditorGroupByExpressionArray,
   QueryEditorWhereArrayExpression,
+  QueryEditorWhereExpression,
 } from './components/LegacyQueryEditor/editor/expressions';
 import { AdxColumnSchema, AutoCompleteQuery, defaultQuery, QueryExpression } from 'types';
 
@@ -70,7 +71,7 @@ describe('KustoExpressionParser', () => {
         from: createProperty('StormEvents'),
         where: createWhereArray([
           createOperator('eventType', '==', 'ThunderStorm'),
-          createWhereArray(
+          createWhereExpressions(
             [createOperator('state', '==', ''), createOperator('eventType', '==', 'Ligthning')],
             QueryEditorExpressionType.Or
           ),
@@ -99,7 +100,7 @@ describe('KustoExpressionParser', () => {
         from: createProperty('StormEvents'),
         where: createWhereArray([
           createOperator('eventType', '==', 'ThunderStorm'),
-          createWhereArray(
+          createWhereExpressions(
             [createOperator('column["type"]', '==', ''), createOperator('eventType', '==', 'Ligthning')],
             QueryEditorExpressionType.Or
           ),
@@ -136,7 +137,7 @@ describe('KustoExpressionParser', () => {
         from: createProperty('StormEvents'),
         where: createWhereArray([
           createOperator('eventType', '==', 'ThunderStorm'),
-          createWhereArray(
+          createWhereExpressions(
             [createOperator('column["type"]', '==', ''), createOperator('eventType', '==', 'Ligthning')],
             QueryEditorExpressionType.Or
           ),
@@ -390,7 +391,7 @@ describe('KustoExpressionParser', () => {
         where: createWhereArray([
           createOperator('isActive', '==', true),
           createOperator('events', 'in', ['triggered', 'closed']),
-          createWhereArray(
+          createWhereExpressions(
             [createOperator('state', '==', 'TEXAS'), createOperator('state', '==', 'FLORIDA')],
             QueryEditorExpressionType.Or
           ),
@@ -1189,7 +1190,7 @@ describe('KustoExpressionParser', () => {
     it('should parse expression with where array containg empty or', () => {
       const expression = createQueryExpression({
         from: createProperty('StormEvents'),
-        where: createWhereArray([createWhereArray([], QueryEditorExpressionType.Or)]),
+        where: createWhereArray([createWhereExpressions([], QueryEditorExpressionType.Or)]),
         reduce: createReduceArray([createReduce('country', 'dcount')]),
         groupBy: createGroupByArray([createGroupBy('continents')]),
       });
@@ -1489,8 +1490,18 @@ const valueToPropertyType = (value: any): QueryEditorPropertyType => {
   }
 };
 
+const createWhereExpressions = (
+  expressions: QueryEditorOperatorExpression[],
+  type: QueryEditorExpressionType = QueryEditorExpressionType.And
+): QueryEditorWhereExpression => {
+  return {
+    type: type,
+    expressions: expressions,
+  };
+};
+
 const createWhereArray = (
-  expressions: Array<QueryEditorOperatorExpression | QueryEditorWhereArrayExpression>,
+  expressions: Array<QueryEditorOperatorExpression | QueryEditorWhereExpression>,
   type: QueryEditorExpressionType = QueryEditorExpressionType.And
 ): QueryEditorWhereArrayExpression => {
   return {

--- a/src/components/LegacyQueryEditor/VisualQueryEditor.tsx
+++ b/src/components/LegacyQueryEditor/VisualQueryEditor.tsx
@@ -6,8 +6,11 @@ import {
   QueryEditorArrayExpression,
   QueryEditorExpression,
   QueryEditorExpressionType,
+  QueryEditorGroupByExpressionArray,
   QueryEditorOperatorExpression,
   QueryEditorPropertyExpression,
+  QueryEditorReduceExpressionArray,
+  QueryEditorWhereArrayExpression,
 } from 'components/LegacyQueryEditor/editor/expressions';
 import React, { useCallback, useMemo, useEffect } from 'react';
 import { useAsync } from 'react-use';
@@ -142,7 +145,7 @@ export const VisualQueryEditor: React.FC<Props> = (props) => {
       const next = {
         ...query.expression,
         from: table,
-        where: expression,
+        where: expression as QueryEditorWhereArrayExpression,
       };
 
       onChangeQuery({
@@ -161,7 +164,7 @@ export const VisualQueryEditor: React.FC<Props> = (props) => {
       const next = {
         ...query.expression,
         from: table,
-        reduce: expression,
+        reduce: expression as QueryEditorReduceExpressionArray,
       };
 
       onChangeQuery({
@@ -180,7 +183,7 @@ export const VisualQueryEditor: React.FC<Props> = (props) => {
       const next = {
         ...query.expression,
         from: table,
-        groupBy: expression,
+        groupBy: expression as QueryEditorGroupByExpressionArray,
       };
 
       onChangeQuery({

--- a/src/components/LegacyQueryEditor/editor/expressions.ts
+++ b/src/components/LegacyQueryEditor/editor/expressions.ts
@@ -33,13 +33,25 @@ export interface QueryEditorReduceExpression extends QueryEditorExpression {
   parameters?: QueryEditorFunctionParameterExpression[];
 }
 
+export interface QueryEditorReduceExpressionArray extends QueryEditorExpression {
+  expressions: QueryEditorReduceExpression[];
+}
+
 export interface QueryEditorGroupByExpression extends QueryEditorExpression {
   property: QueryEditorProperty;
   interval?: QueryEditorProperty;
 }
 
+export interface QueryEditorGroupByExpressionArray extends QueryEditorExpression {
+  expressions: QueryEditorGroupByExpression[];
+}
+
 export interface QueryEditorColumnsExpression extends QueryEditorExpression {
   columns?: string[];
+}
+
+export interface QueryEditorWhereArrayExpression extends QueryEditorExpression {
+  expressions: Array<QueryEditorOperatorExpression | QueryEditorWhereArrayExpression>;
 }
 
 export interface QueryEditorArrayExpression extends QueryEditorExpression {

--- a/src/components/LegacyQueryEditor/editor/expressions.ts
+++ b/src/components/LegacyQueryEditor/editor/expressions.ts
@@ -50,8 +50,12 @@ export interface QueryEditorColumnsExpression extends QueryEditorExpression {
   columns?: string[];
 }
 
+export interface QueryEditorWhereExpression extends QueryEditorExpression {
+  expressions: QueryEditorOperatorExpression[];
+}
+
 export interface QueryEditorWhereArrayExpression extends QueryEditorExpression {
-  expressions: Array<QueryEditorOperatorExpression | QueryEditorWhereArrayExpression>;
+  expressions: Array<QueryEditorOperatorExpression | QueryEditorWhereExpression>;
 }
 
 export interface QueryEditorArrayExpression extends QueryEditorExpression {

--- a/src/components/QueryEditor/VisualQueryEditor/AggregateSection.tsx
+++ b/src/components/QueryEditor/VisualQueryEditor/AggregateSection.tsx
@@ -58,7 +58,7 @@ const AggregateSection: React.FC<AggregateSectionProps> = ({
     setAggregates(cleaned);
 
     // Only save valid and complete filters into the query state
-    const validExpressions: QueryEditorExpression[] = [];
+    const validExpressions: QueryEditorReduceExpression[] = [];
     for (const operatorExpression of cleaned) {
       const validated = sanitizeAggregate(operatorExpression);
       if (validated) {

--- a/src/components/QueryEditor/VisualQueryEditor/FilterSection.test.tsx
+++ b/src/components/QueryEditor/VisualQueryEditor/FilterSection.test.tsx
@@ -66,7 +66,7 @@ describe('FilterSection', () => {
     expect(onChange).toHaveBeenCalledWith(
       expect.objectContaining({
         expression: expect.objectContaining({
-          where: { expressions: [{ expressions: [{ expressions: [], type: 'or' }], type: 'or' }], type: 'and' },
+          where: { expressions: [{ expressions: [], type: 'or' }], type: 'and' },
         }),
       })
     );

--- a/src/components/QueryEditor/VisualQueryEditor/FilterSection.tsx
+++ b/src/components/QueryEditor/VisualQueryEditor/FilterSection.tsx
@@ -55,7 +55,7 @@ const FilterSection: React.FC<FilterSectionProps> = ({
                 onClick={() => {
                   const expr = query.expression.where.expressions.concat({
                     type: QueryEditorExpressionType.Or,
-                    expressions: [{ type: QueryEditorExpressionType.Or, expressions: [] }],
+                    expressions: [],
                   });
                   onChange({
                     ...query,

--- a/src/components/QueryEditor/VisualQueryEditor/GroupBySection.tsx
+++ b/src/components/QueryEditor/VisualQueryEditor/GroupBySection.tsx
@@ -57,7 +57,7 @@ const GroupBySection: React.FC<GroupBySectionProps> = ({
     setGroupBys(cleaned);
 
     // Only save valid and complete filters into the query state
-    const validExpressions: QueryEditorExpression[] = [];
+    const validExpressions: QueryEditorGroupByExpression[] = [];
     for (const operatorExpression of cleaned) {
       const validated = sanitizeGroupBy(operatorExpression);
       if (validated) {

--- a/src/components/QueryEditor/VisualQueryEditor/KQLFilter.tsx
+++ b/src/components/QueryEditor/VisualQueryEditor/KQLFilter.tsx
@@ -6,10 +6,10 @@ import { EditorList } from '@grafana/experimental';
 import { AdxDataSource } from '../../../datasource';
 import { AdxColumnSchema, KustoQuery } from '../../../types';
 import {
-  QueryEditorArrayExpression,
   QueryEditorExpression,
   QueryEditorExpressionType,
   QueryEditorOperatorExpression,
+  QueryEditorWhereExpression,
 } from 'components/LegacyQueryEditor/editor/expressions';
 import { QueryEditorPropertyType } from 'schema/types';
 import { sanitizeOperator } from './utils/utils';
@@ -28,13 +28,22 @@ export interface FilterExpression extends QueryEditorOperatorExpression {
   index: number;
 }
 
-function extractExpressions(whereExpressions: QueryEditorExpression | QueryEditorArrayExpression) {
+function extractExpressions(whereExpressions: QueryEditorOperatorExpression | QueryEditorWhereExpression) {
   let expressions: FilterExpression[] = [];
   if (whereExpressions && 'expressions' in whereExpressions) {
-    expressions = whereExpressions.expressions.map((e, i) => ({
-      ...e,
-      index: i,
-    }));
+    expressions = whereExpressions.expressions.map((e, i) => {
+      return {
+        ...e,
+        index: i,
+      };
+    });
+  } else if (whereExpressions) {
+    expressions = [
+      {
+        ...whereExpressions,
+        index: 0,
+      },
+    ];
   }
   return expressions;
 }

--- a/src/components/QueryEditor/VisualQueryEditor/KQLFilter.tsx
+++ b/src/components/QueryEditor/VisualQueryEditor/KQLFilter.tsx
@@ -28,6 +28,17 @@ export interface FilterExpression extends QueryEditorOperatorExpression {
   index: number;
 }
 
+function extractExpressions(whereExpressions: QueryEditorExpression | QueryEditorArrayExpression) {
+  let expressions: FilterExpression[] = [];
+  if (whereExpressions && 'expressions' in whereExpressions) {
+    expressions = whereExpressions.expressions.map((e, i) => ({
+      ...e,
+      index: i,
+    }));
+  }
+  return expressions;
+}
+
 const KQLFilter: React.FC<KQLFilterProps> = ({
   index,
   query,
@@ -37,9 +48,7 @@ const KQLFilter: React.FC<KQLFilterProps> = ({
   templateVariableOptions,
 }) => {
   // Each expression is a group of several OR statements
-  const expressions: FilterExpression[] = (
-    query.expression.where.expressions[index] as QueryEditorArrayExpression
-  )?.expressions.map((e, i) => ({ ...e, index: i }));
+  const expressions = extractExpressions(query.expression.where.expressions[index]);
   const [filters, setFilters] = useState<FilterExpression[]>(expressions);
 
   useEffect(() => {
@@ -71,7 +80,7 @@ const KQLFilter: React.FC<KQLFilterProps> = ({
 
     const where = { ...query.expression.where };
     if (newItems.length) {
-      (where.expressions[index] as QueryEditorArrayExpression).expressions = validExpressions;
+      where.expressions[index] = { ...where.expressions[index], expressions: validExpressions };
     } else {
       // The expression is empty, remove it
       const expr = where.expressions;

--- a/src/components/QueryEditor/VisualQueryEditor/utils/utils.test.ts
+++ b/src/components/QueryEditor/VisualQueryEditor/utils/utils.test.ts
@@ -1,4 +1,4 @@
-import { QueryEditorExpression, QueryEditorExpressionType } from 'components/LegacyQueryEditor/editor/expressions';
+import { QueryEditorExpressionType } from 'components/LegacyQueryEditor/editor/expressions';
 import { QueryEditorOperator, QueryEditorPropertyType } from 'schema/types';
 import { defaultQuery } from 'types';
 import { AggregateFunctions } from '../AggregateItem';
@@ -339,7 +339,7 @@ describe('defaultTimeSeriesColumns', () => {
                     property: { name: 'foo', type: QueryEditorPropertyType.DateTime },
                   },
                 ],
-              } as QueryEditorExpression,
+              },
             ],
           },
         },
@@ -363,7 +363,8 @@ describe('defaultTimeSeriesColumns', () => {
               {
                 type: QueryEditorExpressionType.Operator,
                 property: { name: 'foo', type: QueryEditorPropertyType.TimeSpan },
-              } as QueryEditorExpression,
+                reduce: { name: AggregateFunctions.Avg, type: QueryEditorPropertyType.Function },
+              },
             ],
           },
         },
@@ -387,7 +388,7 @@ describe('defaultTimeSeriesColumns', () => {
               {
                 type: QueryEditorExpressionType.Operator,
                 property: { name: 'foo', type: QueryEditorPropertyType.TimeSpan },
-              } as QueryEditorExpression,
+              },
             ],
           },
         },

--- a/src/components/QueryEditor/VisualQueryEditor/utils/utils.test.ts
+++ b/src/components/QueryEditor/VisualQueryEditor/utils/utils.test.ts
@@ -337,6 +337,7 @@ describe('defaultTimeSeriesColumns', () => {
                   {
                     type: QueryEditorExpressionType.Property,
                     property: { name: 'foo', type: QueryEditorPropertyType.DateTime },
+                    operator: { name: '==', value: 'bar' },
                   },
                 ],
               },

--- a/src/components/QueryEditor/VisualQueryEditor/utils/utils.ts
+++ b/src/components/QueryEditor/VisualQueryEditor/utils/utils.ts
@@ -239,14 +239,14 @@ export function defaultTimeSeriesColumns(expression: QueryExpression, tableColum
     });
   }
   if (expression.reduce.expressions?.length) {
-    (expression.reduce.expressions as QueryEditorReduceExpression[]).forEach((exp) => {
+    expression.reduce.expressions.forEach((exp) => {
       if (!res.includes(exp.property.name)) {
         res.push(exp.property.name);
       }
     });
   }
   if (expression.groupBy.expressions?.length) {
-    (expression.groupBy.expressions as QueryEditorGroupByExpression[]).forEach((exp) => {
+    expression.groupBy.expressions.forEach((exp) => {
       if (!res.includes(exp.property.name)) {
         res.push(exp.property.name);
       }

--- a/src/datasource.ts
+++ b/src/datasource.ts
@@ -9,8 +9,7 @@ import {
 } from '@grafana/data';
 import { BackendSrv, DataSourceWithBackend, getBackendSrv, getTemplateSrv, TemplateSrv } from '@grafana/runtime';
 import { firstStringFieldToMetricFindValue } from 'common/responseHelpers';
-import { QueryEditorPropertyExpression } from 'components/LegacyQueryEditor/editor/expressions';
-import { QueryEditorOperator, QueryEditorPropertyType } from './schema/types';
+import { QueryEditorPropertyType } from './schema/types';
 import { KustoExpressionParser, escapeColumn } from 'KustoExpressionParser';
 import { map } from 'lodash';
 import { AdxSchemaMapper } from 'schema/AdxSchemaMapper';
@@ -73,7 +72,7 @@ export class AdxDataSource extends DataSourceWithBackend<KustoQuery, AdxDataSour
       return true; // anything else we can check
     }
 
-    const tableExpr = target.expression?.from as QueryEditorPropertyExpression;
+    const tableExpr = target.expression?.from;
     if (!tableExpr) {
       return false;
     }
@@ -325,9 +324,13 @@ export class AdxDataSource extends DataSourceWithBackend<KustoQuery, AdxDataSour
     }
 
     const results = response.data[0].fields[0].values.toArray();
-    const operator: QueryEditorOperator<string> = query.search.operator as QueryEditorOperator<string>; // why is this always T = QueryEditorOperatorValueType
+    const operator = query.search.operator;
 
-    return operator.name === 'contains' ? sortStartsWithValuesFirst(results, operator.value) : results;
+    let searchTerm = '';
+    if (typeof operator.value === 'string') {
+      searchTerm = operator.value;
+    }
+    return operator.name === 'contains' ? sortStartsWithValuesFirst(results, searchTerm) : results;
   }
 }
 

--- a/src/migrations/expression.ts
+++ b/src/migrations/expression.ts
@@ -1,13 +1,11 @@
-import _ from 'lodash';
 import { QueryExpression, defaultQuery } from 'types';
 import {
   QueryEditorExpressionType,
   QueryEditorOperatorExpression,
-  QueryEditorExpression,
-  QueryEditorArrayExpression,
   QueryEditorPropertyExpression,
   QueryEditorReduceExpression,
   QueryEditorGroupByExpression,
+  QueryEditorReduceExpressionArray,
 } from 'components/LegacyQueryEditor/editor/expressions';
 import { QueryEditorPropertyType, QueryEditorProperty } from '../schema/types';
 
@@ -46,7 +44,7 @@ const migrateV2ToV3 = (expression: any): QueryExpression => {
             type: QueryEditorExpressionType.Or,
             expressions: [exp],
           };
-        }) as QueryEditorExpression[],
+        }),
     };
   }
 
@@ -61,7 +59,7 @@ const migrateV2ToV3 = (expression: any): QueryExpression => {
   return migrated;
 };
 
-const migrateV2Array = (expressions: any[]): QueryEditorArrayExpression => {
+const migrateV2Array = (expressions: any[]): QueryEditorReduceExpressionArray => {
   if (!Array.isArray(expressions)) {
     return {
       type: QueryEditorExpressionType.And,
@@ -71,11 +69,13 @@ const migrateV2Array = (expressions: any[]): QueryEditorArrayExpression => {
 
   return {
     type: QueryEditorExpressionType.And,
-    expressions: expressions.map(migrateV2Expression).filter((exp) => !!exp) as QueryEditorExpression[],
+    expressions: expressions.map(migrateV2Expression).filter((exp) => !!exp) as QueryEditorReduceExpression[],
   };
 };
 
-const migrateV2Expression = (expression: any): QueryEditorExpression | undefined => {
+const migrateV2Expression = (
+  expression: any
+): QueryEditorOperatorExpression | QueryEditorPropertyExpression | undefined => {
   switch (expression?.type) {
     case 'fieldAndOperator':
       return migrateV2OperatorExpression(expression);

--- a/src/migrations/expression_v2_to_v3.test.ts
+++ b/src/migrations/expression_v2_to_v3.test.ts
@@ -1,10 +1,10 @@
 import { QueryExpression } from 'types';
 import {
   QueryEditorExpressionType,
-  QueryEditorOperatorExpression,
-  QueryEditorArrayExpression,
   QueryEditorReduceExpression,
   QueryEditorGroupByExpression,
+  QueryEditorReduceExpressionArray,
+  QueryEditorGroupByExpressionArray,
 } from 'components/LegacyQueryEditor/editor/expressions';
 import { QueryEditorPropertyType } from '../schema/types';
 import { migrateExpression } from './expression';
@@ -42,13 +42,13 @@ describe('migrate expression from v2 to v3', () => {
                     name: '==',
                     value: 'United States',
                   },
-                } as QueryEditorOperatorExpression,
+                },
               ],
-            } as QueryEditorArrayExpression,
+            },
           ],
         },
-        reduce: emptyArrayExpression(),
-        groupBy: emptyArrayExpression(),
+        reduce: emptyReduceArrayExpression(),
+        groupBy: emptyGroupByExpression(),
       };
 
       expect(migrated).toStrictEqual(expected);
@@ -84,9 +84,9 @@ describe('migrate expression from v2 to v3', () => {
                     name: 'in',
                     value: ['Texas', '$state'],
                   },
-                } as QueryEditorOperatorExpression,
+                },
               ],
-            } as QueryEditorArrayExpression,
+            },
           ],
         },
         reduce: {
@@ -154,7 +154,14 @@ describe('migrate expression from v2 to v3', () => {
   });
 });
 
-const emptyArrayExpression = (): QueryEditorArrayExpression => {
+const emptyReduceArrayExpression = (): QueryEditorReduceExpressionArray => {
+  return {
+    type: QueryEditorExpressionType.And,
+    expressions: [],
+  };
+};
+
+const emptyGroupByExpression = (): QueryEditorGroupByExpressionArray => {
   return {
     type: QueryEditorExpressionType.And,
     expressions: [],

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,11 +1,13 @@
 import { DataQuery, DataSourceJsonData, DataSourceSettings } from '@grafana/data';
 
 import {
-  QueryEditorArrayExpression,
   QueryEditorColumnsExpression,
   QueryEditorExpressionType,
+  QueryEditorGroupByExpressionArray,
   QueryEditorOperatorExpression,
   QueryEditorPropertyExpression,
+  QueryEditorReduceExpressionArray,
+  QueryEditorWhereArrayExpression,
 } from './components/LegacyQueryEditor/editor/expressions';
 
 const packageJson = require('../package.json');
@@ -13,9 +15,9 @@ const packageJson = require('../package.json');
 export interface QueryExpression {
   from?: QueryEditorPropertyExpression;
   columns?: QueryEditorColumnsExpression;
-  where: QueryEditorArrayExpression;
-  reduce: QueryEditorArrayExpression;
-  groupBy: QueryEditorArrayExpression;
+  where: QueryEditorWhereArrayExpression;
+  reduce: QueryEditorReduceExpressionArray;
+  groupBy: QueryEditorGroupByExpressionArray;
   timeshift?: QueryEditorPropertyExpression;
 }
 


### PR DESCRIPTION
In the legacy editor, the types for the different expression parts (`where`, `reduce` and `groupBy`) were all defined as `QueryEditorArrayExpression` but each property contains different expression types in real life which caused that in the new editor, I had to do a bunch of casting `as <real type>`.

Now I have defined proper types for the different expression parts and removed casting to rely on Typescript compilation (I still needed to do some casting in the legacy editor since some functions there expect the other type but that code will go away eventually).

Fixes #480 