### PR TITLE
Correctly validate query property

### DIFF
--- a/src/components/LegacyQueryEditor/VisualQueryEditor.tsx
+++ b/src/components/LegacyQueryEditor/VisualQueryEditor.tsx
@@ -56,7 +56,7 @@ export const VisualQueryEditor: React.FC<Props> = (props) => {
 
   // Set initial data
   useEffect(() => {
-    if (database && resultFormat && table?.property.name && !query.expression.from) {
+    if (database && resultFormat && table?.property.name && !query.expression?.from) {
       onChangeQuery({
         ...query,
         database,


### PR DESCRIPTION
Checks if `expression` is undefined before attempting to access `from`

Fixes #514 