### PR TITLE
Allow additional trusted hosts

### DIFF
--- a/pkg/azuredx/client/endpoints.go
+++ b/pkg/azuredx/client/endpoints.go
@@ -2,6 +2,7 @@ package client
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/grafana/grafana-azure-sdk-go/azsettings"
 )
@@ -53,10 +54,15 @@ var azureDataExplorerEndpoints = map[string][]string{
 	},
 }
 
-func getAdxEndpoints(azureCloud string) ([]string, error) {
+func getAdxEndpoints(azureCloud string, trustedClustersURLs string) ([]string, error) {
 	if endpoints, ok := azureDataExplorerEndpoints[azureCloud]; !ok {
 		return nil, fmt.Errorf("the Azure cloud '%s' not supported by Azure Data Explorer datasource", azureCloud)
 	} else {
+		// Append the trusted URLs for all clouds
+		var trustedUrls = strings.Split(trustedClustersURLs, ",")
+		if len(trustedUrls) > 1 || trustedUrls[0] != "" {
+			endpoints = append(endpoints, trustedUrls...)
+		}
 		return endpoints, nil
 	}
 }

--- a/pkg/azuredx/client/endpoints_test.go
+++ b/pkg/azuredx/client/endpoints_test.go
@@ -1,0 +1,151 @@
+package client
+
+import (
+	"testing"
+
+	"github.com/grafana/grafana-azure-sdk-go/azsettings"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestGetAdxEndpoints_EmptyTrustedClusters(t *testing.T) {
+	tests := []struct {
+		description         string
+		cloud               string
+		trustedClustersUrls string
+		expectedLastUrl     string
+	}{
+		{
+			description:         "test public cloud",
+			cloud:               azsettings.AzurePublic,
+			trustedClustersUrls: "",
+			expectedLastUrl:     "https://*.kusto.fabric.microsoft.com",
+		},
+		{
+			description:         "test US Government cloud - Texas",
+			cloud:               azsettings.AzureUSGovernment,
+			trustedClustersUrls: "",
+			expectedLastUrl:     "https://*.kustomfa.usgovcloudapi.net",
+		},
+		{
+			description:         "test US Government cloud - Virginia",
+			cloud:               azsettings.AzureUSGovernment,
+			trustedClustersUrls: "",
+			expectedLastUrl:     "https://*.kustomfa.usgovcloudapi.net",
+		},
+		{
+			description:         "test China cloud",
+			cloud:               azsettings.AzureChina,
+			trustedClustersUrls: "",
+			expectedLastUrl:     "https://*.playfab.cn",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.description, func(t *testing.T) {
+			endpoints, err := getAdxEndpoints(tt.cloud, tt.trustedClustersUrls)
+			require.NoError(t, err)
+
+			assert.Len(t, endpoints, 22)
+			assert.Equal(t, tt.expectedLastUrl, endpoints[len(endpoints)-1])
+		})
+	}
+}
+
+func TestGetAdxEndpoints_OneTrustedClusters(t *testing.T) {
+	tests := []struct {
+		description         string
+		cloud               string
+		trustedClustersUrls string
+		expectedLastUrl     string
+	}{
+		{
+			description:         "test public cloud",
+			cloud:               azsettings.AzurePublic,
+			trustedClustersUrls: "https://*.kusto.proxy.com",
+			expectedLastUrl:     "https://*.kusto.proxy.com",
+		},
+		{
+			description:         "test US Government cloud - Texas",
+			cloud:               azsettings.AzureUSGovernment,
+			trustedClustersUrls: "https://*.kusto.proxy.com",
+			expectedLastUrl:     "https://*.kusto.proxy.com",
+		},
+		{
+			description:         "test US Government cloud - Virginia",
+			cloud:               azsettings.AzureUSGovernment,
+			trustedClustersUrls: "https://*.kusto.proxy.com",
+			expectedLastUrl:     "https://*.kusto.proxy.com",
+		},
+		{
+			description:         "test China cloud",
+			cloud:               azsettings.AzureChina,
+			trustedClustersUrls: "https://*.kusto.proxy.com",
+			expectedLastUrl:     "https://*.kusto.proxy.com",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.description, func(t *testing.T) {
+			endpoints, err := getAdxEndpoints(tt.cloud, tt.trustedClustersUrls)
+			require.NoError(t, err)
+
+			assert.Len(t, endpoints, 23)
+			assert.Equal(t, tt.expectedLastUrl, endpoints[len(endpoints)-1])
+		})
+	}
+}
+
+func TestGetAdxEndpoints_MoreThanOneTrustedClusters(t *testing.T) {
+	tests := []struct {
+		description         string
+		cloud               string
+		trustedClustersUrls string
+		expectedLastUrl     string
+	}{
+		{
+			description:         "test public cloud",
+			cloud:               azsettings.AzurePublic,
+			trustedClustersUrls: "https://*.kusto.proxy.com,https://*.kusto.proxy-2.com",
+			expectedLastUrl:     "https://*.kusto.proxy-2.com",
+		},
+		{
+			description:         "test US Government cloud - Texas",
+			cloud:               azsettings.AzureUSGovernment,
+			trustedClustersUrls: "https://*.kusto.proxy.com,https://*.kusto.proxy-2.com",
+			expectedLastUrl:     "https://*.kusto.proxy-2.com",
+		},
+		{
+			description:         "test US Government cloud - Virginia",
+			cloud:               azsettings.AzureUSGovernment,
+			trustedClustersUrls: "https://*.kusto.proxy.com,https://*.kusto.proxy-2.com",
+			expectedLastUrl:     "https://*.kusto.proxy-2.com",
+		},
+		{
+			description:         "test China cloud",
+			cloud:               azsettings.AzureChina,
+			trustedClustersUrls: "https://*.kusto.proxy.com,https://*.kusto.proxy-2.com",
+			expectedLastUrl:     "https://*.kusto.proxy-2.com",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.description, func(t *testing.T) {
+			endpoints, err := getAdxEndpoints(tt.cloud, tt.trustedClustersUrls)
+			require.NoError(t, err)
+
+			assert.Len(t, endpoints, 24)
+			assert.Equal(t, tt.expectedLastUrl, endpoints[len(endpoints)-1])
+		})
+	}
+}
+
+func TestGetAdxEndpoints_UnknownClouds(t *testing.T) {
+	t.Run("should fail when cloud is unknown", func(t *testing.T) {
+		trustedClustersUrls := "https://abc.northeurope.unknown.net"
+
+		_, err := getAdxEndpoints("Unknown", trustedClustersUrls)
+		assert.Error(t, err)
+	})
+}

--- a/pkg/azuredx/client/httpclient.go
+++ b/pkg/azuredx/client/httpclient.go
@@ -77,7 +77,7 @@ func getAuthOpts(azureSettings *azsettings.AzureSettings, dsSettings *models.Dat
 
 	// Enforce only trusted Azure Data Explorer endpoints if enabled
 	if userProvidedEndpoint && dsSettings.EnforceTrustedEndpoints {
-		endpoints, err := getAdxEndpoints(azureCloud)
+		endpoints, err := getAdxEndpoints(azureCloud, dsSettings.TrustedClustersURLs)
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/azuredx/models/settings.go
+++ b/pkg/azuredx/models/settings.go
@@ -13,12 +13,13 @@ import (
 // DatasourceSettings holds the datasource configuration information for Azure Data Explorer's API
 // that is needed to execute a request against Azure's Data Explorer API.
 type DatasourceSettings struct {
-	ClusterURL         string `json:"clusterUrl"`
-	DefaultDatabase    string `json:"defaultDatabase"`
-	DataConsistency    string `json:"dataConsistency"`
-	CacheMaxAge        string `json:"cacheMaxAge"`
-	DynamicCaching     bool   `json:"dynamicCaching"`
-	EnableUserTracking bool   `json:"enableUserTracking"`
+	ClusterURL          string `json:"clusterUrl"`
+	TrustedClustersURLs string `json:"trustedClustersURLs"`
+	DefaultDatabase     string `json:"defaultDatabase"`
+	DataConsistency     string `json:"dataConsistency"`
+	CacheMaxAge         string `json:"cacheMaxAge"`
+	DynamicCaching      bool   `json:"dynamicCaching"`
+	EnableUserTracking  bool   `json:"enableUserTracking"`
 
 	// QueryTimeoutRaw is a duration string set in the datasource settings and corresponds
 	// to the server execution timeout.

--- a/src/components/ConfigEditor/ConnectionConfig.tsx
+++ b/src/components/ConfigEditor/ConnectionConfig.tsx
@@ -13,17 +13,31 @@ const ConnectionConfig: React.FC<ConnectionConfigProps> = ({ options, updateJson
   const { jsonData } = options;
 
   return (
-    <Field label="Default cluster URL (Optional)" description="The default cluster url for this data source.">
-      <Input
-        aria-label="Cluster URL"
-        data-testid={selectors.components.configEditor.clusterURL.input}
-        value={jsonData.clusterUrl}
-        id="adx-cluster-url"
-        placeholder="https://yourcluster.kusto.windows.net"
-        width={60}
-        onChange={(ev: React.ChangeEvent<HTMLInputElement>) => updateJsonData('clusterUrl', ev.target.value)}
-      />
-    </Field>
+    <>
+      <Field label="Default cluster URL (Optional)" description="The default cluster url for this data source.">
+        <Input
+          aria-label="Cluster URL"
+          data-testid={selectors.components.configEditor.clusterURL.input}
+          value={jsonData.clusterUrl}
+          id="adx-cluster-url"
+          placeholder="https://yourcluster.kusto.windows.net"
+          width={60}
+          onChange={(ev: React.ChangeEvent<HTMLInputElement>) => updateJsonData('clusterUrl', ev.target.value)}
+        />
+      </Field>
+
+      <Field label="Additional Trusted Cluster URLs (Optional)" description="The comma separated list of additional trusted cluster URLs.">
+        <Input
+          aria-label="Additional Trusted Clusters URLs"
+          data-testid={selectors.components.configEditor.trustedClustersURLs.input}
+          value={jsonData.trustedClustersURLs}
+          id="adx-trusted-clusters-urls"
+          placeholder="https://yourcluster.kusto.windows.net"
+          width={60}
+          onChange={(ev: React.ChangeEvent<HTMLInputElement>) => updateJsonData('trustedClustersURLs', ev.target.value)}
+        />
+      </Field>
+    </>
   );
 };
 

--- a/src/components/__fixtures__/ConfigEditor.fixtures.ts
+++ b/src/components/__fixtures__/ConfigEditor.fixtures.ts
@@ -29,6 +29,7 @@ export const mockConfigEditorProps = (optionsOverrides?: Partial<ConfigEditorPro
       useSchemaMapping: false,
       enableUserTracking: true,
       clusterUrl: Chance().url(),
+      trustedClustersURLs: Chance().url(),
     },
     readOnly: true,
     withCredentials: true,

--- a/src/components/__fixtures__/Datasource.ts
+++ b/src/components/__fixtures__/Datasource.ts
@@ -34,6 +34,7 @@ export const mockDatasourceOptions: DataSourcePluginOptionsEditorProps<
       useSchemaMapping: false,
       enableUserTracking: false,
       clusterUrl: 'clusterUrl',
+      trustedClustersURLs: '',
     },
     secureJsonFields: {},
     readOnly: false,

--- a/src/test/selectors.ts
+++ b/src/test/selectors.ts
@@ -14,6 +14,9 @@ export const components = {
     clusterURL: {
       input: 'data-testid cluster-url',
     },
+    trustedClustersURLs: {
+      input: 'data-testid trusted-clusters-urls',
+    },
     clientID: {
       input: 'data-testid client-id',
     },

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -125,6 +125,7 @@ export interface AdxDataSourceOptions extends DataSourceJsonData {
   azureCredentials?: AzureCredentials;
   onBehalfOf?: boolean;
   enableSecureSocksProxy?: boolean;
+  trustedClustersURLs: string;
 }
 
 export interface AdxDataSourceSecureOptions {


### PR DESCRIPTION
<!-- To surface this PR in the changelog add the label: changelog -->
<!-- If this PR is going in the changelog please make sure the title of the PR explains the feature in a user-centric way: -->
<!-- Bad: fix state bug in hooks -->
<!-- Good: Fix crash when switching from Query Builder -->

Add an option to support additional trusted endpoints. This will allow the users to trust specific hosts, and not need to drop the whole validation of endpoints.

I tested it locally, but unfortunately did not have proper proxy to fully test. Nonetheless, I used a local DNS forwarding to verify, but was not able to fully check due to the TLS certs.

![image](https://github.com/grafana/azure-data-explorer-datasource/assets/126269987/6cf71c88-5c70-45de-8210-367be38e9df3)
