### PR TITLE
Do not execute a query on editor load

### DIFF
--- a/cypress/integration/smoke.spec.ts
+++ b/cypress/integration/smoke.spec.ts
@@ -32,7 +32,7 @@ const addAdxVariable = (
   name: string,
   type: AdxQueryType,
   isFirst: boolean,
-  options?: { cluster?: string, database?: string; table?: string }
+  options?: { cluster?: string; database?: string; table?: string }
 ) => {
   if (isFirst) {
     e2e.components.PageToolbar.item('Dashboard settings').click();
@@ -155,8 +155,7 @@ e2e.scenario({
         e2eSelectors.queryEditor.database.input().click({ force: true });
         cy.contains('PerfTest').click({ force: true });
 
-        e2eSelectors.queryEditor.tableFrom.input().click({ force: true });
-        cy.contains('PerfTest').click({ force: true });
+        e2eSelectors.queryEditor.tableFrom.input().click({ force: true }).type('PerfTest{enter}');
 
         e2eSelectors.queryEditor.runQuery.button().click({ force: true }).wait(6000);
         cy.contains('_val1_').should('exist');

--- a/src/components/QueryEditor/VisualQueryEditor.tsx
+++ b/src/components/QueryEditor/VisualQueryEditor.tsx
@@ -121,10 +121,6 @@ const useSelectedTable = (
       };
     }
 
-    if (options.length > 0) {
-      return options[0];
-    }
-
     return;
   }, [options, table, variables]);
 };


### PR DESCRIPTION
When opening the `VisualQueryEditor` the current behaviour is to auto-select the first table and all of its columns, leading to a query being immediately run.

This is not the best behaviour as these queries could lead to large amounts of data being returned. This is also not the standard Grafana behaviour.

This PR changes the behaviour to not auto-run a query by not auto-selecting a table.

Fixes #796 