### PR TITLE
Puts focus on field when a new field is added.

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,6 +20,9 @@
     "generate-release-notes": "PREV_TAG=$(git tag | tail -n 1) && gh api --method POST /repos/grafana/azure-data-explorer-datasource/releases/generate-notes -f tag_name=v${npm_package_version} -f target_commitish=main -f previous_tag_name=${PREV_TAG} | jq -r .body",
     "spellcheck": "cspell -c cspell.config.json \"**/*.{ts,tsx,js,go,md,mdx,yml,yaml,json,scss,css}\""
   },
+  "engines": {
+    "node": ">=16.0.0"
+  },
   "author": "Grafana Labs",
   "license": "Apache",
   "devDependencies": {
@@ -46,6 +49,7 @@
     "@typescript-eslint/parser": "^4.33.0",
     "chance": "^1.1.7",
     "copy-webpack-plugin": "^10.0.0",
+    "cspell": "6.13.3",
     "css-loader": "6.7.1",
     "cypress": "9.3.1",
     "eslint": "^7.32.0",
@@ -67,7 +71,6 @@
     "replace-in-file-webpack-plugin": "^1.0.6",
     "sass": "1.55.0",
     "sass-loader": "13.1.0",
-    "cspell": "6.13.3",
     "style-loader": "3.3.1",
     "swc-loader": "^0.1.15",
     "ts-node": "^10.5.0",
@@ -80,7 +83,7 @@
   "dependencies": {
     "@emotion/css": "^11.1.3",
     "@grafana/data": "9.2.1",
-    "@grafana/experimental": "0.0.2-canary.35",
+    "@grafana/experimental": "^1.1.0",
     "@grafana/runtime": "9.2.1",
     "@grafana/ui": "9.2.1",
     "debounce-promise": "^3.1.2",

--- a/src/components/ConfigEditor/DatabaseConfig.tsx
+++ b/src/components/ConfigEditor/DatabaseConfig.tsx
@@ -35,7 +35,7 @@ function formatMappingValue(mapping): string {
   }
 }
 
-const LABEL_WIDTH = 18;
+const LABEL_WIDTH = 19;
 
 function isFetchError(e: unknown): e is FetchError {
   return typeof e === 'object' && e !== null && 'status' in e && 'data' in e;

--- a/src/components/ConfigEditor/QueryConfig.tsx
+++ b/src/components/ConfigEditor/QueryConfig.tsx
@@ -18,7 +18,7 @@ const editorModeOptions: Array<{ value: EditorMode; label: string }> = [
   { value: EditorMode.Raw, label: 'Raw' },
 ];
 
-const LABEL_WIDTH = 20;
+const LABEL_WIDTH = 21;
 
 const QueryConfig: React.FC<QueryConfigProps> = ({ options, updateJsonData }) => {
   const { jsonData } = options;

--- a/src/components/ConfigEditor/TrackingConfig.tsx
+++ b/src/components/ConfigEditor/TrackingConfig.tsx
@@ -8,7 +8,7 @@ interface TrackingConfigProps
   updateJsonData: <T extends keyof AdxDataSourceOptions>(fieldName: T, value: AdxDataSourceOptions[T]) => void;
 }
 
-const LABEL_WIDTH = 27;
+const LABEL_WIDTH = 28;
 
 const TrackingConfig: React.FC<TrackingConfigProps> = ({ options, updateJsonData }) => {
   const { jsonData } = options;

--- a/src/components/LegacyQueryEditor/editor/expressions.ts
+++ b/src/components/LegacyQueryEditor/editor/expressions.ts
@@ -31,6 +31,7 @@ export interface QueryEditorReduceExpression extends QueryEditorExpression {
   property: QueryEditorProperty;
   reduce: QueryEditorProperty;
   parameters?: QueryEditorFunctionParameterExpression[];
+  focus?: boolean;
 }
 
 export interface QueryEditorReduceExpressionArray extends QueryEditorExpression {
@@ -40,6 +41,7 @@ export interface QueryEditorReduceExpressionArray extends QueryEditorExpression 
 export interface QueryEditorGroupByExpression extends QueryEditorExpression {
   property: QueryEditorProperty;
   interval?: QueryEditorProperty;
+  focus?: boolean;
 }
 
 export interface QueryEditorGroupByExpressionArray extends QueryEditorExpression {

--- a/src/components/QueryEditor/VisualQueryEditor/AggregateItem.tsx
+++ b/src/components/QueryEditor/VisualQueryEditor/AggregateItem.tsx
@@ -46,6 +46,7 @@ const AggregateItem: React.FC<AggregateItemProps> = (props) => {
     <InputGroup>
       <Select
         aria-label="function"
+        autoFocus={aggregate.focus}
         width="auto"
         value={aggregate.reduce?.name ? valueToDefinition(aggregate.reduce?.name) : null}
         options={Object.values(AggregateFunctions).map((f) => ({ label: f, value: f }))}
@@ -63,66 +64,70 @@ const AggregateItem: React.FC<AggregateItemProps> = (props) => {
           })
         }
       />
-      {aggregate.reduce?.name === AggregateFunctions.Percentile && (
-        <Select
-          aria-label="percentile"
-          options={range(0, 100, 5).map((n) => ({ label: n.toString(), value: n.toString() }))}
-          value={aggregate.parameters?.length ? aggregate.parameters[0].value : undefined}
-          width="auto"
-          allowCustomValue
-          onChange={(e) => {
-            e.value &&
-              onChange({
-                property: {
-                  name: aggregate.property?.name || '',
-                  type: aggregate.property?.type || QueryEditorPropertyType.String,
-                },
-                reduce: {
-                  name: aggregate.reduce?.name || '',
-                  type: aggregate.property?.type || QueryEditorPropertyType.Function,
-                },
-                parameters: [
-                  {
-                    type: QueryEditorExpressionType.FunctionParameter,
-                    fieldType: QueryEditorPropertyType.Number,
-                    value: e.value,
-                    name: 'percentileParam',
-                  },
-                ],
-                type: QueryEditorExpressionType.Reduce,
-              });
-          }}
-        />
-      )}
-      {aggregate.reduce?.name !== AggregateFunctions.Count && (
-        <>
-          <Label style={{ margin: '9px 9px 0 9px' }}>of</Label>
+      <>
+        {aggregate.reduce?.name === AggregateFunctions.Percentile && (
           <Select
-            aria-label="column"
-            width={'auto'}
-            value={aggregate.property?.name ? valueToDefinition(aggregate.property?.name) : null}
-            options={columnOptions}
+            aria-label="percentile"
+            options={range(0, 100, 5).map((n) => ({ label: n.toString(), value: n.toString() }))}
+            value={aggregate.parameters?.length ? aggregate.parameters[0].value : undefined}
+            width="auto"
             allowCustomValue
-            onChange={(e) =>
+            onChange={(e) => {
               e.value &&
-              onChange({
-                property: {
-                  name: e.value,
-                  type: toPropertyType(
-                    columns?.find((c) => c.Name === e.value)?.CslType || QueryEditorPropertyType.String
-                  ),
-                },
-                reduce: {
-                  name: aggregate.reduce?.name || '',
-                  type: aggregate.property?.type || QueryEditorPropertyType.Function,
-                },
-                parameters: aggregate.parameters,
-                type: QueryEditorExpressionType.Reduce,
-              })
-            }
+                onChange({
+                  property: {
+                    name: aggregate.property?.name || '',
+                    type: aggregate.property?.type || QueryEditorPropertyType.String,
+                  },
+                  reduce: {
+                    name: aggregate.reduce?.name || '',
+                    type: aggregate.property?.type || QueryEditorPropertyType.Function,
+                  },
+                  parameters: [
+                    {
+                      type: QueryEditorExpressionType.FunctionParameter,
+                      fieldType: QueryEditorPropertyType.Number,
+                      value: e.value,
+                      name: 'percentileParam',
+                    },
+                  ],
+                  type: QueryEditorExpressionType.Reduce,
+                });
+            }}
           />
-        </>
-      )}
+        )}
+      </>
+      <>
+        {aggregate.reduce?.name !== AggregateFunctions.Count && (
+          <>
+            <Label style={{ margin: '9px 9px 0 9px' }}>of</Label>
+            <Select
+              aria-label="column"
+              width={'auto'}
+              value={aggregate.property?.name ? valueToDefinition(aggregate.property?.name) : null}
+              options={columnOptions}
+              allowCustomValue
+              onChange={(e) =>
+                e.value &&
+                onChange({
+                  property: {
+                    name: e.value,
+                    type: toPropertyType(
+                      columns?.find((c) => c.Name === e.value)?.CslType || QueryEditorPropertyType.String
+                    ),
+                  },
+                  reduce: {
+                    name: aggregate.reduce?.name || '',
+                    type: aggregate.property?.type || QueryEditorPropertyType.Function,
+                  },
+                  parameters: aggregate.parameters,
+                  type: QueryEditorExpressionType.Reduce,
+                })
+              }
+            />
+          </>
+        )}
+      </>
       <AccessoryButton aria-label="remove" icon="times" variant="secondary" onClick={onDelete} />
     </InputGroup>
   );

--- a/src/components/QueryEditor/VisualQueryEditor/AggregateSection.test.tsx
+++ b/src/components/QueryEditor/VisualQueryEditor/AggregateSection.test.tsx
@@ -47,6 +47,7 @@ describe('AggregateSection', () => {
                 property: { name: 'foo', type: QueryEditorPropertyType.String },
                 reduce: { name: AggregateFunctions.Avg, type: QueryEditorPropertyType.String },
                 type: QueryEditorExpressionType.Reduce,
+                focus: false,
               },
             ],
             type: QueryEditorExpressionType.And,

--- a/src/components/QueryEditor/VisualQueryEditor/AggregateSection.tsx
+++ b/src/components/QueryEditor/VisualQueryEditor/AggregateSection.tsx
@@ -47,14 +47,17 @@ const AggregateSection: React.FC<AggregateSectionProps> = ({
   }, [currentTable, query.expression.from?.property.name]);
 
   const onChange = (newItems: Array<Partial<QueryEditorReduceExpression>>) => {
-    const cleaned = newItems.map(
-      (v): QueryEditorReduceExpression => ({
+    const cleaned = newItems.map((v): QueryEditorReduceExpression => {
+      const isNewItem = Object.keys(v).length === 0;
+
+      return {
         type: QueryEditorExpressionType.Reduce,
         property: v.property ?? { type: QueryEditorPropertyType.String, name: '' },
         reduce: v.reduce ?? { name: '', type: QueryEditorPropertyType.String },
         parameters: v.parameters,
-      })
-    );
+        focus: isNewItem,
+      };
+    });
     setAggregates(cleaned);
 
     // Only save valid and complete filters into the query state

--- a/src/components/QueryEditor/VisualQueryEditor/FilterItem.tsx
+++ b/src/components/QueryEditor/VisualQueryEditor/FilterItem.tsx
@@ -73,6 +73,7 @@ const FilterItem: React.FC<FilterItemProps> = (props) => {
     <InputGroup>
       <Select
         aria-label="column"
+        autoFocus={filter.focus}
         width="auto"
         value={filter.property?.name ? valueToDefinition(filter.property?.name) : null}
         options={columns ? columnsToDefinition(columns) : []}
@@ -121,7 +122,7 @@ const FilterItem: React.FC<FilterItemProps> = (props) => {
         />
       </div>
       <AccessoryButton aria-label="remove" icon="times" variant="secondary" onClick={onDelete} />
-      {Number(filter.index) < filtersLength - 1 ? <Label className={styles.orLabel}>OR</Label> : null}
+      <>{Number(filter.index) < filtersLength - 1 ? <Label className={styles.orLabel}>OR</Label> : null}</>
     </InputGroup>
   );
 };

--- a/src/components/QueryEditor/VisualQueryEditor/FilterSection.tsx
+++ b/src/components/QueryEditor/VisualQueryEditor/FilterSection.tsx
@@ -3,7 +3,7 @@ import { Button, Label, useStyles2 } from '@grafana/ui';
 import { EditorField, EditorFieldGroup, EditorRow } from '@grafana/experimental';
 import { QueryEditorExpressionType } from 'components/LegacyQueryEditor/editor/expressions';
 import { AdxDataSource } from 'datasource';
-import React from 'react';
+import React, { useState } from 'react';
 import { AdxColumnSchema, AdxDataSourceOptions, KustoQuery } from 'types';
 import KQLFilter from './KQLFilter';
 import { css } from '@emotion/css';
@@ -23,6 +23,7 @@ const FilterSection: React.FC<FilterSectionProps> = ({
   columns,
   templateVariableOptions,
 }) => {
+  const [focus, setFocus] = useState(false);
   const styles = useStyles2(getStyles);
 
   return (
@@ -37,6 +38,8 @@ const FilterSection: React.FC<FilterSectionProps> = ({
                     <div key={`filter${i}`}>
                       <KQLFilter
                         index={i}
+                        focusNewGroup={focus}
+                        setFocus={setFocus}
                         query={query}
                         onChange={onChange}
                         datasource={datasource}
@@ -67,6 +70,7 @@ const FilterSection: React.FC<FilterSectionProps> = ({
                       },
                     },
                   });
+                  setFocus(true);
                 }}
               >
                 Add group

--- a/src/components/QueryEditor/VisualQueryEditor/GroupByItem.tsx
+++ b/src/components/QueryEditor/VisualQueryEditor/GroupByItem.tsx
@@ -34,6 +34,7 @@ const GroupByItem: React.FC<GroupByItemProps> = (props) => {
       <Select
         aria-label="column"
         width={'auto'}
+        autoFocus={groupBy.focus}
         value={groupBy.property?.name ? valueToDefinition(groupBy.property?.name) : null}
         options={columnOptions}
         allowCustomValue
@@ -51,39 +52,41 @@ const GroupByItem: React.FC<GroupByItemProps> = (props) => {
             });
         }}
       />
-      {groupBy.property?.type === QueryEditorPropertyType.DateTime && (
-        <Select
-          width={'auto'}
-          aria-label="interval"
-          allowCustomValue
-          options={[
-            { label: 'auto', value: '$__timeInterval' },
-            { label: '1 minute', value: '1m' },
-            { label: '5 minutes', value: '5m' },
-            { label: '15 minutes', value: '15m' },
-            { label: '30 minutes', value: '30m' },
-            { label: '1 hour', value: '1h' },
-            { label: '6 hours', value: '6h' },
-            { label: '12 hours', value: '12h' },
-            { label: '1 day', value: '1d' },
-          ]}
-          value={groupBy.interval?.name}
-          onChange={(e) => {
-            e.value &&
-              onChange({
-                interval: {
-                  name: e.value,
-                  type: QueryEditorPropertyType.Interval,
-                },
-                property: groupBy.property ?? {
-                  name: '',
-                  type: QueryEditorPropertyType.String,
-                },
-                type: QueryEditorExpressionType.GroupBy,
-              });
-          }}
-        />
-      )}
+      <>
+        {groupBy.property?.type === QueryEditorPropertyType.DateTime && (
+          <Select
+            width={'auto'}
+            aria-label="interval"
+            allowCustomValue
+            options={[
+              { label: 'auto', value: '$__timeInterval' },
+              { label: '1 minute', value: '1m' },
+              { label: '5 minutes', value: '5m' },
+              { label: '15 minutes', value: '15m' },
+              { label: '30 minutes', value: '30m' },
+              { label: '1 hour', value: '1h' },
+              { label: '6 hours', value: '6h' },
+              { label: '12 hours', value: '12h' },
+              { label: '1 day', value: '1d' },
+            ]}
+            value={groupBy.interval?.name}
+            onChange={(e) => {
+              e.value &&
+                onChange({
+                  interval: {
+                    name: e.value,
+                    type: QueryEditorPropertyType.Interval,
+                  },
+                  property: groupBy.property ?? {
+                    name: '',
+                    type: QueryEditorPropertyType.String,
+                  },
+                  type: QueryEditorExpressionType.GroupBy,
+                });
+            }}
+          />
+        )}
+      </>
       <AccessoryButton aria-label="remove" icon="times" variant="secondary" onClick={onDelete} />
     </InputGroup>
   );

--- a/src/components/QueryEditor/VisualQueryEditor/GroupBySection.test.tsx
+++ b/src/components/QueryEditor/VisualQueryEditor/GroupBySection.test.tsx
@@ -33,6 +33,7 @@ describe('GroupBySection', () => {
               {
                 property: { name: 'foo', type: QueryEditorPropertyType.String },
                 type: QueryEditorExpressionType.GroupBy,
+                focus: false,
               },
             ],
             type: QueryEditorExpressionType.And,

--- a/src/components/QueryEditor/VisualQueryEditor/GroupBySection.tsx
+++ b/src/components/QueryEditor/VisualQueryEditor/GroupBySection.tsx
@@ -47,13 +47,16 @@ const GroupBySection: React.FC<GroupBySectionProps> = ({
   }, [currentTable, query.expression.from?.property.name]);
 
   const onChange = (newItems: Array<Partial<QueryEditorGroupByExpression>>) => {
-    const cleaned = newItems.map(
-      (v): QueryEditorGroupByExpression => ({
+    const cleaned = newItems.map((v): QueryEditorGroupByExpression => {
+      const isNewItem = Object.keys(v).length === 0;
+
+      return {
         type: QueryEditorExpressionType.GroupBy,
         property: v.property ?? { type: QueryEditorPropertyType.String, name: '' },
         interval: v.interval,
-      })
-    );
+        focus: isNewItem,
+      };
+    });
     setGroupBys(cleaned);
 
     // Only save valid and complete filters into the query state

--- a/src/components/QueryEditor/VisualQueryEditor/Timeshift.tsx
+++ b/src/components/QueryEditor/VisualQueryEditor/Timeshift.tsx
@@ -46,42 +46,47 @@ const Timeshift: React.FC<TimeshiftProps> = (props) => {
               type="button"
               hidden={displaySelect}
             />
-            <div hidden={!displaySelect}>
-              <Select
-                width={'auto'}
-                aria-label="timeshift"
-                allowCustomValue
-                options={[
-                  {
-                    label: 'No timeshift',
-                    value: '',
-                  },
-                  {
-                    label: 'Hour before',
-                    value: '1h',
-                  },
-                  {
-                    label: 'Day before',
-                    value: '1d',
-                  },
-                  {
-                    label: 'Week before',
-                    value: '7d',
-                  },
-                ]}
-                value={query.expression.timeshift?.property?.name || ''}
-                onChange={(e) => onChangeValue(e.value)}
-              />
-              <AccessoryButton
-                aria-label="remove"
-                icon="times"
-                variant="secondary"
-                onClick={() => {
-                  onChangeValue();
-                  setDisplaySelect(false);
-                }}
-              />
-            </div>
+            <>
+              {displaySelect && (
+                <>
+                  <Select
+                    width={'auto'}
+                    aria-label="timeshift"
+                    autoFocus={displaySelect}
+                    allowCustomValue
+                    options={[
+                      {
+                        label: 'No timeshift',
+                        value: '',
+                      },
+                      {
+                        label: 'Hour before',
+                        value: '1h',
+                      },
+                      {
+                        label: 'Day before',
+                        value: '1d',
+                      },
+                      {
+                        label: 'Week before',
+                        value: '7d',
+                      },
+                    ]}
+                    value={query.expression.timeshift?.property?.name || ''}
+                    onChange={(e) => onChangeValue(e.value)}
+                  />
+                  <AccessoryButton
+                    aria-label="remove"
+                    icon="times"
+                    variant="secondary"
+                    onClick={() => {
+                      onChangeValue();
+                      setDisplaySelect(false);
+                    }}
+                  />
+                </>
+              )}
+            </>
           </InputGroup>
         </EditorField>
       </EditorFieldGroup>

--- a/yarn.lock
+++ b/yarn.lock
@@ -1620,10 +1620,10 @@
     prettier "2.5.1"
     typescript "4.4.4"
 
-"@grafana/experimental@0.0.2-canary.35":
-  version "0.0.2-canary.35"
-  resolved "https://registry.yarnpkg.com/@grafana/experimental/-/experimental-0.0.2-canary.35.tgz#b1d9e0759f4b8a718cef59cd1e321cfd098cd48c"
-  integrity sha512-afD9RdcMXjmA1f82XyhOn4lrrmuAETqvJcLV7cyZrKplqQl94Ma12BVHK7I153avCxAXjwbFLX135KNU6OkW1Q==
+"@grafana/experimental@^1.1.0":
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/@grafana/experimental/-/experimental-1.1.0.tgz#36b9644b1e61c782ed42b4805c5e297f2cc3f8bf"
+  integrity sha512-pQhYhw+jB7Q+t8rLcd1jcx91BiFDNslBATJkNIgO9I2Bah+ww+2RH1hUGVoJNPL84vW7WRU7w9k/L7FJs7/L6Q==
   dependencies:
     "@types/uuid" "^8.3.3"
     uuid "^8.3.2"


### PR DESCRIPTION
![Peek 2023-01-19 10-08](https://user-images.githubusercontent.com/1048831/213478399-6110c682-26f9-4707-8476-b752e1ece90a.gif)

**To test**
1. Load up ADX
2. Select the correct database
3. Navigate from that dropdown to the Builder via `TAB` on your keyboard.
4. You should be able to add filter groups and and other clauses via `TAB` and `Enter` or `Space`. The `focus` should move to the logically correct place after taking an action.

**Other changes**
- Fixes various eslint issues. We might want to revisit how [`@grafana/experimental` defines `Children`](https://github.com/grafana/grafana-experimental/blob/2ce409b4c94f68f4789b30430d01d6f77c56ccc0/src/QueryEditor/InputGroup.tsx#L5) to avoid the `Fragment` usage here?
- I also could see a desire to separate "ui" properties from data properties in our types, e.g. `focus` being added to `QueryEditorReduceExpressionArray`.
- Updates grafana/experimental version

Ref #486
