### PR TITLE
Add OpenAI integration

### DIFF
--- a/cspell.config.json
+++ b/cspell.config.json
@@ -160,6 +160,9 @@
     "retrievebytes",
     "pascaldekloe",
     "xorcare",
+    "openai",
+    "AIAPI",
+    "AIURL",
     ""
   ]
 }

--- a/pkg/azuredx/datasource.go
+++ b/pkg/azuredx/datasource.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"math/rand"
 	"net/http"
+	"strings"
 
 	"github.com/grafana/azure-data-explorer-datasource/pkg/azuredx/adxauth/adxcredentials"
 	"github.com/grafana/grafana-azure-sdk-go/azsettings"
@@ -43,6 +44,7 @@ func NewDatasource(instanceSettings backend.DataSourceInstanceSettings) (instanc
 		return nil, err
 	}
 	adx.settings = datasourceSettings
+	adx.settings.OpenAIAPIKey = strings.TrimSpace(instanceSettings.DecryptedSecureJSONData["OpenAIAPIKey"])
 
 	azureSettings, err := azsettings.ReadFromEnv()
 	if err != nil {

--- a/pkg/azuredx/models/settings.go
+++ b/pkg/azuredx/models/settings.go
@@ -28,6 +28,7 @@ type DatasourceSettings struct {
 	// ServerTimeoutValue is the QueryTimeout formatted as a MS Timespan
 	// which is used as a connection property option.
 	ServerTimeoutValue string `json:"-"`
+	OpenAIAPIKey       string
 }
 
 // newDataSourceData creates a dataSourceData from the plugin API's DatasourceInfo's

--- a/pkg/azuredx/resource_handler.go
+++ b/pkg/azuredx/resource_handler.go
@@ -1,7 +1,9 @@
 package azuredx
 
 import (
+	"bytes"
 	"encoding/json"
+	"io"
 	"net/http"
 
 	"github.com/grafana/azure-data-explorer-datasource/pkg/azuredx/models"
@@ -10,9 +12,89 @@ import (
 func (adx *AzureDataExplorer) registerRoutes(mux *http.ServeMux) {
 	mux.HandleFunc("/databases", adx.getDatabases)
 	mux.HandleFunc("/schema", adx.getSchema)
+	mux.HandleFunc("/generateQuery", adx.generateQuery)
 }
 
 const ManagementApiPath = "/v1/rest/mgmt"
+
+const (
+	OpenAIURL   = "https://api.openai.com/v1/chat/completions"
+	OpenAIModel = "gpt-3.5-turbo"
+)
+
+type openaiBody struct {
+	Model    string          `json:"model"`
+	Messages []openaiMessage `json:"messages"`
+}
+
+type openaiMessage struct {
+	Role    string `json:"role"`
+	Content string `json:"content"`
+}
+
+type openaiResponse struct {
+	Choices []openaiChoice `json:"choices"`
+}
+
+type openaiChoice struct {
+	Message struct {
+		Content string
+	}
+}
+
+func (adx *AzureDataExplorer) generateQuery(rw http.ResponseWriter, req *http.Request) {
+	client := &http.Client{}
+	if req.Method != "POST" {
+		respondWithError(rw, http.StatusMethodNotAllowed, "Invalid HTTP method", nil)
+		return
+	}
+
+	body, _ := io.ReadAll(req.Body)
+
+	reqBody := openaiBody{
+		Model: OpenAIModel,
+		Messages: []openaiMessage{
+			{
+				Role:    "user",
+				Content: string(body),
+			},
+		},
+	}
+
+	jsonReq, err := json.Marshal(reqBody)
+	if err != nil {
+		respondWithError(rw, http.StatusInternalServerError, "Error reading JSON reqBody", err)
+		return
+	}
+
+	request, err := http.NewRequest(http.MethodPost, OpenAIURL, bytes.NewReader(jsonReq))
+	if err != nil {
+		respondWithError(rw, http.StatusInternalServerError, "Error creating HTTP request", err)
+		return
+	}
+	request.Header.Set("Accept", "application/json")
+	request.Header.Set("Content-Type", "application/json")
+	request.Header.Set("Authorization", "Bearer "+adx.settings.OpenAIAPIKey)
+	resp, err := client.Do(request)
+	if err != nil {
+		respondWithError(rw, http.StatusInternalServerError, "Error during query generation", err)
+		return
+	}
+	defer resp.Body.Close()
+
+	var content openaiResponse
+	body, _ = io.ReadAll(resp.Body)
+	err = json.Unmarshal(body, &content)
+	if err != nil {
+		respondWithError(rw, http.StatusInternalServerError, "Error parsing generated query", err)
+		return
+	}
+	err = json.NewEncoder(rw).Encode(content)
+	if err != nil {
+		respondWithError(rw, http.StatusInternalServerError, "Error returning generated query", err)
+		return
+	}
+}
 
 func (adx *AzureDataExplorer) getSchema(rw http.ResponseWriter, req *http.Request) {
 	if req.Method != "GET" {

--- a/pkg/azuredx/resource_handler_test.go
+++ b/pkg/azuredx/resource_handler_test.go
@@ -32,6 +32,9 @@ func TestResourceHandler(t *testing.T) {
 
 		mux.ServeHTTP(res, httptest.NewRequest("PUT", "/schema", nil))
 		require.Equal(t, http.StatusMethodNotAllowed, res.Code)
+
+		mux.ServeHTTP(res, httptest.NewRequest("PUT", "/generateQuery", nil))
+		require.Equal(t, http.StatusMethodNotAllowed, res.Code)
 	})
 
 	t.Run("When kust request fails route should return an error", func(t *testing.T) {

--- a/src/components/ConfigEditor/OpenAIConfig.tsx
+++ b/src/components/ConfigEditor/OpenAIConfig.tsx
@@ -1,0 +1,60 @@
+import React, { ChangeEvent } from 'react';
+import { DataSourcePluginOptionsEditorProps } from '@grafana/data';
+import { Button, FieldSet, Input, InlineField, InlineFieldRow } from '@grafana/ui';
+import { AdxDataSourceOptions, AdxDataSourceSecureOptions } from 'types';
+
+interface Props extends DataSourcePluginOptionsEditorProps<AdxDataSourceOptions, AdxDataSourceSecureOptions> {
+  updateJsonData: <T extends keyof AdxDataSourceOptions>(fieldName: T, value: AdxDataSourceOptions[T]) => void;
+}
+
+export function OpenAIConfig(props: Props) {
+  const { options, onOptionsChange } = props;
+  const { secureJsonData, secureJsonFields } = options;
+
+  const onAPIKeyChange = (event: ChangeEvent<HTMLInputElement>) => {
+    onOptionsChange({
+      ...options,
+      secureJsonData: {
+        OpenAIAPIKey: event.target.value,
+      },
+    });
+  };
+
+  const onResetAPIKey = () => {
+    onOptionsChange({
+      ...options,
+      secureJsonFields: {
+        ...options.secureJsonFields,
+        apiKey: false,
+      },
+      secureJsonData: {
+        ...options.secureJsonData,
+        OpenAIAPIKey: '',
+      },
+    });
+  };
+
+  return (
+    <FieldSet label="OpenAI API Key" className="gf-form-group">
+      <InlineFieldRow>
+        <InlineField label="OpenAI API Key" labelWidth={18} htmlFor="openai-api-key">
+          <Input
+            id="openai-api-key"
+            aria-label="OpenAI API Key"
+            placeholder={secureJsonFields?.OpenAIAPIKey ? 'configured' : ''}
+            value={secureJsonData?.OpenAIAPIKey ?? ''}
+            onChange={onAPIKeyChange}
+            data-testid={'openai-api-key'}
+          />
+        </InlineField>
+        <InlineField>
+          <Button variant="secondary" type="button" onClick={onResetAPIKey}>
+            Reset
+          </Button>
+        </InlineField>
+      </InlineFieldRow>
+    </FieldSet>
+  );
+}
+
+export default OpenAIConfig;

--- a/src/components/ConfigEditor/index.tsx
+++ b/src/components/ConfigEditor/index.tsx
@@ -3,6 +3,7 @@ import { DataSourcePluginOptionsEditorProps } from '@grafana/data';
 import { config } from '@grafana/runtime';
 import ConfigHelp from './ConfigHelp';
 import { AdxDataSourceOptions, AdxDataSourceSecureOptions, AdxDataSourceSettings } from 'types';
+import OpenAIConfig from './OpenAIConfig';
 import ConnectionConfig from './ConnectionConfig';
 import DatabaseConfig from './DatabaseConfig';
 import QueryConfig from './QueryConfig';
@@ -79,6 +80,8 @@ const ConfigEditor: React.FC<ConfigEditorProps> = (props) => {
       <DatabaseConfig options={options} onOptionsChange={onOptionsChange} updateJsonData={updateJsonData} />
 
       <TrackingConfig options={options} onOptionsChange={onOptionsChange} updateJsonData={updateJsonData} />
+
+      <OpenAIConfig options={options} updateJsonData={updateJsonData} onOptionsChange={onOptionsChange} />
     </div>
   );
 };

--- a/src/components/QueryEditor/OpenAIEditor.test.tsx
+++ b/src/components/QueryEditor/OpenAIEditor.test.tsx
@@ -1,0 +1,49 @@
+import { render, screen } from '@testing-library/react';
+import React from 'react';
+import { selectors } from 'test/selectors';
+
+import { mockDatasource, mockQuery } from '../__fixtures__/Datasource';
+import { OpenAIEditor } from './OpenAIEditor';
+
+jest.mock('../../monaco/KustoMonacoEditor', () => {
+  return {
+    KustoMonacoEditor: function C() {
+      return <></>;
+    },
+  };
+});
+
+jest.mock('@grafana/runtime', () => {
+  const original = jest.requireActual('@grafana/runtime');
+  return {
+    ...original,
+    getTemplateSrv: () => ({
+      getVariables: () => [],
+    }),
+    config: {
+      ...original.config,
+      buildInfo: {
+        ...original.config.buildInfo,
+        version: '8.1.0',
+      },
+    },
+  };
+});
+
+const defaultProps = {
+  database: 'default',
+  templateVariableOptions: {},
+  onChange: jest.fn(),
+  onRunQuery: jest.fn(),
+  datasource: mockDatasource(),
+  query: mockQuery,
+  schema: { Databases: {} },
+  setDirty: jest.fn(),
+};
+
+describe('OpenAIEditor', () => {
+  it('should render the OpenAI code editor', async () => {
+    render(<OpenAIEditor {...defaultProps} />);
+    expect(screen.getByTestId(selectors.components.queryEditor.codeEditor.openAI)).toBeInTheDocument();
+  });
+});

--- a/src/components/QueryEditor/OpenAIEditor.tsx
+++ b/src/components/QueryEditor/OpenAIEditor.tsx
@@ -43,7 +43,7 @@ export const OpenAIEditor: React.FC<RawQueryEditorProps> = (props) => {
   const [variables] = useState(getTemplateSrv().getVariables());
   const [stateSchema, setStateSchema] = useState(cloneDeep(schema));
   const styles = useStyles2(getStyles);
-  const baselinePrompt = `You are an AI assistant that is fluent in KQL for querying Azure Data Explorer and you only respond with the correct KQL code snippets and no explainations. Generate a query that fulfills the following text.\nText:"""`;
+  const baselinePrompt = `You are an AI assistant that is fluent in KQL for querying Azure Data Explorer and you only respond with the correct KQL code snippets and no explanations. Generate a query that fulfills the following text.\nText:"""`;
 
   const onRawQueryChange = (kql: string) => {
     if (kql !== props.query.query) {
@@ -118,7 +118,7 @@ export const OpenAIEditor: React.FC<RawQueryEditorProps> = (props) => {
         <Alert
           onRemove={() => setError(false)}
           severity="error"
-          title="An error occured generating your query, tweak your prompt and try again."
+          title="An error occurred generating your query, tweak your prompt and try again."
         />
       )}
       <div className={styles.outerMargin}>

--- a/src/components/QueryEditor/OpenAIEditor.tsx
+++ b/src/components/QueryEditor/OpenAIEditor.tsx
@@ -1,0 +1,165 @@
+import { GrafanaTheme2, QueryEditorProps, SelectableValue } from '@grafana/data';
+import { getTemplateSrv, reportInteraction } from '@grafana/runtime';
+import {
+  Alert,
+  Button,
+  CodeEditor,
+  Spinner,
+  Monaco,
+  MonacoEditor,
+  useStyles2,
+  TextArea,
+  HorizontalGroup,
+} from '@grafana/ui';
+import { AdxDataSource } from 'datasource';
+import React, { ChangeEvent, useEffect, useState } from 'react';
+import { selectors } from 'test/selectors';
+import { AdxDataSourceOptions, AdxSchema, KustoQuery } from 'types';
+import { cloneDeep } from 'lodash';
+import { css } from '@emotion/css';
+
+import { getFunctions, getSignatureHelp } from './Suggestions';
+
+type Props = QueryEditorProps<AdxDataSource, KustoQuery, AdxDataSourceOptions>;
+
+interface RawQueryEditorProps extends Props {
+  schema?: AdxSchema;
+  database: string;
+  templateVariableOptions: SelectableValue<string>;
+  setDirty: () => void;
+}
+
+interface Worker {
+  setSchemaFromShowSchema: (schema: AdxSchema, url: string, database: string) => void;
+}
+
+export const OpenAIEditor: React.FC<RawQueryEditorProps> = (props) => {
+  const { schema, datasource } = props;
+  const [worker, setWorker] = useState<Worker>();
+  const [prompt, setPrompt] = useState('');
+  const [isWaiting, setWaiting] = useState(false);
+  const [hasError, setError] = useState(false);
+  const [generatedQuery, setGeneratedQuery] = useState('//OpenAI generated query');
+  const [variables] = useState(getTemplateSrv().getVariables());
+  const [stateSchema, setStateSchema] = useState(cloneDeep(schema));
+  const styles = useStyles2(getStyles);
+  const baselinePrompt = `You are an AI assistant that is fluent in KQL for querying Azure Data Explorer and you only respond with the correct KQL code snippets and no explainations. Generate a query that fulfills the following text.\nText:"""`;
+
+  const onRawQueryChange = (kql: string) => {
+    if (kql !== props.query.query) {
+      props.setDirty();
+      props.onChange({
+        ...props.query,
+        query: kql,
+      });
+    }
+  };
+
+  useEffect(() => {
+    if (schema && !stateSchema) {
+      setStateSchema(cloneDeep(schema));
+    }
+  }, [schema, stateSchema]);
+
+  const generateQuery = () => {
+    setWaiting(true);
+    setError(false);
+    reportInteraction('grafana_ds_adx_openai_query_generated');
+    datasource
+      .generateQueryForOpenAI(`${baselinePrompt}${prompt}"""`)
+      .then((resp) => {
+        setWaiting(false);
+        setGeneratedQuery(resp);
+        onRawQueryChange(resp);
+      })
+      .catch((e) => {
+        setWaiting(false);
+        setError(true);
+      });
+  };
+
+  const onPromptChange = (event: ChangeEvent<HTMLTextAreaElement>) => {
+    setPrompt(event.target.value);
+  };
+
+  const handleEditorMount = (editor: MonacoEditor, monaco: Monaco) => {
+    monaco.languages.registerSignatureHelpProvider('kusto', {
+      signatureHelpTriggerCharacters: ['(', ')'],
+      provideSignatureHelp: getSignatureHelp,
+    });
+    monaco.languages['kusto']
+      .getKustoWorker()
+      .then((kusto) => {
+        const model = editor.getModel();
+        return model && kusto(model.uri);
+      })
+      .then((worker) => {
+        setWorker(worker);
+      });
+  };
+
+  useEffect(() => {
+    if (worker && stateSchema) {
+      // Populate Database schema with macros
+      Object.keys(stateSchema.Databases).forEach((db) =>
+        Object.assign(stateSchema.Databases[db].Functions, getFunctions(variables))
+      );
+      worker.setSchemaFromShowSchema(stateSchema, 'https://help.kusto.windows.net', props.database);
+    }
+  }, [worker, stateSchema, variables, props.database]);
+
+  if (!stateSchema) {
+    return null;
+  }
+
+  return (
+    <div>
+      {hasError && (
+        <Alert
+          onRemove={() => setError(false)}
+          severity="error"
+          title="An error occured generating your query, tweak your prompt and try again."
+        />
+      )}
+      <div className={styles.outerMargin}>
+        <HorizontalGroup justify="space-between">
+          <h5>Ask OpenAI to generate a KQL query</h5>
+          <Button onClick={generateQuery} variant={'secondary'} size={'sm'}>
+            {isWaiting && <Spinner inline={true} />} Generate query
+          </Button>
+        </HorizontalGroup>
+        <TextArea
+          data-testid={selectors.components.queryEditor.codeEditor.openAI}
+          value={prompt}
+          onChange={onPromptChange}
+          className={styles.innerMargin}
+        ></TextArea>
+      </div>
+      <div className={styles.innerMargin}>
+        <h5>Generated query</h5>
+        <div data-testid={selectors.components.queryEditor.codeEditor.container}>
+          <CodeEditor
+            language="kusto"
+            value={generatedQuery}
+            onBlur={onRawQueryChange}
+            showMiniMap={false}
+            showLineNumbers={true}
+            height="240px"
+            onEditorDidMount={handleEditorMount}
+          />
+        </div>
+      </div>
+    </div>
+  );
+};
+
+const getStyles = (theme: GrafanaTheme2) => {
+  return {
+    outerMargin: css({
+      marginTop: theme.spacing(1),
+    }),
+    innerMargin: css({
+      marginTop: theme.spacing(2),
+    }),
+  };
+};

--- a/src/components/QueryEditor/QueryEditor.tsx
+++ b/src/components/QueryEditor/QueryEditor.tsx
@@ -9,6 +9,7 @@ import { AdxDataSourceOptions, EditorMode, KustoQuery } from 'types';
 import { AdxDataSource } from '../../datasource';
 import { QueryHeader } from './QueryHeader';
 import { RawQueryEditor } from './RawQueryEditor';
+import { OpenAIEditor } from './OpenAIEditor';
 import { VisualQueryEditor } from './VisualQueryEditor';
 
 type Props = QueryEditorProps<AdxDataSource, KustoQuery, AdxDataSourceOptions>;
@@ -34,7 +35,6 @@ export const QueryEditor: React.FC<Props> = (props) => {
       onRunQuery();
     }
   });
-
   return (
     <>
       {schema.error && <Alert title="Could not load datasource schema">{parseSchemaError(schema.error)}</Alert>}
@@ -48,6 +48,16 @@ export const QueryEditor: React.FC<Props> = (props) => {
         onRunQuery={onRunQuery}
         templateVariableOptions={templateVariables}
       />
+      {query.OpenAI ? (
+        <OpenAIEditor
+          {...props}
+          schema={schema.value}
+          database={query.database}
+          datasource={datasource}
+          templateVariableOptions={templateVariables}
+          setDirty={() => !dirty && setDirty(true)}
+        />
+      ) : null}
       {query.rawMode ? (
         <RawQueryEditor
           {...props}
@@ -56,14 +66,15 @@ export const QueryEditor: React.FC<Props> = (props) => {
           templateVariableOptions={templateVariables}
           setDirty={() => !dirty && setDirty(true)}
         />
-      ) : (
+      ) : null}
+      {!query.rawMode && !query.OpenAI ? (
         <VisualQueryEditor
           {...props}
           schema={schema.value}
           database={query.database}
           templateVariableOptions={templateVariables}
         />
-      )}
+      ) : null}
     </>
   );
 };

--- a/src/components/QueryEditor/QueryHeader.test.tsx
+++ b/src/components/QueryEditor/QueryHeader.test.tsx
@@ -15,6 +15,7 @@ jest.mock('@grafana/runtime', () => {
       getVariables: () => [],
       replace: (s: string) => s,
     }),
+    reportInteraction: (string, props) => ({}),
     config: {
       ...original.config,
       buildInfo: {

--- a/src/components/QueryEditor/RawQueryEditor.tsx
+++ b/src/components/QueryEditor/RawQueryEditor.tsx
@@ -1,5 +1,5 @@
 import { QueryEditorProps, SelectableValue } from '@grafana/data';
-import { getTemplateSrv } from '@grafana/runtime';
+import { getTemplateSrv, reportInteraction } from '@grafana/runtime';
 import { CodeEditor, Monaco, MonacoEditor } from '@grafana/ui';
 import { AdxDataSource } from 'datasource';
 import React, { useEffect, useState } from 'react';
@@ -29,6 +29,7 @@ export const RawQueryEditor: React.FC<RawQueryEditorProps> = (props) => {
   const [stateSchema, setStateSchema] = useState(cloneDeep(schema));
 
   const onRawQueryChange = (kql: string) => {
+    reportInteraction('grafana_ds_adx_raw_editor_query_blurred');
     if (kql !== props.query.query) {
       props.setDirty();
       props.onChange({

--- a/src/datasource.ts
+++ b/src/datasource.ts
@@ -57,6 +57,7 @@ export class AdxDataSource extends DataSourceWithBackend<KustoQuery, AdxDataSour
     this.parseExpression = this.parseExpression.bind(this);
     this.autoCompleteQuery = this.autoCompleteQuery.bind(this);
     this.getSchemaMapper = this.getSchemaMapper.bind(this);
+    this.generateQueryForOpenAI = this.generateQueryForOpenAI.bind(this);
 
     this.variables = new VariableSupport(this);
   }
@@ -108,6 +109,12 @@ export class AdxDataSource extends DataSourceWithBackend<KustoQuery, AdxDataSour
   async getDatabases(): Promise<DatabaseItem[]> {
     return this.getResource<KustoDatabaseList>('databases').then((response) => {
       return new ResponseParser().parseDatabases(response);
+    });
+  }
+
+  async generateQueryForOpenAI(body): Promise<any> {
+    return super.postResource('generateQuery', body).then((resp) => {
+      return new ResponseParser().parseOpenAIResponse(resp);
     });
   }
 

--- a/src/response_parser.ts
+++ b/src/response_parser.ts
@@ -88,4 +88,9 @@ export class ResponseParser {
     const schemaJson = results.Tables[0].Rows[0][0];
     return JSON.parse(schemaJson) as AdxSchema;
   }
+
+  parseOpenAIResponse(results: any) {
+    const content = results.choices[0].Message.Content;
+    return content;
+  }
 }

--- a/src/test/selectors.ts
+++ b/src/test/selectors.ts
@@ -28,6 +28,7 @@ export const components = {
     },
     codeEditor: {
       container: 'data-testid code-editor',
+      openAI: 'data-testid open-ai-editor',
     },
     database: {
       input: 'Database',

--- a/src/types.ts
+++ b/src/types.ts
@@ -21,7 +21,7 @@ export interface QueryExpression {
   timeshift?: QueryEditorPropertyExpression;
 }
 
-type QuerySource = 'raw' | 'schema' | 'autocomplete' | 'visual';
+type QuerySource = 'raw' | 'schema' | 'autocomplete' | 'visual' | 'openai';
 export interface KustoQuery extends DataQuery {
   query: string;
   database: string;
@@ -33,6 +33,7 @@ export interface KustoQuery extends DataQuery {
   pluginVersion: string;
   queryType: AdxQueryType;
   table?: string;
+  OpenAI?: boolean;
 }
 
 export interface AutoCompleteQuery {
@@ -45,6 +46,7 @@ export interface AutoCompleteQuery {
 export enum EditorMode {
   Visual = 'visual',
   Raw = 'raw',
+  OpenAI = 'openai',
 }
 
 export enum AdxQueryType {
@@ -112,7 +114,9 @@ export interface AdxDataSourceOptions extends DataSourceJsonData {
   clusterUrl: string;
 }
 
-export interface AdxDataSourceSecureOptions {}
+export interface AdxDataSourceSecureOptions {
+  OpenAIAPIKey?: string;
+}
 
 export interface AdxSchema {
   Databases: Record<string, AdxDatabaseSchema>;


### PR DESCRIPTION
This integration adds an additional field in the datasource Config where the user can save their OpenAI API token. Once that token is present the user can use an additional mode of the Editor where they can use natural language to generate KQL queries.

**Additional future enhancements could be:**

- [ ] Display cost estimate before generating query
- [ ] Give the user the option to include the schema in the prompt to get more personalized results

**Examples**
![openai-adx](https://github.com/grafana/azure-data-explorer-datasource/assets/1048831/7b2e29e7-1fa5-4c55-81de-a726f42d1311)
![openai-adx-advanced](https://github.com/grafana/azure-data-explorer-datasource/assets/1048831/2aafc112-5348-4fe3-863d-6ce332599211)
