### PR TITLE
Bump code coverage workflow version

### DIFF
--- a/.github/workflows/code-coverage.yml
+++ b/.github/workflows/code-coverage.yml
@@ -4,7 +4,7 @@ on:
     branches-ignore: [dependabot/**]
 jobs:
   workflow-call:
-    uses: grafana/code-coverage/.github/workflows/code-coverage.yml@v0.1.10
+    uses: grafana/code-coverage/.github/workflows/code-coverage.yml@v0.1.13
     with:
       frontend-path-regexp: src
       backend-path-regexp: pkg\/azuredx


### PR DESCRIPTION
Use latest version to avoid Node version mismatch.