### PR TITLE
User identity authentication in configuration UI

### DIFF
--- a/cspell.config.json
+++ b/cspell.config.json
@@ -18,6 +18,7 @@
     "azhttpclient",
     "azusercontext",
     "clientsecret",
+    "currentuser",
     "Codeowners",
     "datasource",
     "datetime",

--- a/doc/current-user-auth.md
+++ b/doc/current-user-auth.md
@@ -1,0 +1,57 @@
+# Current User Authorization
+
+**Note**: The feature is experimental, which means it may not work as expected and breaking changes may be introduced
+in the future.
+
+⚠️ Only compatible with Grafana 10.0 or above.
+
+## Prerequisites
+
+Current User Authorization only can work together with Azure AD Grafana authentication.
+
+## Configuration
+
+Assuming that Azure AD authentication has been already configured, for example:
+
+```ini
+[auth.azuread]
+enabled = true
+
+auth_url = https://login.microsoftonline.com/fd719c11-a91c-40fd-8379-1e6cd3c59568//oauth2/v2.0/authorize
+token_url = https://login.microsoftonline.com/fd719c11-a91c-40fd-8379-1e6cd3c59568/oauth2/v2.0/token
+client_id = f85aa887-490d-4fac-9306-9b99ad0aa31d
+client_secret = 87808761-ff7b-492e-bb0d-5de2437ffa55
+```
+
+Current User authentication can be enabled in the `[azure]` section of the Grafana config:
+
+```ini
+[azure]
+user_identity_enabled = true
+```
+
+Optionally, it's possible to provide another AAD app for token exchange (On-Behalf-Of token request):
+
+```ini
+[azure]
+user_identity_enabled = true
+
+# Use different AAD app (OBO)
+user_identity_client_id = 4fc34037-97bd-4e84-9db4-86238c78e32a
+user_identity_client_secret = 4479f5a6-444c-4271-8790-60eeb42225ae
+```
+
+Also, it's possible to customize the token endpoint:
+
+```ini
+[azure]
+user_identity_enabled = true
+
+user_identity_token_url = https://custom-token-endpoint/oauth2/v2.0/token
+user_identity_client_id = 4fc34037-97bd-4e84-9db4-86238c78e32a
+user_identity_client_secret = 4479f5a6-444c-4271-8790-60eeb42225ae
+```
+
+## See also
+
+- [User identity authentication in Azure Data Explorer and other Azure datasources](https://github.com/grafana/grafana/discussions/62994)

--- a/doc/current-user-auth.md
+++ b/doc/current-user-auth.md
@@ -1,6 +1,6 @@
 # Current User Authorization
 
-**Note**: The feature is experimental, which means it may not work as expected and breaking changes may be introduced
+**Note**: The feature is experimental, which means it may not work as expected, it may cause Grafana to behave in an unexpected way, and breaking changes may be introduced
 in the future.
 
 ⚠️ Only compatible with Grafana 10.0 or above.

--- a/src/components/ConfigEditor/AzureCredentials.ts
+++ b/src/components/ConfigEditor/AzureCredentials.ts
@@ -12,12 +12,16 @@ export const KnownAzureClouds = [
   { value: AzureCloud.USGovernment, label: 'Azure US Government' },
 ] as SelectableValue[];
 
-export type AzureAuthType = 'msi' | 'clientsecret' | 'clientsecret-obo';
+export type AzureAuthType = 'currentuser' | 'msi' | 'clientsecret' | 'clientsecret-obo';
 
 export type ConcealedSecret = symbol;
 
 interface AzureCredentialsBase {
   authType: AzureAuthType;
+}
+
+interface AadCurrentUserCredentials extends AzureCredentialsBase {
+  authType: 'currentuser';
 }
 
 export interface AzureManagedIdentityCredentials extends AzureCredentialsBase {
@@ -41,12 +45,14 @@ interface AzureClientSecretOboCredentials extends AzureCredentialsBase {
 }
 
 export type AzureCredentials =
+  | AadCurrentUserCredentials
   | AzureManagedIdentityCredentials
   | AzureClientSecretCredentials
   | AzureClientSecretOboCredentials;
 
 export function isCredentialsComplete(credentials: AzureCredentials): boolean {
   switch (credentials.authType) {
+    case 'currentuser':
     case 'msi':
       return true;
     case 'clientsecret':

--- a/src/components/ConfigEditor/AzureCredentialsForm.tsx
+++ b/src/components/ConfigEditor/AzureCredentialsForm.tsx
@@ -7,6 +7,7 @@ import { AzureAuthType, AzureCredentials } from './AzureCredentials';
 import { selectors } from 'test/selectors';
 
 export interface Props {
+  userIdentityEnabled: boolean;
   managedIdentityEnabled: boolean;
   oboEnabled: boolean;
   credentials: AzureCredentials;
@@ -32,6 +33,13 @@ export const AzureCredentialsForm: FunctionComponent<Props> = (props: Props) => 
       });
     }
 
+    if (props.userIdentityEnabled) {
+      opts.unshift({
+        value: 'currentuser',
+        label: 'Current User',
+      });
+    }
+
     if (props.oboEnabled) {
       opts.push({
         value: 'clientsecret-obo',
@@ -40,7 +48,7 @@ export const AzureCredentialsForm: FunctionComponent<Props> = (props: Props) => 
     }
 
     return opts;
-  }, [props.managedIdentityEnabled, props.oboEnabled]);
+  }, [props.userIdentityEnabled, props.managedIdentityEnabled, props.oboEnabled]);
 
   const onAuthTypeChange = (selected: SelectableValue<AzureAuthType>) => {
     if (onCredentialsChange) {

--- a/src/components/ConfigEditor/AzureCredentialsForm.tsx
+++ b/src/components/ConfigEditor/AzureCredentialsForm.tsx
@@ -146,7 +146,8 @@ export const AzureCredentialsForm: FunctionComponent<Props> = (props: Props) => 
       {credentials.authType === 'currentuser' && (
         <>
           <Alert title="Current user authentication is experimental" severity="warning">
-            Certain Grafana features (e.g. alerting) may not work as expected. For other known limitations and issues, bug reports, or feedback, please visit{' '}
+            Certain Grafana features (e.g. alerting) may not work as expected. For other known limitations and issues,
+            bug reports, or feedback, please visit{' '}
             <a
               href="https://github.com/grafana/azure-data-explorer-datasource/blob/main/doc/current-user-auth.md"
               target="_blank"

--- a/src/components/ConfigEditor/AzureCredentialsForm.tsx
+++ b/src/components/ConfigEditor/AzureCredentialsForm.tsx
@@ -143,6 +143,21 @@ export const AzureCredentialsForm: FunctionComponent<Props> = (props: Props) => 
           />
         </InlineField>
       )}
+      {credentials.authType === 'currentuser' && (
+        <>
+          <Alert title="Current user authentication is experimental" severity="warning">
+            For known limitations and issues, bug report, or feedback, please visit{' '}
+            <a
+              href="https://github.com/grafana/azure-data-explorer-datasource/blob/main/doc/current-user-auth.md"
+              target="_blank"
+              rel="noreferrer"
+            >
+              the documentation
+            </a>
+            .
+          </Alert>
+        </>
+      )}
       {credentials.authType === 'clientsecret-obo' && (
         <>
           <Alert title="On-Behalf-Of feature is in beta" severity="warning">

--- a/src/components/ConfigEditor/AzureCredentialsForm.tsx
+++ b/src/components/ConfigEditor/AzureCredentialsForm.tsx
@@ -146,7 +146,7 @@ export const AzureCredentialsForm: FunctionComponent<Props> = (props: Props) => 
       {credentials.authType === 'currentuser' && (
         <>
           <Alert title="Current user authentication is experimental" severity="warning">
-            For known limitations and issues, bug report, or feedback, please visit{' '}
+            Certain Grafana features (e.g. alerting) may not work as expected. For other known limitations and issues, bug reports, or feedback, please visit{' '}
             <a
               href="https://github.com/grafana/azure-data-explorer-datasource/blob/main/doc/current-user-auth.md"
               target="_blank"

--- a/src/components/ConfigEditor/index.tsx
+++ b/src/components/ConfigEditor/index.tsx
@@ -8,7 +8,7 @@ import DatabaseConfig from './DatabaseConfig';
 import QueryConfig from './QueryConfig';
 import TrackingConfig from './TrackingConfig';
 import { AzureCredentials, KnownAzureClouds } from './AzureCredentials';
-import { getCredentials, getOboEnabled, updateCredentials } from './AzureCredentialsConfig';
+import { getCredentials, getUserIdentityEnabled, getOboEnabled, updateCredentials } from './AzureCredentialsConfig';
 import AzureCredentialsForm from './AzureCredentialsForm';
 
 export interface ConfigEditorProps
@@ -45,6 +45,7 @@ const ConfigEditor: React.FC<ConfigEditorProps> = (props) => {
 
       <h3 className="page-heading">Authentication</h3>
       <AzureCredentialsForm
+        userIdentityEnabled={getUserIdentityEnabled()}
         managedIdentityEnabled={config.azure.managedIdentityEnabled}
         oboEnabled={getOboEnabled()}
         credentials={credentials}


### PR DESCRIPTION
This PR adds "Current User" as an authentication option for the datasource.

<img width="75%" alt="Current User authentication" src="https://github.com/grafana/azure-data-explorer-datasource/assets/1131253/1c84cbd4-ff90-4661-8549-4a48a25fcba3">

The option is available to the user only if user identity authentication was enabled in Grafana config (see https://github.com/grafana/grafana/pull/50277). It can be enabled as default via feature flag `adxUserIdentityPreferred `.

Fixes #381