### PR TITLE
Enable PDC for ADX

### DIFF
--- a/cspell.config.json
+++ b/cspell.config.json
@@ -161,6 +161,7 @@
     "Ymax",
     "Ymin",
     "llms",
+    "proxying",
     ""
   ]
 }

--- a/src/components/ConfigEditor/index.tsx
+++ b/src/components/ConfigEditor/index.tsx
@@ -1,6 +1,8 @@
 import React, { useCallback, useEffect, useMemo } from 'react';
-import { DataSourcePluginOptionsEditorProps } from '@grafana/data';
+import { FeatureToggles, DataSourcePluginOptionsEditorProps } from '@grafana/data';
+import { Switch,  InlineField} from '@grafana/ui';
 import { config } from '@grafana/runtime';
+import { gte } from 'semver';
 import ConfigHelp from './ConfigHelp';
 import { AdxDataSourceOptions, AdxDataSourceSecureOptions, AdxDataSourceSettings } from 'types';
 import ConnectionConfig from './ConnectionConfig';
@@ -20,6 +22,14 @@ import {
 import AzureCredentialsForm from './AzureCredentialsForm';
 import { DataSourceDescription, ConfigSection } from '@grafana/experimental';
 import { Divider } from './Divider';
+import { css } from '@emotion/css';
+
+const styles = {
+    toggle: css`
+    margin-top: 7px;
+    margin-left: 5px;
+  `,
+};
 
 export interface ConfigEditorProps
   extends DataSourcePluginOptionsEditorProps<AdxDataSourceOptions, AdxDataSourceSecureOptions> {}
@@ -106,6 +116,49 @@ const ConfigEditor: React.FC<ConfigEditorProps> = (props) => {
         <DatabaseConfig options={options} onOptionsChange={onOptionsChange} updateJsonData={updateJsonData} />
         <TrackingConfig options={options} onOptionsChange={onOptionsChange} updateJsonData={updateJsonData} />
       </ConfigSection>
+
+      <Divider />
+      {config.featureToggles['secureSocksDSProxyEnabled' as keyof FeatureToggles] &&
+        gte(config.buildInfo.version, '10.0.0') && (
+          <>
+            <div className="gf-form-group">
+              <h3 className="page-heading">Additional Properties</h3>
+                <br/>
+                  <InlineField
+                    label="Secure Socks Proxy"
+                    tooltip={
+                      <>
+                        Enable proxying the datasource connection through the secure socks proxy to a
+                        different network.
+                        See{' '}
+                        <a
+                          href="https://grafana.com/docs/grafana/next/setup-grafana/configure-grafana/proxy/"
+                          target="_blank"
+                          rel="noopener noreferrer"
+                        >
+                          Configure a datasource connection proxy.
+                        </a>
+                      </>
+                    }
+                  >
+                  <div className={styles.toggle}>
+                    <Switch
+                      value={options.jsonData.enableSecureSocksProxy}
+                      onChange={(e) => {
+                        onOptionsChange({
+                          ...options,
+                            jsonData: {
+                              ...options.jsonData,
+                              enableSecureSocksProxy: e.currentTarget.checked
+                            },
+                        });
+                      }}
+                    />
+                  </div>
+                </InlineField>
+              </div>
+            </>
+          )}
     </>
   );
 };

--- a/src/types.ts
+++ b/src/types.ts
@@ -123,6 +123,7 @@ export interface AdxDataSourceOptions extends DataSourceJsonData {
   clusterUrl: string;
   azureCredentials?: AzureCredentials;
   onBehalfOf?: boolean;
+  enableSecureSocksProxy?: boolean;
 }
 
 export interface AdxDataSourceSecureOptions {


### PR DESCRIPTION
## Enabling Private Datasource Connect for ADX

### Background
This PR enables support for [the secure socks proxy](https://grafana.com/docs/grafana/next/setup-grafana/configure-grafana/proxy/), which is a new feature in Grafana 10. The feature allows datasource connections to be proxied through a socks5 proxy with TLS. This enables Grafana users to connect to datasources that live in different networks than where Grafana is running when they cannot open up ports to the public internet.

### Implementation notes
- The feature itself no longer sits behind a feature toggle in Grafana OSS, but a feature toggle is being used in all non-core datasources until the datasource can upgrade the frontend dependency@grafana/runtime to at least 10.0.0. At that point, we can switch [this line](https://github.com/grafana/azure-data-explorer-datasource/pull/768/files#diff-46e37405ec7a5456cabd314e64f20aa4bc69ed018f57d8cab41ee85c2abb7c3cR121) to look at config.secureSocksDSProxyEnabled, rather than the feature toggle.
- As ADX datasource uses httpclient from grafana-plugin-sdk, there are not mayor changes needed in the backend, as the configuration is read and set in the SDK constructor functions for the httpclient.

### Dependency updates:
- Not needed, plugin-sdk was already updated to the required version. 

### Tests:
- This was tested locally, running the PDC server and ensuring the connections went through the PDC tunnel. 

Screenshot of configuration page (running locally):
![image](https://github.com/grafana/azure-data-explorer-datasource/assets/34773040/2bbf6f98-db78-435f-8241-336f18379500)