### PR TITLE
Fix: Query that return exceptions

### DIFF
--- a/pkg/azuredx/models/table_test.go
+++ b/pkg/azuredx/models/table_test.go
@@ -94,6 +94,12 @@ func TestResponseToFrames(t *testing.T) {
 			}
 		})
 	}
+
+	t.Run("query with exceptions", func(t *testing.T) {
+		_, err := tableFromJSONFile("query_with_exceptions.json")
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "Query execution lacks memory resources")
+	})
 }
 
 func TestTableResponse_ToADXTimeSeries(t *testing.T) {

--- a/pkg/azuredx/models/testdata/query_with_exceptions.json
+++ b/pkg/azuredx/models/testdata/query_with_exceptions.json
@@ -1,0 +1,24 @@
+{
+  "Tables": [
+    {
+      "TableName": "Table_0",
+      "Columns": [
+        {
+          "ColumnName": "avg_string_size_numArr",
+          "DataType": "Double",
+          "ColumnType": "real"
+        }
+      ],
+      "Rows": [
+        {
+          "Exceptions": [
+            "Query execution lacks memory resources to complete (80DA0007): Partial query failure: Low memory condition (E_LOW_MEMORY_CONDITION)"
+          ]
+        }
+      ]
+    }
+  ],
+  "Exceptions": [
+    "Query execution lacks memory resources to complete (80DA0007): Partial query failure: Low memory condition (E_LOW_MEMORY_CONDITION)"
+  ]
+}

--- a/pkg/azuredx/resource_handler_test.go
+++ b/pkg/azuredx/resource_handler_test.go
@@ -87,6 +87,7 @@ func (c *workingClient) TestRequest(datasourceSettings *models.DatasourceSetting
 }
 
 func (c *workingClient) KustoRequest(url string, payload models.RequestPayload, additionalHeaders map[string]string) (*models.TableResponse, error) {
+
 	return &models.TableResponse{
 		Tables: []models.Table{
 			{
@@ -96,12 +97,8 @@ func (c *workingClient) KustoRequest(url string, payload models.RequestPayload, 
 					{ColumnName: "col2"},
 				},
 				Rows: []models.Row{
-					{
-						"val1",
-					},
-					{
-						"val2",
-					},
+					"val1",
+					"val2",
 				},
 			},
 		},


### PR DESCRIPTION
<!-- To surface this PR in the changelog add the label: changelog -->
<!-- If this PR is going in the changelog please make sure the title of the PR explains the feature in a user-centric way: -->
<!-- Bad: fix state bug in hooks -->
<!-- Good: Fix crash when switching from Query Builder -->

If a query return some error, the current model does not represent the API response, which caused an error when parsing this response. This PR addresses that.

![Screenshot from 2022-12-19 17-25-45](https://user-images.githubusercontent.com/4025665/208473236-8de0d277-da37-4e35-bcc5-52a7bff75d17.png)


Fixes #508