### PR TITLE
Allow dynamic values to be empty for traces

### DIFF
--- a/README.md
+++ b/README.md
@@ -221,9 +221,9 @@ T | make-series AvgHatInventory=avg(HatInventory) default=double(null) on Timest
 The trace format option can be used to display appropriately formatted data using the built in trace visualization. To use this visualization, data must be presented following the schema that is defined [here](https://grafana.com/docs/grafana/latest/explore/trace-integration/#data-frame-structure). The schema contains the `logs`, `serviceTags`, and `tags` fields which are expected to be JSON objects. These fields will be converted to the expected data structure provided the schema in ADX matches the below:
 
 - `logs` - an array of JSON objects with a `timestamp` field that has a numeric value, and a `fields` field that is key-value object.
-- `serviceTags` and tags - a typical key-value JSON object without nested objects.
+- `serviceTags` and `tags` - a typical key-value JSON object without nested objects.
 
-The values for keys are expected to be primitive types rather than complex types.
+The values for keys are expected to be primitive types rather than complex types. The correct value to pass when empty is either `null`, an empty JSON object for `serviceTags` and `tags`, or an empty array for `logs`.
 
 ### Time Macros
 

--- a/pkg/azuredx/models/table.go
+++ b/pkg/azuredx/models/table.go
@@ -305,7 +305,7 @@ type KeyValue struct {
 }
 
 func parseKeyValue(m map[string]any) []KeyValue {
-	parsedTags := make([]KeyValue, 0, len(m)-1)
+	parsedTags := []KeyValue{}
 	for k, v := range m {
 		if v == nil {
 			continue
@@ -379,7 +379,7 @@ var logsConverter = data.FieldConverter{
 			}
 		}
 
-		parsedLogs := make([]TraceLog, 0, len(m)-1)
+		parsedLogs := []TraceLog{}
 		for i := range m {
 			current, ok := m[i].(map[string]any)
 			if !ok {

--- a/pkg/azuredx/models/table_test.go
+++ b/pkg/azuredx/models/table_test.go
@@ -30,6 +30,8 @@ func TestResponseToFrames(t *testing.T) {
 	_ = serviceTags.UnmarshalJSON([]byte("[{\"key\": \"cloud_RoleInstance\", \"value\": \"test-cloud-id\"},{\"key\": \"cloud_RoleName\", \"value\": \"test-app\"}]"))
 	_ = tags.UnmarshalJSON([]byte("[{\"key\":\"appId\",\"value\":\"test-app\"}]"))
 	_ = logs.UnmarshalJSON([]byte("[{\"timestamp\": 1687260450000,\"fields\": [{\"key\":\"key\", \"value\": \"test\"},{\"key\":\"value\", \"value\": \"value\"}]}]"))
+	var emptyArray json.RawMessage
+	_ = emptyArray.UnmarshalJSON([]byte("[]"))
 	tests := []struct {
 		name     string
 		testFile string
@@ -113,6 +115,27 @@ func TestResponseToFrames(t *testing.T) {
 				data.NewField("tags", nil, []*json.RawMessage{&tags}),
 				data.NewField("itemId", nil, []*string{pointer.String("11ee-a66c-0022481b10a7")}),
 				data.NewField("logs", nil, []*json.RawMessage{&logs})).SetMeta(
+				&data.FrameMeta{Custom: AzureFrameMD{ColumnTypes: []string{"real", "string", "string", "real", "guid", "string", "string", "string", "dynamic", "dynamic", "guid", "dynamic"}}, PreferredVisualization: "trace"},
+			),
+			format: "trace",
+		},
+		{
+			name:     "traces with empty dynamics should be converted to dataframe appropriately",
+			testFile: "adx_traces_table_empty_dynamics.json",
+			errorIs:  assert.NoError,
+			frame: data.NewFrame("",
+				data.NewField("startTime", nil, []*float64{pointer.Float64(1687260000000)}),
+				data.NewField("itemType", nil, []*string{pointer.String("request")}),
+				data.NewField("serviceName", nil, []*string{pointer.String("test-app")}),
+				data.NewField("duration", nil, []*float64{pointer.Float64(26.7374)}),
+				data.NewField("traceID", nil, []*string{pointer.String("fc5b1c02-57fa-8611c2df33e2")}),
+				data.NewField("spanID", nil, []*string{pointer.String("92930421e2a400394")}),
+				data.NewField("parentSpanID", nil, []*string{pointer.String("test-id")}),
+				data.NewField("operationName", nil, []*string{pointer.String("service")}),
+				data.NewField("serviceTags", nil, []*json.RawMessage{&emptyArray}),
+				data.NewField("tags", nil, []*json.RawMessage{&emptyArray}),
+				data.NewField("itemId", nil, []*string{pointer.String("11ee-a66c-0022481b10a7")}),
+				data.NewField("logs", nil, []*json.RawMessage{&emptyArray})).SetMeta(
 				&data.FrameMeta{Custom: AzureFrameMD{ColumnTypes: []string{"real", "string", "string", "real", "guid", "string", "string", "string", "dynamic", "dynamic", "guid", "dynamic"}}, PreferredVisualization: "trace"},
 			),
 			format: "trace",

--- a/pkg/azuredx/models/testdata/adx_traces_table_empty_dynamics.json
+++ b/pkg/azuredx/models/testdata/adx_traces_table_empty_dynamics.json
@@ -1,0 +1,85 @@
+{
+  "Tables": [
+    {
+      "TableName": "Table_0",
+      "Columns": [
+        {
+          "ColumnName": "startTime",
+          "DataType": "Double",
+          "ColumnType": "real"
+        },
+        {
+          "ColumnName": "itemType",
+          "DataType": "String",
+          "ColumnType": "string"
+        },
+        {
+          "ColumnName": "serviceName",
+          "DataType": "String",
+          "ColumnType": "string"
+        },
+        {
+          "ColumnName": "duration",
+          "DataType": "Double",
+          "ColumnType": "real"
+        },
+        {
+          "ColumnName": "traceID",
+          "DataType": "Guid",
+          "ColumnType": "guid"
+        },
+        {
+          "ColumnName": "spanID",
+          "DataType": "String",
+          "ColumnType": "string"
+        },
+        {
+          "ColumnName": "parentSpanID",
+          "DataType": "String",
+          "ColumnType": "string"
+        },
+        {
+          "ColumnName": "operationName",
+          "DataType": "String",
+          "ColumnType": "string"
+        },
+        {
+          "ColumnName": "serviceTags",
+          "DataType": "Object",
+          "ColumnType": "dynamic"
+        },
+        {
+          "ColumnName": "tags",
+          "DataType": "Object",
+          "ColumnType": "dynamic"
+        },
+        {
+          "ColumnName": "itemId",
+          "DataType": "Guid",
+          "ColumnType": "guid"
+        },
+        {
+          "ColumnName": "logs",
+          "DataType": "Object",
+          "ColumnType": "dynamic"
+        }
+      ],
+      "Rows": [
+        [
+          1687260000000,
+          "request",
+          "test-app",
+          26.7374,
+          "fc5b1c02-57fa-8611c2df33e2",
+          "92930421e2a400394",
+          "test-id",
+          "service",
+          {},
+          {},
+          "11ee-a66c-0022481b10a7",
+          []
+        ]
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
This fixes a bug where if the `serviceTags`, `tags`, or `logs` fields are empty the query would fail.
