### PR TITLE
OpenAI: Add explain button to KQL query

### DIFF
--- a/src/components/QueryEditor/QueryHeader.test.tsx
+++ b/src/components/QueryEditor/QueryHeader.test.tsx
@@ -151,4 +151,19 @@ describe('QueryEditor', () => {
       expect(onChange).toHaveBeenCalledWith(expect.objectContaining({ resultFormat: 'time_series' }));
     });
   });
+
+  describe('kql explanation', () => {
+    it('renders the Explain KQL button in raw mode', async () => {
+      const onChange = jest.fn();
+      render(<QueryHeader 
+        {...defaultProps} 
+        query={{
+        ...mockQuery,
+        rawMode: true,
+        }} 
+        onChange={onChange} 
+      />);
+      expect(screen.getByText('Explain KQL')).toBeInTheDocument();
+    });
+  });
 });

--- a/src/components/QueryEditor/QueryHeader.tsx
+++ b/src/components/QueryEditor/QueryHeader.tsx
@@ -1,6 +1,6 @@
 import React, { useMemo, useState, useEffect } from 'react';
 
-import { Alert, Button, CollapsableSection, ConfirmModal, RadioButtonGroup, useStyles2 } from '@grafana/ui';
+import { Button, ConfirmModal, RadioButtonGroup, useStyles2 } from '@grafana/ui';
 import { EditorHeader, FlexItem, InlineSelect, llms } from '@grafana/experimental';
 
 import { AdxSchema, ClusterOption, defaultQuery, EditorMode, FormatOptions, KustoQuery } from '../../types';
@@ -53,10 +53,9 @@ export const QueryHeader = (props: QueryEditorHeaderProps) => {
   const [formats, setFormats] = useState(EDITOR_FORMATS);
   const [showWarning, setShowWarning] = useState(false);
   const [enabled, setEnabled] = useState(false);
-  const [error, setError] = useState(false);
+  // const [error, setError] = useState(false);
   const [generatedExplanation, setGeneratedExplanation] = useState('');
   const baselinePrompt = `You are a KQL expert and a Grafana expert that can explain any KQL query that contains Grafana macros clearly to someone who isn't familiar with KQL or Grafana. Explain the following KQL.\nText:"""`;
-  const styles = useStyles2(getStyles);
 
   useAsync(async () => {
     const enabled = await llms.openai.enabled();
@@ -135,17 +134,17 @@ export const QueryHeader = (props: QueryEditorHeaderProps) => {
           setGeneratedExplanation(m);
         },
         complete: () => {
-          console.log('hello')
+          console.log('hello');
           // setWaiting(false);
         },
         error: (e) => {
-          console.log('goodbye')
+          console.log('goodbye:', e)
           // setError(true);
           // setErrorMessage(e);
         },
       });
     } else {
-      setError(true);
+      // setError(true);
     }
   };
 
@@ -210,53 +209,29 @@ export const QueryHeader = (props: QueryEditorHeaderProps) => {
         }}
       />
       <FlexItem grow={1} />
+      {query.rawMode && (
+        <Button
+        variant="secondary"
+        size="sm"
+        onClick={showExplanation}
+        style={{margin: '0 0 0 15px'}}
+        disabled={!enabled}
+        >
+          Explain KQL
+        </Button>
+      )}
       {!query.OpenAI && (
         <Button
-          variant="primary"
-          icon="play"
-          size="sm"
-          onClick={onRunQuery}
-          data-testid={selectors.components.queryEditor.runQuery.button}
+        variant="primary"
+        icon="play"
+        size="sm"
+        onClick={onRunQuery}
+        data-testid={selectors.components.queryEditor.runQuery.button}
         >
           Run query
         </Button>
       )}
-      <div>
-        <RadioButtonGroup size="sm" options={EDITOR_MODES} value={EditorSelector()} onChange={changeEditorMode} />
-        {query.rawMode && (
-          <Button
-          variant="secondary"
-          size="sm"
-          onClick={showExplanation}
-          style={{margin: '0 0 0 15px'}}
-          disabled={!enabled}
-          >
-            Explain KQL
-          </Button>
-        )}
-        <CollapsableSection isOpen={true} label="KQL Explanation" className={styles.collapse}>
-          {generatedExplanation}
-        </CollapsableSection>
-        {/* {generatedExplanation && (
-          // <div>
-          //   <Button
-          //   variant="destructive"
-          //   size="sm"
-          //   style={{margin: '0 0 0 15px'}}
-          //   onClick={() => setGeneratedExplanation("")}
-          //   >
-          //     Clear explanation
-          //   </Button>
-          // </div>
-        // )} */}
-      </div>
-      <div>
-        {error && (
-          <Alert severity="error" title="Invalid query" onRemove={() => setError(false)} >
-            Query is empty or invalid. Please edit your query and try again.
-          </Alert>
-        )}
-      </div>
+      <RadioButtonGroup size="sm" options={EDITOR_MODES} value={EditorSelector()} onChange={changeEditorMode} />
     </EditorHeader>
   );
 };


### PR DESCRIPTION
This PR adds adds a button to the KQL editor send the current raw query to OpenAI and get back an explanation in plain language. This builds upon #577 to add the reverse functionality. 

<img width="1362" alt="Screenshot 2024-01-29 at 12 05 26 PM" src="https://github.com/grafana/azure-data-explorer-datasource/assets/58453566/e37b18ed-7acc-40b4-b624-be3a268ec8ae">

Fixes #582 