### PR TITLE
Use correct error message property

### DIFF
--- a/pkg/azuredx/client/testdata/error-response.json
+++ b/pkg/azuredx/client/testdata/error-response.json
@@ -1,9 +1,8 @@
 {
   "error": {
     "code": "General_BadRequest",
-    "message": "Request is invalid and cannot be executed.",
     "@type": "Kusto.Data.Exceptions.KustoBadRequestException",
-    "@message": "Request is invalid and cannot be processed: Syntax error: SYN0002: A recognition error occurred. [line:position=1:9]. Query: 'PerfTest take 5'",
+    "message": "Request is invalid and cannot be processed: Syntax error: SYN0002: A recognition error occurred. [line:position=1:9]. Query: 'PerfTest take 5'",
     "@context": {
       "timestamp": "2021-05-26T13:23:26.2867367Z",
       "serviceAlias": "GRAFANAADXDEV",

--- a/pkg/azuredx/models/types.go
+++ b/pkg/azuredx/models/types.go
@@ -29,7 +29,7 @@ type AzureFrameMD struct {
 // error body,
 type ErrorResponse struct {
 	Error struct {
-		Message string `json:"@message"`
+		Message string `json:"message"`
 	} `json:"error"`
 }
 

--- a/pkg/azuredx/testdata/error-response.json
+++ b/pkg/azuredx/testdata/error-response.json
@@ -1,9 +1,8 @@
 {
   "error": {
     "code": "General_BadRequest",
-    "message": "Request is invalid and cannot be executed.",
     "@type": "Kusto.Data.Exceptions.KustoBadRequestException",
-    "@message": "Request is invalid and cannot be processed: Syntax error: SYN0002: A recognition error occurred. [line:position=1:9]. Query: 'PerfTest take 5'",
+    "message": "Request is invalid and cannot be processed: Syntax error: SYN0002: A recognition error occurred. [line:position=1:9]. Query: 'PerfTest take 5'",
     "@context": {
       "timestamp": "2021-05-26T13:23:26.2867367Z",
       "serviceAlias": "GRAFANAADXDEV",


### PR DESCRIPTION
Update the error type to correctly reflect the API allowing error messages to be properly displayed to the user.

Fixes #821 and #820