### PR TITLE
Minor fix of config texts

### DIFF
--- a/src/components/ConfigEditor/index.tsx
+++ b/src/components/ConfigEditor/index.tsx
@@ -122,10 +122,10 @@ const ConfigEditor: React.FC<ConfigEditorProps> = (props) => {
         gte(config.buildInfo.version, '10.0.0') && (
           <>
             <div className="gf-form-group">
-              <h3 className="page-heading">Additional Properties</h3>
+              <h3 className="page-heading">Secure Socks Proxy</h3>
                 <br/>
                   <InlineField
-                    label="Secure Socks Proxy"
+                    label="Enable"
                     tooltip={
                       <>
                         Enable proxying the datasource connection through the secure socks proxy to a


### PR DESCRIPTION
Minor fix to  https://github.com/grafana/azure-data-explorer-datasource/pull/768 as some texts weren't updated in the PR

Updates texts to be the same as the image:
![image](https://github.com/grafana/azure-data-explorer-datasource/assets/34773040/8e16329e-a812-4b2b-bf00-043f29b0c7dd)
