### PR TITLE
Generate CHANGELOG from PRs labeled with changelog

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,4 @@
+<!-- To surface this PR in the changelog add the label: changelog -->
+<!-- If this PR is going in the changelog please make sure the title of the PR explains the feature in a user-centric way: -->
+<!-- Bad: fix state bug in hooks -->
+<!-- Good: Fix crash when switching from Query Builder -->

--- a/.github/release.yml
+++ b/.github/release.yml
@@ -1,0 +1,9 @@
+changelog:
+  categories:
+    - title: Copy the following lines for the CHANGELOG
+      labels:
+        - changelog
+    - title: Hidden
+      exclude:
+        labels:
+          - '*'


### PR DESCRIPTION
The goal of this config is to minimize discussion/decisions on what to include in the CHANGELOG when cutting a new release by moving the decision point to PR creation via the `changelog` label instead of release creation. 

## New Flow
1. Mark PRs for inclusion in the CHANGELOG as they are created by tagging the PRs with the label `changelog`.
2. When it comes time to cut a release use the [generate release notes](https://docs.github.com/en/repositories/releasing-projects-on-github/automatically-generated-release-notes) feature to generate the list of PRs to include in the CHANGELOG and then copy and paste them into the CHANGELOG.
3. PR the changes to the CHANGELOG along with the new version.
4. Once the PR is merged and the Drone build is passing go into Drone and "Promote the build" to release the new version.
