### PR TITLE
Re-add method for compatibility

### DIFF
--- a/src/common/responseHelpers.ts
+++ b/src/common/responseHelpers.ts
@@ -5,7 +5,7 @@ export function firstStringFieldToMetricFindValue(frame: DataFrame): MetricFindV
   const field = frame.fields.find((f) => f.type === FieldType.string);
   if (field) {
     for (let i = 0; i < field.values.length; i++) {
-      values.push({ text: field.values[i] });
+      values.push({ text: field.values.get(i) });
     }
   }
   return values;


### PR DESCRIPTION
The `get` method is required for backwards compatibility with 9.5.x. We will remove this in a later version when we bump the minimum grafana dependency.