### PR TITLE
Prepare v4.2.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Change Log
 
+## [4.2.0]
+
+This release enables a new query builder:
+
+- New feature: It's now possible to filter columns to query, improving the performance of queries.
+- The query preview includes syntax highlighting for Kusto.
+- The rest of components has been refactored to match the latest Grafana UI.
+
 ## [4.1.10]
 
 - Fix: Invalid code editor loaded for Grafana versions that don't follow semantic versioning by @aangelisc in https://github.com/grafana/azure-data-explorer-datasource/pull/506

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,9 +4,15 @@
 
 This release revamps the plugin query builder:
 
-- New feature: It's now possible to filter columns to query, improving the performance of queries.
+- New feature: It's now possible to filter columns within a query, improving the performance of queries.
 - The query preview includes syntax highlighting for Kusto.
-- The rest of components has been refactored to match the latest Grafana UI.
+- All other components have been refactored to match the latest Grafana UI.
+
+Apart from that, this release also includes:
+
+- Refactor: Authentication and configuration has been refactored to match other Azure plugins.
+- Fix: Health check for data sources configured with On-Behalf-Of authentication.
+- Fix: Alert queries that returns no data.
 
 ## [4.1.10]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## [4.2.0]
 
-This release enables a new query builder:
+This release revamps the plugin query builder:
 
 - New feature: It's now possible to filter columns to query, improving the performance of queries.
 - The query preview includes syntax highlighting for Kusto.

--- a/cypress/integration/smoke.spec.ts
+++ b/cypress/integration/smoke.spec.ts
@@ -73,7 +73,7 @@ e2e.scenario({
           queriesForm: () => {
             e2eSelectors.queryEditor.database.input().click({ force: true });
             cy.contains('PerfTest').click({ force: true });
-            e2eSelectors.queryEditor.editKQL.button().click({ force: true });
+            cy.contains('KQL').click({ force: true });
             // Wait for the schema to load
             cy.get('.Table', { timeout: 10000 });
             e2eSelectors.queryEditor.codeEditor

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "grafana-azure-data-explorer-datasource",
-  "version": "4.1.10",
+  "version": "4.2.0",
   "description": "Grafana data source for Azure Data Explorer",
   "scripts": {
     "build": "webpack -c ./.config/webpack/webpack.config.ts --env production",

--- a/src/components/QueryEditor/QueryHeader.tsx
+++ b/src/components/QueryEditor/QueryHeader.tsx
@@ -10,6 +10,7 @@ import { QueryEditorPropertyDefinition } from 'schema/types';
 import { useAsync } from 'react-use';
 import { databaseToDefinition } from 'schema/mapper';
 import { SelectableValue } from '@grafana/data';
+import { selectors } from 'test/selectors';
 
 export interface QueryEditorHeaderProps {
   datasource: AdxDataSource;
@@ -111,7 +112,13 @@ export const QueryHeader = (props: QueryEditorHeaderProps) => {
         }}
       />
       <FlexItem grow={1} />
-      <Button variant="primary" icon="play" size="sm" onClick={onRunQuery} aria-label="Run query">
+      <Button
+        variant="primary"
+        icon="play"
+        size="sm"
+        onClick={onRunQuery}
+        data-testid={selectors.components.queryEditor.runQuery.button}
+      >
         Run query
       </Button>
       <RadioButtonGroup

--- a/src/components/QueryEditor/QueryHeader.tsx
+++ b/src/components/QueryEditor/QueryHeader.tsx
@@ -94,6 +94,7 @@ export const QueryHeader = (props: QueryEditorHeaderProps) => {
       ></ConfirmModal>
       <InlineSelect
         label="Database"
+        aria-label="Database"
         options={databases}
         value={database}
         isLoading={schema.loading}
@@ -110,7 +111,7 @@ export const QueryHeader = (props: QueryEditorHeaderProps) => {
         }}
       />
       <FlexItem grow={1} />
-      <Button variant="primary" icon="play" size="sm" onClick={onRunQuery}>
+      <Button variant="primary" icon="play" size="sm" onClick={onRunQuery} aria-label="Run query">
         Run query
       </Button>
       <RadioButtonGroup

--- a/src/components/QueryEditor/index.tsx
+++ b/src/components/QueryEditor/index.tsx
@@ -9,5 +9,5 @@ import { AdxDataSourceOptions, KustoQuery } from 'types';
 type Props = QueryEditorProps<AdxDataSource, KustoQuery, AdxDataSourceOptions>;
 
 export const QueryEditor: React.FC<Props> = (props) => {
-  return config.featureToggles.adxNewEditor ? <NewQueryEditor {...props} /> : <LegacyQueryEditor {...props} />;
+  return config.featureToggles.adxLegacyEditor ? <LegacyQueryEditor {...props} /> : <NewQueryEditor {...props} />;
 };

--- a/src/test/selectors.ts
+++ b/src/test/selectors.ts
@@ -36,7 +36,7 @@ export const components = {
       input: 'Table',
     },
     runQuery: {
-      button: 'Run query',
+      button: 'data-testid run-query',
     },
   },
 };

--- a/src/test/selectors.ts
+++ b/src/test/selectors.ts
@@ -20,7 +20,7 @@ export const components = {
   },
   queryEditor: {
     editKQL: {
-      button: 'Edit KQL',
+      button: 'KQL',
     },
     codeEditorLegacy: {
       container: 'data-testid legacy-editor',
@@ -33,10 +33,10 @@ export const components = {
       input: 'Database',
     },
     tableFrom: {
-      input: 'From table',
+      input: 'Table',
     },
     runQuery: {
-      button: 'Run Query',
+      button: 'Run query',
     },
   },
 };


### PR DESCRIPTION
<!-- To surface this PR in the changelog add the label: changelog -->
<!-- If this PR is going in the changelog please make sure the title of the PR explains the feature in a user-centric way: -->
<!-- Bad: fix state bug in hooks -->
<!-- Good: Fix crash when switching from Query Builder -->

Closes #391

I am still leaving the legacy editor behind a feature flag to be able to rollback to the previous editor in case there is some unexpected bug.