### PR TITLE
Refactor: Use version from plugin meta info

### DIFF
--- a/src/module.ts
+++ b/src/module.ts
@@ -26,7 +26,7 @@ getAppEvents().subscribe<DashboardLoadedEvent<KustoQuery>>(
     }
 
     trackADXMonitorDashboardLoaded({
-      adx_plugin_version: pluginJson.info.version,
+      adx_plugin_version: plugin.meta.info.version,
       grafana_version: grafanaVersion,
       dashboard_id: dashboardId,
       org_id: orgId,


### PR DESCRIPTION
The version that was being pass down was the string `%VERSION%` rather than the real version of the plugin.