### PR TITLE
Add anonymous authentication capability

### DIFF
--- a/pkg/azuredx/adxauth/adxcredentials/anonymous_credentials.go
+++ b/pkg/azuredx/adxauth/adxcredentials/anonymous_credentials.go
@@ -1,0 +1,12 @@
+package adxcredentials
+
+const (
+	AzureAnonymousIdentity = "anonymous"
+)
+
+type AzureAnonymousCredentials struct {
+}
+
+func (credentials *AzureAnonymousCredentials) AzureAuthType() string {
+	return AzureAnonymousIdentity
+}

--- a/pkg/azuredx/adxauth/adxcredentials/builder.go
+++ b/pkg/azuredx/adxauth/adxcredentials/builder.go
@@ -13,6 +13,17 @@ func FromDatasourceData(data map[string]interface{}, secureData map[string]strin
 	var credentials azcredentials.AzureCredentials
 	var err error
 
+	// Check for anonymous authentication
+	if credentialsObj, err := maputil.GetMapOptional(data, "azureCredentials"); err != nil {
+		return nil, err
+	} else if credentialsObj != nil {
+		if authType, err := maputil.GetStringOptional(credentialsObj, "authType"); err != nil {
+			return nil, err
+		} else if authType == "anonymous" {
+			return &AzureAnonymousCredentials{}, nil
+		}
+	}
+
 	credentials, err = azcredentials.FromDatasourceData(data, secureData)
 	if err != nil {
 		return nil, err

--- a/pkg/azuredx/adxauth/adxcredentials/builder_test.go
+++ b/pkg/azuredx/adxauth/adxcredentials/builder_test.go
@@ -185,6 +185,21 @@ func TestFromDatasourceData(t *testing.T) {
 		_, err := FromDatasourceData(data, secureData)
 		assert.Error(t, err)
 	})
+
+	t.Run("should return anonymous credentials when anonymous auth configured", func(t *testing.T) {
+		var data = map[string]interface{}{
+			"azureCredentials": map[string]interface{}{
+				"authType": "anonymous",
+			},
+		}
+		var secureData = map[string]string{}
+
+		result, err := FromDatasourceData(data, secureData)
+		require.NoError(t, err)
+
+		require.NotNil(t, result)
+		assert.IsType(t, &AzureAnonymousCredentials{}, result)
+	})
 }
 
 func TestNormalizeAzureCloud(t *testing.T) {

--- a/pkg/azuredx/client/httpclient.go
+++ b/pkg/azuredx/client/httpclient.go
@@ -5,6 +5,7 @@ import (
 	"net/http"
 
 	"github.com/grafana/azure-data-explorer-datasource/pkg/azuredx/adxauth"
+	"github.com/grafana/azure-data-explorer-datasource/pkg/azuredx/adxauth/adxcredentials"
 	"github.com/grafana/azure-data-explorer-datasource/pkg/azuredx/models"
 	"github.com/grafana/grafana-azure-sdk-go/azcredentials"
 	"github.com/grafana/grafana-azure-sdk-go/azhttpclient"
@@ -14,27 +15,33 @@ import (
 )
 
 func newHttpClient(instanceSettings *backend.DataSourceInstanceSettings, dsSettings *models.DatasourceSettings, azureSettings *azsettings.AzureSettings, credentials azcredentials.AzureCredentials) (*http.Client, error) {
-	authOpts := azhttpclient.NewAuthOptions(azureSettings)
-
-        // Enables support for the experimental user-based authentication feature if the user_identity_enabled flag is set to true in the Grafana configuration
-	authOpts.AllowUserIdentity()
-
-	// TODO: #555 configure on-behalf-of authentication if enabled in AzureSettings
-	authOpts.AddTokenProvider(azcredentials.AzureAuthClientSecretObo, adxauth.NewOnBehalfOfAccessTokenProvider)
-
-	scopes, err := getAdxScopes(azureSettings, credentials, dsSettings.ClusterURL)
-	if err != nil {
-		return nil, err
-	}
-	authOpts.Scopes(scopes)
-
 	clientOpts, err := instanceSettings.HTTPClientOptions()
 	if err != nil {
 		return nil, fmt.Errorf("error creating http client: %w", err)
 	}
 	clientOpts.Timeouts.Timeout = dsSettings.QueryTimeout
 
-	azhttpclient.AddAzureAuthentication(&clientOpts, authOpts, credentials)
+	// Do not add any azure authentication to the http client if anonymous authentication is configured
+	switch credentials.(type) {
+	case *adxcredentials.AzureAnonymousCredentials:
+		break
+	default:
+		authOpts := azhttpclient.NewAuthOptions(azureSettings)
+
+		// Enables support for the experimental user-based authentication feature if the user_identity_enabled flag is set to true in the Grafana configuration
+		authOpts.AllowUserIdentity()
+
+		// TODO: #555 configure on-behalf-of authentication if enabled in AzureSettings
+		authOpts.AddTokenProvider(azcredentials.AzureAuthClientSecretObo, adxauth.NewOnBehalfOfAccessTokenProvider)
+
+		scopes, err := getAdxScopes(azureSettings, credentials, dsSettings.ClusterURL)
+		if err != nil {
+			return nil, err
+		}
+		authOpts.Scopes(scopes)
+
+		azhttpclient.AddAzureAuthentication(&clientOpts, authOpts, credentials)
+	}
 
 	httpClient, err := httpclient.NewProvider().New(clientOpts)
 	if err != nil {

--- a/src/components/ConfigEditor/AzureCredentials.ts
+++ b/src/components/ConfigEditor/AzureCredentials.ts
@@ -12,7 +12,7 @@ export const KnownAzureClouds = [
   { value: AzureCloud.USGovernment, label: 'Azure US Government' },
 ] as SelectableValue[];
 
-export type AzureAuthType = 'currentuser' | 'msi' | 'clientsecret' | 'clientsecret-obo';
+export type AzureAuthType = 'currentuser' | 'msi' | 'clientsecret' | 'clientsecret-obo' | 'anonymous';
 
 export type ConcealedSecret = symbol;
 
@@ -44,16 +44,22 @@ interface AzureClientSecretOboCredentials extends AzureCredentialsBase {
   clientSecret?: string | ConcealedSecret;
 }
 
+interface AzureAnonymousCredentials extends AzureCredentialsBase {
+  authType: 'anonymous';
+}
+
 export type AzureCredentials =
   | AadCurrentUserCredentials
   | AzureManagedIdentityCredentials
   | AzureClientSecretCredentials
-  | AzureClientSecretOboCredentials;
+  | AzureClientSecretOboCredentials
+  | AzureAnonymousCredentials;
 
 export function isCredentialsComplete(credentials: AzureCredentials): boolean {
   switch (credentials.authType) {
     case 'currentuser':
     case 'msi':
+    case 'anonymous':
       return true;
     case 'clientsecret':
     case 'clientsecret-obo':

--- a/src/components/ConfigEditor/AzureCredentialsConfig.ts
+++ b/src/components/ConfigEditor/AzureCredentialsConfig.ts
@@ -98,6 +98,10 @@ export function getCredentials(options: DataSourceSettings<any, any>): AzureCred
         clientId: credentials.clientId,
         clientSecret: getSecret(options),
       };
+    case 'anonymous':
+      return {
+        authType: 'anonymous',
+      };
   }
 }
 
@@ -215,6 +219,17 @@ export function updateCredentials(
           ...options.secureJsonFields,
           azureClientSecret: credentials.clientSecret === concealed,
           clientSecret: credentials.clientSecret === concealedLegacy,
+        },
+      };
+      break;
+    case 'anonymous':
+      options = {
+        ...options,
+        jsonData: {
+          ...options.jsonData,
+          azureCredentials: {
+            authType: 'anonymous',
+          },
         },
       };
       break;

--- a/src/components/ConfigEditor/AzureCredentialsForm.tsx
+++ b/src/components/ConfigEditor/AzureCredentialsForm.tsx
@@ -24,6 +24,10 @@ export const AzureCredentialsForm: FunctionComponent<Props> = (props: Props) => 
         value: 'clientsecret',
         label: 'App Registration',
       },
+      {
+        value: 'anonymous',
+        label: 'Anonymous',
+      },
     ];
 
     if (props.managedIdentityEnabled) {

--- a/src/tracking.test.ts
+++ b/src/tracking.test.ts
@@ -142,6 +142,18 @@ describe('analyzeQueries', () => {
       },
       expectedCounters: { app_registration_queries: 1 },
     },
+    {
+      description: 'should count anonymous queries',
+      queries: [{ query: '' }],
+      dsSettings: {
+        jsonData: {
+          azureCredentials: {
+            authType: 'anonymous',
+          },
+        },
+      },
+      expectedCounters: { anonymous_queries: 1 },
+    },
   ];
   tests.forEach((t) => {
     it(t.description, () => {

--- a/src/tracking.ts
+++ b/src/tracking.ts
@@ -41,6 +41,8 @@ export type ADXCounters = {
   msi_queries: number;
   /** number of queries using app registration authentication */
   app_registration_queries: number;
+  /** number of queries using anonymous authentication */
+  anonymous_queries: number;
   /** number of queries using a timeout different than the default */
   queries_with_custom_timeout: number;
   /** number of queries using ADX dynamic caching */
@@ -72,6 +74,7 @@ export const analyzeQueries = (queries: KustoQuery[], datasourceSrv: DataSourceS
     on_behalf_of_queries: 0,
     msi_queries: 0,
     app_registration_queries: 0,
+    anonymous_queries: 0,
     queries_with_custom_timeout: 0,
     dynamic_caching_queries: 0,
     weak_data_consistency_queries: 0,
@@ -117,6 +120,9 @@ export const analyzeQueries = (queries: KustoQuery[], datasourceSrv: DataSourceS
       }
       if (authType === 'clientsecret') {
         counters.app_registration_queries++;
+      }
+      if (authType === 'anonymous') {
+        counters.anonymous_queries++;
       }
       if (dsSettings.jsonData?.queryTimeout) {
         counters.queries_with_custom_timeout++;


### PR DESCRIPTION
Microsoft recently released the [Azure Data Explorer Kusto emulator](https://learn.microsoft.com/en-gb/azure/data-explorer/kusto-emulator-overview), which allows you to create a local cluster for local development. The emulator, however, [does not support any type of Azure AD authentication](https://learn.microsoft.com/en-gb/azure/data-explorer/kusto-emulator-install#connect-to-the-emulator), and therefore must be connected to anonymously without any of the usual Azure AD headers. 

This pull request adds the option for anonymous authentication to be configured via the UI, and if selected will remove all Azure AD middleware from the go HTTP client. 

Thanks!