### PR TITLE
Fix: Invalid code editor loaded for Grafana versions that don't follow semantic versioning

### DIFF
--- a/src/components/LegacyQueryEditor/RawQueryEditor.test.tsx
+++ b/src/components/LegacyQueryEditor/RawQueryEditor.test.tsx
@@ -59,4 +59,46 @@ describe('RawQueryEditor', () => {
       await screen.findByText('Loading...');
     });
   });
+
+  describe('when the Grafana version is <=8.5 and is a security release', () => {
+    beforeEach(() => {
+      config.buildInfo.version = '8.1.0.1';
+    });
+    it('should render legacy editor', () => {
+      render(<RawQueryEditor {...defaultProps} />);
+      expect(screen.getByTestId(selectors.components.queryEditor.codeEditorLegacy.container)).toBeInTheDocument();
+    });
+  });
+
+  describe('when the Grafana version is >=8.5 and is a security release', () => {
+    beforeEach(() => {
+      config.buildInfo.version = '8.5.0.1';
+    });
+    it('should render the new code editor', async () => {
+      render(<RawQueryEditor {...defaultProps} />);
+      expect(screen.getByTestId(selectors.components.queryEditor.codeEditor.container)).toBeInTheDocument();
+      await screen.findByText('Loading...');
+    });
+  });
+
+  describe('when the Grafana version is <=8.5 and is a pre-release', () => {
+    beforeEach(() => {
+      config.buildInfo.version = '8.1.0-pre.1';
+    });
+    it('should render legacy editor', () => {
+      render(<RawQueryEditor {...defaultProps} />);
+      expect(screen.getByTestId(selectors.components.queryEditor.codeEditorLegacy.container)).toBeInTheDocument();
+    });
+  });
+
+  describe('when the Grafana version is >=8.5 and is a pre-release', () => {
+    beforeEach(() => {
+      config.buildInfo.version = '8.6.0-pre.1';
+    });
+    it('should render the new code editor', async () => {
+      render(<RawQueryEditor {...defaultProps} />);
+      expect(screen.getByTestId(selectors.components.queryEditor.codeEditor.container)).toBeInTheDocument();
+      await screen.findByText('Loading...');
+    });
+  });
 });

--- a/src/components/LegacyQueryEditor/RawQueryEditor.tsx
+++ b/src/components/LegacyQueryEditor/RawQueryEditor.tsx
@@ -42,7 +42,7 @@ interface Worker {
 // Remove this code once Grafana 8.5 is the minimal version supported
 function gtGrafana8_5() {
   const version = config.buildInfo.version
-  const isValid = valid(config.buildInfo.version)
+  const isValid = valid(version)
   // Assume that a security release will be of the form 'w.x.y.z' - Pre releases of the form 'w.x.y-pre.z' are already valid
   const isSecurityRelease = version.split('.').length > 3
   if (!isValid && isSecurityRelease) {
@@ -50,7 +50,7 @@ function gtGrafana8_5() {
     const coercedValue = coerce(version)
     return coercedValue ? gte(coercedValue, '8.5.0') : null;
   }
-  return valid(config.buildInfo.version) && gte(config.buildInfo.version, '8.5.0');
+  return isValid && gte(version, '8.5.0');
 }
 
 export const RawQueryEditor: React.FC<RawQueryEditorProps> = (props) => {


### PR DESCRIPTION
Will correctly handle security releases by coercing the version into a value that follows semver rules.

Fixes #505 