### PR TITLE
CurrentUserContext to carry current user identity to the authentication layer

### DIFF
--- a/cspell.config.json
+++ b/cspell.config.json
@@ -15,6 +15,7 @@
   "words": [
     "adxauth",
     "adxcredentials",
+    "adxusercontext",
     "clientsecret",
     "Codeowners",
     "datasource",

--- a/pkg/azuredx/adxauth/adxusercontext/context.go
+++ b/pkg/azuredx/adxauth/adxusercontext/context.go
@@ -1,0 +1,25 @@
+package adxusercontext
+
+import (
+	"context"
+
+	"github.com/grafana/grafana-plugin-sdk-go/backend"
+)
+
+type userCtxKey struct {
+}
+
+type CurrentUserContext struct {
+	User        *backend.User
+	IdToken     string
+	AccessToken string
+}
+
+func WithCurrentUser(ctx context.Context, currentUser CurrentUserContext) context.Context {
+	return context.WithValue(ctx, userCtxKey{}, currentUser)
+}
+
+func GetCurrentUser(ctx context.Context) (CurrentUserContext, bool) {
+	resourceReq, ok := ctx.Value(userCtxKey{}).(CurrentUserContext)
+	return resourceReq, ok
+}

--- a/pkg/azuredx/adxauth/adxusercontext/from_req.go
+++ b/pkg/azuredx/adxauth/adxusercontext/from_req.go
@@ -46,7 +46,8 @@ func FromHealthCheckReq(ctx context.Context, req *backend.CheckHealthRequest) co
 		return ctx
 	}
 
-	// TODO: Add support for ID and access tokens
+	// TODO: CheckHealthRequest currently doesn't support ID and access tokens, only user information
+	// See issue https://github.com/grafana/grafana-plugin-sdk-go/issues/579
 	currentUser := CurrentUserContext{
 		User:        req.PluginContext.User,
 		IdToken:     "",
@@ -57,7 +58,6 @@ func FromHealthCheckReq(ctx context.Context, req *backend.CheckHealthRequest) co
 }
 
 func getQueryReqHeader(req *backend.QueryDataRequest, headerName string) string {
-	// TODO: Check what subset of Unicode is case-insensitive for request headers, possibly narrow to ASCII
 	headerNameCI := strings.ToLower(headerName)
 
 	for name, value := range req.Headers {
@@ -70,7 +70,6 @@ func getQueryReqHeader(req *backend.QueryDataRequest, headerName string) string 
 }
 
 func getResourceReqHeader(req *backend.CallResourceRequest, headerName string) string {
-	// TODO: Check what subset of Unicode is case-insensitive for request headers, possibly narrow to ASCII
 	headerNameCI := strings.ToLower(headerName)
 
 	for name, values := range req.Headers {

--- a/pkg/azuredx/adxauth/adxusercontext/from_req.go
+++ b/pkg/azuredx/adxauth/adxusercontext/from_req.go
@@ -7,7 +7,7 @@ import (
 	"github.com/grafana/grafana-plugin-sdk-go/backend"
 )
 
-func FromQueryReq(ctx context.Context, req *backend.QueryDataRequest) context.Context {
+func WithUserFromQueryReq(ctx context.Context, req *backend.QueryDataRequest) context.Context {
 	if req == nil {
 		return ctx
 	}
@@ -24,7 +24,7 @@ func FromQueryReq(ctx context.Context, req *backend.QueryDataRequest) context.Co
 	return WithCurrentUser(ctx, currentUser)
 }
 
-func FromResourceReq(ctx context.Context, req *backend.CallResourceRequest) context.Context {
+func WithUserFromResourceReq(ctx context.Context, req *backend.CallResourceRequest) context.Context {
 	if req == nil {
 		return ctx
 	}
@@ -41,7 +41,7 @@ func FromResourceReq(ctx context.Context, req *backend.CallResourceRequest) cont
 	return WithCurrentUser(ctx, currentUser)
 }
 
-func FromHealthCheckReq(ctx context.Context, req *backend.CheckHealthRequest) context.Context {
+func WithUserFromHealthCheckReq(ctx context.Context, req *backend.CheckHealthRequest) context.Context {
 	if req == nil {
 		return ctx
 	}

--- a/pkg/azuredx/adxauth/adxusercontext/from_req.go
+++ b/pkg/azuredx/adxauth/adxusercontext/from_req.go
@@ -1,0 +1,98 @@
+package adxusercontext
+
+import (
+	"context"
+	"strings"
+
+	"github.com/grafana/grafana-plugin-sdk-go/backend"
+)
+
+func FromQueryReq(ctx context.Context, req *backend.QueryDataRequest) context.Context {
+	if req == nil {
+		return ctx
+	}
+
+	idToken := getQueryReqHeader(req, "X-ID-Token")
+	accessToken := extractBearerToken(getQueryReqHeader(req, "Authorization"))
+
+	currentUser := CurrentUserContext{
+		User:        req.PluginContext.User,
+		IdToken:     idToken,
+		AccessToken: accessToken,
+	}
+
+	return WithCurrentUser(ctx, currentUser)
+}
+
+func FromResourceReq(ctx context.Context, req *backend.CallResourceRequest) context.Context {
+	if req == nil {
+		return ctx
+	}
+
+	idToken := getResourceReqHeader(req, "X-ID-Token")
+	accessToken := extractBearerToken(getResourceReqHeader(req, "Authorization"))
+
+	currentUser := CurrentUserContext{
+		User:        req.PluginContext.User,
+		IdToken:     idToken,
+		AccessToken: accessToken,
+	}
+
+	return WithCurrentUser(ctx, currentUser)
+}
+
+func FromHealthCheckReq(ctx context.Context, req *backend.CheckHealthRequest) context.Context {
+	if req == nil {
+		return ctx
+	}
+
+	// TODO: Add support for ID and access tokens
+	currentUser := CurrentUserContext{
+		User:        req.PluginContext.User,
+		IdToken:     "",
+		AccessToken: "",
+	}
+
+	return WithCurrentUser(ctx, currentUser)
+}
+
+func getQueryReqHeader(req *backend.QueryDataRequest, headerName string) string {
+	// TODO: Check what subset of Unicode is case-insensitive for request headers, possibly narrow to ASCII
+	headerNameCI := strings.ToLower(headerName)
+
+	for name, value := range req.Headers {
+		if strings.ToLower(name) == headerNameCI {
+			return value
+		}
+	}
+
+	return ""
+}
+
+func getResourceReqHeader(req *backend.CallResourceRequest, headerName string) string {
+	// TODO: Check what subset of Unicode is case-insensitive for request headers, possibly narrow to ASCII
+	headerNameCI := strings.ToLower(headerName)
+
+	for name, values := range req.Headers {
+		if strings.ToLower(name) == headerNameCI {
+			if len(values) > 0 {
+				return values[0]
+			} else {
+				return ""
+			}
+		}
+	}
+
+	return ""
+}
+
+func extractBearerToken(authorizationHeader string) string {
+	const bearerPrefix = "Bearer "
+
+	var accessToken string
+	if strings.HasPrefix(authorizationHeader, bearerPrefix) {
+		accessToken = strings.TrimPrefix(authorizationHeader, bearerPrefix)
+	}
+
+	return accessToken
+}

--- a/pkg/azuredx/adxauth/auth.go
+++ b/pkg/azuredx/adxauth/auth.go
@@ -2,11 +2,11 @@ package adxauth
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"net/http"
 	"time"
 
+	"github.com/grafana/azure-data-explorer-datasource/pkg/azuredx/adxauth/adxusercontext"
 	"github.com/grafana/azure-data-explorer-datasource/pkg/azuredx/models"
 	"github.com/grafana/grafana-azure-sdk-go/azcredentials"
 	"github.com/grafana/grafana-azure-sdk-go/azsettings"
@@ -16,8 +16,8 @@ import (
 
 // ServiceCredentials provides authorization for cloud service usage.
 type ServiceCredentials interface {
-	ServicePrincipalAuthorization(ctx context.Context) (string, error)
-	QueryDataAuthorization(ctx context.Context, req *backend.QueryDataRequest) (string, error)
+	GetServiceAccessToken(ctx context.Context) (string, error)
+	GetAccessToken(ctx context.Context) (string, error)
 }
 
 type ServiceCredentialsImpl struct {
@@ -67,20 +67,19 @@ func NewServiceCredentials(settings *models.DatasourceSettings, azureSettings *a
 	}, nil
 }
 
-// ServicePrincipalAuthorization returns an HTTP Authorization-header value which
-// represents the service principal.
-func (c *ServiceCredentialsImpl) ServicePrincipalAuthorization(ctx context.Context) (string, error) {
-	token, err := c.tokenProvider.GetAccessToken(ctx, c.scopes)
-	if err != nil {
-		return "", fmt.Errorf("service principal token unavailable: %w", err)
-	}
-
-	return "Bearer " + token, nil
+// GetServiceAccessToken returns access token for the service credentials
+func (c *ServiceCredentialsImpl) GetServiceAccessToken(ctx context.Context) (string, error) {
+	backend.Logger.Debug("using service principal token for data request")
+	return c.tokenProvider.GetAccessToken(ctx, c.scopes)
 }
 
-// QueryDataAuthorization returns an HTTP Authorization-header value which
-// represents the respective request.
-func (c *ServiceCredentialsImpl) QueryDataAuthorization(ctx context.Context, req *backend.QueryDataRequest) (string, error) {
+// GetAccessToken returns access token for configured credentials
+func (c *ServiceCredentialsImpl) GetAccessToken(ctx context.Context) (string, error) {
+	if ctx == nil {
+		err := fmt.Errorf("parameter 'ctx' cannot be nil")
+		return "", err
+	}
+
 	if c.QueryTimeout != 0 {
 		var cancel context.CancelFunc
 		ctx, cancel = context.WithTimeout(ctx, c.QueryTimeout)
@@ -89,45 +88,33 @@ func (c *ServiceCredentialsImpl) QueryDataAuthorization(ctx context.Context, req
 
 	// Use AAD client if initialized (for OBO credentials)
 	if c.aadClient != nil {
-		return c.queryDataOnBehalfOf(ctx, req)
+		// TODO: Add temporary workaround for cases when OBO isn't possible
+		return c.onBehalfOf(ctx)
 	} else {
+		// Service identity credentials
 		backend.Logger.Debug("using service principal token for data request")
-		return c.ServicePrincipalAuthorization(ctx)
+		return c.tokenProvider.GetAccessToken(ctx, c.scopes)
 	}
 }
 
-func (c *ServiceCredentialsImpl) queryDataOnBehalfOf(ctx context.Context, req *backend.QueryDataRequest) (string, error) {
-	user := req.PluginContext.User // do nil-check once for all
-	if user == nil {
-		return "", errors.New("non-user requests not permitted with on-behalf-of configuration")
-	}
-
-	// Azure requires an ID token (instead of an access token) for the exchange.
-	userToken, ok := req.Headers["X-ID-Token"]
+func (c *ServiceCredentialsImpl) onBehalfOf(ctx context.Context) (string, error) {
+	currentUser, ok := adxusercontext.GetCurrentUser(ctx)
 	if !ok {
-		if _, ok := req.Headers["Authorization"]; !ok {
-			return "", errors.New("system accounts are denied with on-behalf-of configuration")
-		}
-
-		backend.Logger.Error("ID token absent for data request; enable them on the Azure portal under: “App Registrations” → the respective application → “Manage” → “Authentication”", "user", user.Login)
-		return "", errors.New("ID token absent for data request")
-	}
-
-	onBehalfOfToken, err := c.onBehalfOf(ctx, userToken)
-	if err != nil {
-		backend.Logger.Error(err.Error(), "user", user.Login)
-		// Don't leak any context to the end-user.
-		return "", errors.New("on-behalf-of token exchange failed for data request")
-	}
-	backend.Logger.Debug("acquired on-behalf-of token for data request")
-
-	return "Bearer " + onBehalfOfToken, nil
-}
-
-func (c *ServiceCredentialsImpl) onBehalfOf(ctx context.Context, idToken string) (onBehalfOfToken string, err error) {
-	result, err := c.aadClient.AcquireTokenOnBehalfOf(ctx, idToken, c.scopes)
-	if err != nil {
+		err := fmt.Errorf("user context not configured")
 		return "", err
 	}
+
+	if currentUser.IdToken == "" {
+		err := fmt.Errorf("user context doesn't have ID token")
+		return "", err
+	}
+
+	result, err := c.aadClient.AcquireTokenOnBehalfOf(ctx, currentUser.IdToken, c.scopes)
+	if err != nil {
+		backend.Logger.Error(err.Error(), "user", currentUser.User.Login)
+		err = fmt.Errorf("unable to acquire access token for user '%s'", currentUser.User.Login)
+		return "", err
+	}
+
 	return result.AccessToken, nil
 }

--- a/pkg/azuredx/adxauth/auth_test.go
+++ b/pkg/azuredx/adxauth/auth_test.go
@@ -76,7 +76,7 @@ func TestOnBehalfOf(t *testing.T) {
 			c.aadClient = fakeAADClient
 		}
 
-		auth, err := c.QueryDataAuthorization(context.Background(), &req)
+		auth, err := c.GetAccessToken(context.Background())
 
 		switch {
 		case err != nil:

--- a/pkg/azuredx/client/client.go
+++ b/pkg/azuredx/client/client.go
@@ -2,9 +2,11 @@ package client
 
 import (
 	"bytes"
+	"context"
 	"fmt"
 	"net/http"
 
+	"github.com/grafana/azure-data-explorer-datasource/pkg/azuredx/adxauth"
 	// 100% compatible drop-in replacement of "encoding/json"
 	json "github.com/json-iterator/go"
 
@@ -12,24 +14,25 @@ import (
 )
 
 type AdxClient interface {
-	TestRequest(datasourceSettings *models.DatasourceSettings, properties *models.Properties, additionalHeaders map[string]string) error
-	KustoRequest(url string, payload models.RequestPayload, additionalHeaders map[string]string) (*models.TableResponse, error)
+	TestRequest(ctx context.Context, datasourceSettings *models.DatasourceSettings, properties *models.Properties, additionalHeaders map[string]string) error
+	KustoRequest(ctx context.Context, url string, payload models.RequestPayload, additionalHeaders map[string]string) (*models.TableResponse, error)
 }
 
 var _ AdxClient = new(Client) // validates interface conformance
 
 // Client is an http.Client used for API requests.
 type Client struct {
-	httpClient *http.Client
+	httpClient         *http.Client
+	serviceCredentials adxauth.ServiceCredentials
 }
 
 // NewClient creates a Grafana Plugin SDK Go Http Client
-func New(client *http.Client) *Client {
-	return &Client{httpClient: client}
+func New(serviceCredentials adxauth.ServiceCredentials, client *http.Client) *Client {
+	return &Client{serviceCredentials: serviceCredentials, httpClient: client}
 }
 
 // TestRequest handles a data source test request in Grafana's Datasource configuration UI.
-func (c *Client) TestRequest(datasourceSettings *models.DatasourceSettings, properties *models.Properties, additionalHeaders map[string]string) error {
+func (c *Client) TestRequest(ctx context.Context, datasourceSettings *models.DatasourceSettings, properties *models.Properties, additionalHeaders map[string]string) error {
 	buf, err := json.Marshal(models.RequestPayload{
 		CSL:        ".show databases schema",
 		DB:         datasourceSettings.DefaultDatabase,
@@ -39,11 +42,19 @@ func (c *Client) TestRequest(datasourceSettings *models.DatasourceSettings, prop
 		return err
 	}
 
+	// TODO: This is a workaround because Plugin SDK doesn't expose user context for CheckHealth
+	accessToken, err := c.serviceCredentials.GetServiceAccessToken(ctx)
+	if err != nil {
+		return err
+	}
+
 	req, err := http.NewRequest("POST", datasourceSettings.ClusterURL+"/v1/rest/query", bytes.NewReader(buf))
 	if err != nil {
 		return err
 	}
+
 	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Authorization", "Bearer "+accessToken)
 	for key, value := range additionalHeaders {
 		req.Header.Set(key, value)
 	}
@@ -63,18 +74,25 @@ func (c *Client) TestRequest(datasourceSettings *models.DatasourceSettings, prop
 // KustoRequest executes a Kusto Query language request to Azure's Data Explorer V1 REST API
 // and returns a TableResponse. If there is a query syntax error, the error message inside
 // the API's JSON error response is returned as well (if available).
-func (c *Client) KustoRequest(url string, payload models.RequestPayload, additionalHeaders map[string]string) (*models.TableResponse, error) {
+func (c *Client) KustoRequest(ctx context.Context, url string, payload models.RequestPayload, additionalHeaders map[string]string) (*models.TableResponse, error) {
 	buf, err := json.Marshal(payload)
 	if err != nil {
 		return nil, fmt.Errorf("no Azure request serial: %w", err)
+	}
+
+	accessToken, err := c.serviceCredentials.GetAccessToken(ctx)
+	if err != nil {
+		return nil, err
 	}
 
 	req, err := http.NewRequest(http.MethodPost, url, bytes.NewReader(buf))
 	if err != nil {
 		return nil, fmt.Errorf("no Azure request instance: %w", err)
 	}
+
 	req.Header.Set("Accept", "application/json")
 	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Authorization", "Bearer "+accessToken)
 	req.Header.Set("x-ms-app", "Grafana-ADX")
 	if payload.QuerySource == "" {
 		payload.QuerySource = "unspecified"

--- a/pkg/azuredx/client/client_test.go
+++ b/pkg/azuredx/client/client_test.go
@@ -34,8 +34,8 @@ func TestClient(t *testing.T) {
 			QuerySource: "schema",
 		}
 
-		client := New(server.Client())
-		table, err := client.KustoRequest(context.TODO(), server.URL, payload, nil)
+		client := New(&fakeCredentialsProvider{}, server.Client())
+		table, err := client.KustoRequest(context.Background(), server.URL, payload, nil)
 		require.NoError(t, err)
 		require.NotNil(t, table)
 	})
@@ -61,8 +61,8 @@ func TestClient(t *testing.T) {
 			QuerySource: "schema",
 		}
 
-		client := New(server.Client())
-		table, err := client.KustoRequest(context.TODO(), server.URL, payload, nil)
+		client := New(&fakeCredentialsProvider{}, server.Client())
+		table, err := client.KustoRequest(context.Background(), server.URL, payload, nil)
 		require.Nil(t, table)
 		require.NotNil(t, err)
 		require.Contains(t, err.Error(), "Request is invalid and cannot be processed: Syntax error: SYN0002: A recognition error occurred. [line:position=1:9]. Query: 'PerfTest take 5'")
@@ -88,8 +88,8 @@ func TestClient(t *testing.T) {
 			"x-ms-client-request-id": "KGC.schema;deadbeef",
 		}
 
-		client := New(server.Client())
-		table, err := client.KustoRequest(context.TODO(), server.URL, payload, headers)
+		client := New(&fakeCredentialsProvider{}, server.Client())
+		table, err := client.KustoRequest(context.Background(), server.URL, payload, headers)
 		require.Nil(t, table)
 		require.NotNil(t, err)
 	})
@@ -101,4 +101,14 @@ func loadTestFile(path string) ([]byte, error) {
 		return nil, err
 	}
 	return jsonBody, nil
+}
+
+type fakeCredentialsProvider struct{}
+
+func (c *fakeCredentialsProvider) GetServiceAccessToken(_ context.Context) (string, error) {
+	return "FAKE_TOKEN", nil
+}
+
+func (c *fakeCredentialsProvider) GetAccessToken(_ context.Context) (string, error) {
+	return "FAKE_TOKEN", nil
 }

--- a/pkg/azuredx/client/client_test.go
+++ b/pkg/azuredx/client/client_test.go
@@ -1,6 +1,7 @@
 package client
 
 import (
+	"context"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -34,7 +35,7 @@ func TestClient(t *testing.T) {
 		}
 
 		client := New(server.Client())
-		table, err := client.KustoRequest(server.URL, payload, nil)
+		table, err := client.KustoRequest(context.TODO(), server.URL, payload, nil)
 		require.NoError(t, err)
 		require.NotNil(t, table)
 	})
@@ -61,7 +62,7 @@ func TestClient(t *testing.T) {
 		}
 
 		client := New(server.Client())
-		table, err := client.KustoRequest(server.URL, payload, nil)
+		table, err := client.KustoRequest(context.TODO(), server.URL, payload, nil)
 		require.Nil(t, table)
 		require.NotNil(t, err)
 		require.Contains(t, err.Error(), "Request is invalid and cannot be processed: Syntax error: SYN0002: A recognition error occurred. [line:position=1:9]. Query: 'PerfTest take 5'")
@@ -88,7 +89,7 @@ func TestClient(t *testing.T) {
 		}
 
 		client := New(server.Client())
-		table, err := client.KustoRequest(server.URL, payload, headers)
+		table, err := client.KustoRequest(context.TODO(), server.URL, payload, headers)
 		require.Nil(t, table)
 		require.NotNil(t, err)
 	})

--- a/pkg/azuredx/datasource.go
+++ b/pkg/azuredx/datasource.go
@@ -87,7 +87,7 @@ func NewDatasource(instanceSettings backend.DataSourceInstanceSettings) (instanc
 
 // QueryData is the primary method called by grafana-server
 func (adx *AzureDataExplorer) QueryData(ctx context.Context, req *backend.QueryDataRequest) (*backend.QueryDataResponse, error) {
-	ctx = adxusercontext.FromQueryReq(ctx, req)
+	ctx = adxusercontext.WithUserFromQueryReq(ctx, req)
 	backend.Logger.Debug("Query", "datasource", req.PluginContext.DataSourceInstanceSettings.Name)
 
 	res := backend.NewQueryDataResponse()
@@ -100,12 +100,12 @@ func (adx *AzureDataExplorer) QueryData(ctx context.Context, req *backend.QueryD
 }
 
 func (adx *AzureDataExplorer) CallResource(ctx context.Context, req *backend.CallResourceRequest, sender backend.CallResourceResponseSender) error {
-	return adx.CallResourceHandler.CallResource(adxusercontext.FromResourceReq(ctx, req), req, sender)
+	return adx.CallResourceHandler.CallResource(adxusercontext.WithUserFromResourceReq(ctx, req), req, sender)
 }
 
 // CheckHealth handles health checks
 func (adx *AzureDataExplorer) CheckHealth(ctx context.Context, req *backend.CheckHealthRequest) (*backend.CheckHealthResult, error) {
-	ctx = adxusercontext.FromHealthCheckReq(ctx, req)
+	ctx = adxusercontext.WithUserFromHealthCheckReq(ctx, req)
 	headers := map[string]string{}
 	err := adx.client.TestRequest(ctx, adx.settings, models.NewConnectionProperties(adx.settings, nil), headers)
 	if err != nil {

--- a/pkg/azuredx/datasource.go
+++ b/pkg/azuredx/datasource.go
@@ -93,7 +93,7 @@ func (adx *AzureDataExplorer) QueryData(ctx context.Context, req *backend.QueryD
 	res := backend.NewQueryDataResponse()
 
 	for _, q := range req.Queries {
-		res.Responses[q.RefID] = adx.handleQuery(adxusercontext.FromQueryReq(ctx, req), q, req.PluginContext.User)
+		res.Responses[q.RefID] = adx.handleQuery(ctx, q, req.PluginContext.User)
 	}
 
 	return res, nil

--- a/pkg/azuredx/datasource_test.go
+++ b/pkg/azuredx/datasource_test.go
@@ -46,17 +46,17 @@ func TestDatasource(t *testing.T) {
 			require.Contains(t, additionalHeaders["x-ms-client-request-id"], UserLogin)
 			return table, nil
 		}
-		res := adx.handleQuery(context.TODO(), query, &backend.User{Login: UserLogin})
+		res := adx.handleQuery(context.Background(), query, &backend.User{Login: UserLogin})
 		require.NoError(t, res.Error)
 	})
 }
 
 type fakeClient struct{}
 
-func (c *fakeClient) TestRequest(datasourceSettings *models.DatasourceSettings, properties *models.Properties, additionalHeaders map[string]string) error {
+func (c *fakeClient) TestRequest(_ context.Context, _ *models.DatasourceSettings, _ *models.Properties, _ map[string]string) error {
 	panic("not implemented")
 }
 
-func (c *fakeClient) KustoRequest(url string, payload models.RequestPayload, additionalHeaders map[string]string) (*models.TableResponse, error) {
+func (c *fakeClient) KustoRequest(_ context.Context, url string, payload models.RequestPayload, additionalHeaders map[string]string) (*models.TableResponse, error) {
 	return kustoRequestMock(url, payload, additionalHeaders)
 }

--- a/pkg/azuredx/datasource_test.go
+++ b/pkg/azuredx/datasource_test.go
@@ -1,6 +1,7 @@
 package azuredx
 
 import (
+	"context"
 	"testing"
 
 	"github.com/grafana/azure-data-explorer-datasource/pkg/azuredx/models"
@@ -45,7 +46,7 @@ func TestDatasource(t *testing.T) {
 			require.Contains(t, additionalHeaders["x-ms-client-request-id"], UserLogin)
 			return table, nil
 		}
-		res := adx.handleQuery(query, &backend.User{Login: UserLogin}, "")
+		res := adx.handleQuery(context.TODO(), query, &backend.User{Login: UserLogin})
 		require.NoError(t, res.Error)
 	})
 }

--- a/pkg/azuredx/resource_handler.go
+++ b/pkg/azuredx/resource_handler.go
@@ -25,12 +25,12 @@ func (adx *AzureDataExplorer) getSchema(rw http.ResponseWriter, req *http.Reques
 		QuerySource: "schema",
 	}
 
-	authorization, err := adx.serviceCredentials.ServicePrincipalAuthorization(req.Context())
+	accessToken, err := adx.serviceCredentials.GetAccessToken(req.Context())
 	if err != nil {
 		respondWithError(rw, http.StatusInternalServerError, "Azure query denied", err)
 		return
 	}
-	headers := map[string]string{"Authorization": authorization}
+	headers := map[string]string{"Authorization": "Bearer " + accessToken}
 	response, err := adx.client.KustoRequest(adx.settings.ClusterURL+ManagementApiPath, payload, headers)
 	if err != nil {
 		respondWithError(rw, http.StatusInternalServerError, "Azure query unsuccessful", err)
@@ -54,12 +54,12 @@ func (adx *AzureDataExplorer) getDatabases(rw http.ResponseWriter, req *http.Req
 		CSL: ".show databases",
 	}
 
-	authorization, err := adx.serviceCredentials.ServicePrincipalAuthorization(req.Context())
+	accessToken, err := adx.serviceCredentials.GetAccessToken(req.Context())
 	if err != nil {
 		respondWithError(rw, http.StatusInternalServerError, "Azure query denied", err)
 		return
 	}
-	headers := map[string]string{"Authorization": authorization}
+	headers := map[string]string{"Authorization": "Bearer " + accessToken}
 	response, err := adx.client.KustoRequest(adx.settings.ClusterURL+ManagementApiPath, payload, headers)
 	if err != nil {
 		respondWithError(rw, http.StatusInternalServerError, "Azure query unsuccessful", err)

--- a/pkg/azuredx/resource_handler.go
+++ b/pkg/azuredx/resource_handler.go
@@ -25,13 +25,8 @@ func (adx *AzureDataExplorer) getSchema(rw http.ResponseWriter, req *http.Reques
 		QuerySource: "schema",
 	}
 
-	accessToken, err := adx.serviceCredentials.GetAccessToken(req.Context())
-	if err != nil {
-		respondWithError(rw, http.StatusInternalServerError, "Azure query denied", err)
-		return
-	}
-	headers := map[string]string{"Authorization": "Bearer " + accessToken}
-	response, err := adx.client.KustoRequest(adx.settings.ClusterURL+ManagementApiPath, payload, headers)
+	headers := map[string]string{}
+	response, err := adx.client.KustoRequest(req.Context(), adx.settings.ClusterURL+ManagementApiPath, payload, headers)
 	if err != nil {
 		respondWithError(rw, http.StatusInternalServerError, "Azure query unsuccessful", err)
 		return
@@ -54,13 +49,8 @@ func (adx *AzureDataExplorer) getDatabases(rw http.ResponseWriter, req *http.Req
 		CSL: ".show databases",
 	}
 
-	accessToken, err := adx.serviceCredentials.GetAccessToken(req.Context())
-	if err != nil {
-		respondWithError(rw, http.StatusInternalServerError, "Azure query denied", err)
-		return
-	}
-	headers := map[string]string{"Authorization": "Bearer " + accessToken}
-	response, err := adx.client.KustoRequest(adx.settings.ClusterURL+ManagementApiPath, payload, headers)
+	headers := map[string]string{}
+	response, err := adx.client.KustoRequest(req.Context(), adx.settings.ClusterURL+ManagementApiPath, payload, headers)
 	if err != nil {
 		respondWithError(rw, http.StatusInternalServerError, "Azure query unsuccessful", err)
 		return

--- a/pkg/azuredx/resource_handler_test.go
+++ b/pkg/azuredx/resource_handler_test.go
@@ -1,14 +1,12 @@
 package azuredx
 
 import (
-	"context"
 	"encoding/json"
 	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"testing"
 
-	"github.com/grafana/grafana-plugin-sdk-go/backend"
 	"github.com/stretchr/testify/require"
 
 	"github.com/grafana/azure-data-explorer-datasource/pkg/azuredx/models"
@@ -41,7 +39,6 @@ func TestResourceHandler(t *testing.T) {
 		adx.settings = &models.DatasourceSettings{
 			ClusterURL: "some-baseurl",
 		}
-		adx.serviceCredentials = &FakeServiceCredentials{}
 		mux.ServeHTTP(res, httptest.NewRequest("GET", "/databases", nil))
 		require.Equal(t, http.StatusInternalServerError, res.Code)
 		httpError := models.HttpError{}
@@ -58,7 +55,6 @@ func TestResourceHandler(t *testing.T) {
 		adx.settings = &models.DatasourceSettings{
 			ClusterURL: "some-baseurl",
 		}
-		adx.serviceCredentials = &FakeServiceCredentials{}
 		mux.ServeHTTP(res, httptest.NewRequest("GET", "/databases", nil))
 		require.Equal(t, http.StatusOK, res.Code)
 		tableResponse := models.TableResponse{}
@@ -106,15 +102,4 @@ func (c *workingClient) KustoRequest(url string, payload models.RequestPayload, 
 			},
 		},
 	}, nil
-}
-
-type FakeServiceCredentials struct {
-}
-
-func (c *FakeServiceCredentials) ServicePrincipalAuthorization(ctx context.Context) (string, error) {
-	return "Bearer test-token", nil
-}
-
-func (c *FakeServiceCredentials) QueryDataAuthorization(ctx context.Context, req *backend.QueryDataRequest) (string, error) {
-	return c.ServicePrincipalAuthorization(ctx)
 }

--- a/pkg/azuredx/resource_handler_test.go
+++ b/pkg/azuredx/resource_handler_test.go
@@ -1,6 +1,7 @@
 package azuredx
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"net/http"
@@ -68,21 +69,21 @@ func TestResourceHandler(t *testing.T) {
 
 type failingClient struct{}
 
-func (c *failingClient) TestRequest(datasourceSettings *models.DatasourceSettings, properties *models.Properties, additionalHeaders map[string]string) error {
+func (c *failingClient) TestRequest(_ context.Context, _ *models.DatasourceSettings, _ *models.Properties, _ map[string]string) error {
 	panic("not implemented")
 }
 
-func (c *failingClient) KustoRequest(url string, payload models.RequestPayload, additionalHeaders map[string]string) (*models.TableResponse, error) {
+func (c *failingClient) KustoRequest(_ context.Context, _ string, _ models.RequestPayload, _ map[string]string) (*models.TableResponse, error) {
 	return nil, fmt.Errorf("HTTP error: %v - %v", http.StatusBadRequest, "")
 }
 
 type workingClient struct{}
 
-func (c *workingClient) TestRequest(datasourceSettings *models.DatasourceSettings, properties *models.Properties, additionalHeaders map[string]string) error {
+func (c *workingClient) TestRequest(_ context.Context, _ *models.DatasourceSettings, _ *models.Properties, _ map[string]string) error {
 	panic("not implemented")
 }
 
-func (c *workingClient) KustoRequest(url string, payload models.RequestPayload, additionalHeaders map[string]string) (*models.TableResponse, error) {
+func (c *workingClient) KustoRequest(_ context.Context, _ string, _ models.RequestPayload, _ map[string]string) (*models.TableResponse, error) {
 	return &models.TableResponse{
 		Tables: []models.Table{
 			{


### PR DESCRIPTION
The final goal is to completely separate authentication logic from the business layer. The token request logic should not live  alongside with normal query code. This will allow to abstract out authentication from the core plugin implementation and eventually move authentication to the Grafana Azure SDK.

This is intermediate PR which introduces `CurrentUserContext` context abstraction which is supposed to carry current user identity though context down to the transport layer.

ADX client extracts the `CurrentUserContext` and uses it for authentication regardless of where the context was originated.

Helper methods `adxusercontext.FromQueryReq` and `adxusercontext.FromResourceReq` provided to create user context for query ([here](https://github.com/grafana/azure-data-explorer-datasource/blob/09ce9e1aa33cee133f80ae40d9eee4915c39d1a1/pkg/azuredx/datasource.go#L90)) and resource ([here](https://github.com/grafana/azure-data-explorer-datasource/blob/09ce9e1aa33cee133f80ae40d9eee4915c39d1a1/pkg/azuredx/datasource.go#L103)) requests. After the context was created, it can be passed to the rest of the business logic, down to ADX client without having to have any handling of access token or authorization header.

### Problem with heath check

Due to current design of Plugin SDK, `CheckHealth` doesn't carry ID token (see [here](https://github.com/grafana/azure-data-explorer-datasource/blob/09ce9e1aa33cee133f80ae40d9eee4915c39d1a1/pkg/azuredx/adxauth/adxusercontext/from_req.go#L52)), so this PR has a workaround specifically for `TestRequest` to use service identity via `GetServiceAccessToken(ctx)` for datasource testing ([here](https://github.com/grafana/azure-data-explorer-datasource/blob/09ce9e1aa33cee133f80ae40d9eee4915c39d1a1/pkg/azuredx/client/client.go#L46)), rather than using the proper user identity.

This is incorrect behavior which already existed before this PR. This PR just isolated it to `CheckHealth`/`TestRequest` so the issue becomes more straightforward to address.

* #509
* https://github.com/grafana/grafana-plugin-sdk-go/issues/579
