### PR TITLE
Make tooltip clickable

### DIFF
--- a/src/components/QueryEditor/VisualQueryEditor/TableSection.tsx
+++ b/src/components/QueryEditor/VisualQueryEditor/TableSection.tsx
@@ -96,6 +96,7 @@ const TableSection: React.FC<TableSectionProps> = ({
         </EditorField>
         <EditorField
           label="Columns"
+          tooltipInteractive={true}
           tooltip={
             <>
               Select a subset of columns for faster results. Time series requires both time and number values, other


### PR DESCRIPTION
`tooltipInteractive` makes links inside a tooltip prop clickable.

closes https://github.com/grafana/azure-data-explorer-datasource/pull/377