### PR TITLE
Move tracking headers to client

### DIFF
--- a/pkg/azuredx/client/client_test.go
+++ b/pkg/azuredx/client/client_test.go
@@ -8,6 +8,8 @@ import (
 	"testing"
 
 	"github.com/grafana/azure-data-explorer-datasource/pkg/azuredx/models"
+	"github.com/grafana/grafana-azure-sdk-go/azusercontext"
+	"github.com/grafana/grafana-plugin-sdk-go/backend"
 	"github.com/stretchr/testify/require"
 )
 
@@ -35,7 +37,7 @@ func TestClient(t *testing.T) {
 		}
 
 		client := &Client{httpClientKusto: server.Client()}
-		table, err := client.KustoRequest(context.Background(), "", server.URL, payload, nil)
+		table, err := client.KustoRequest(context.Background(), "", server.URL, payload, false)
 		require.NoError(t, err)
 		require.NotNil(t, table)
 	})
@@ -62,13 +64,33 @@ func TestClient(t *testing.T) {
 		}
 
 		client := &Client{httpClientKusto: server.Client()}
-		table, err := client.KustoRequest(context.Background(), "", server.URL, payload, nil)
+		table, err := client.KustoRequest(context.Background(), "", server.URL, payload, false)
 		require.Nil(t, table)
 		require.NotNil(t, err)
 		require.Contains(t, err.Error(), "Request is invalid and cannot be processed: Syntax error: SYN0002: A recognition error occurred. [line:position=1:9]. Query: 'PerfTest take 5'")
 	})
 
-	t.Run("Headers are set", func(t *testing.T) {
+	t.Run("Headers are set - excluding tracking headers", func(t *testing.T) {
+		server := httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
+			require.Equal(t, "application/json", req.Header.Get("Accept"))
+			require.Equal(t, "application/json", req.Header.Get("Content-Type"))
+			require.Equal(t, "Grafana-ADX", req.Header.Get("x-ms-app"))
+		}))
+		defer server.Close()
+
+		payload := models.RequestPayload{
+			DB:          "db-name",
+			CSL:         "show databases",
+			QuerySource: "schema",
+		}
+
+		client := &Client{httpClientKusto: server.Client()}
+		table, err := client.KustoRequest(context.Background(), "", server.URL, payload, false)
+		require.Nil(t, table)
+		require.NotNil(t, err)
+	})
+
+	t.Run("Headers are set - including tracking headers", func(t *testing.T) {
 		server := httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
 			require.Equal(t, "application/json", req.Header.Get("Accept"))
 			require.Equal(t, "application/json", req.Header.Get("Content-Type"))
@@ -83,16 +105,19 @@ func TestClient(t *testing.T) {
 			CSL:         "show databases",
 			QuerySource: "schema",
 		}
-		headers := map[string]string{
-			"x-ms-user-id":           testUserLogin,
-			"x-ms-client-request-id": "KGC.schema;deadbeef",
-		}
 
 		client := &Client{httpClientKusto: server.Client()}
-		table, err := client.KustoRequest(context.Background(), "", server.URL, payload, headers)
+		ctx := context.Background()
+		ctxWithUser := azusercontext.WithCurrentUser(ctx, azusercontext.CurrentUserContext{
+			User: &backend.User{
+				Login: "test-user",
+			},
+		})
+		table, err := client.KustoRequest(ctxWithUser, "", server.URL, payload, true)
 		require.Nil(t, table)
 		require.NotNil(t, err)
 	})
+
 }
 
 func loadTestFile(path string) ([]byte, error) {

--- a/pkg/azuredx/datasource.go
+++ b/pkg/azuredx/datasource.go
@@ -163,7 +163,7 @@ func (adx *AzureDataExplorer) modelQuery(ctx context.Context, q models.QueryMode
 		DB:          q.Database,
 		Properties:  props,
 		QuerySource: q.QuerySource,
-	}, headers)
+	}, adx.settings.EnableUserTracking)
 	if err != nil {
 		backend.Logger.Debug("error building kusto request", "error", err.Error())
 		return backend.DataResponse{}, err

--- a/pkg/azuredx/datasource_test.go
+++ b/pkg/azuredx/datasource_test.go
@@ -10,7 +10,7 @@ import (
 )
 
 var (
-	kustoRequestMock      func(url string, cluster string, payload models.RequestPayload, additionalHeaders map[string]string) (*models.TableResponse, error)
+	kustoRequestMock      func(url string, cluster string, payload models.RequestPayload, enableUserTracking bool) (*models.TableResponse, error)
 	ARGClusterRequestMock func(payload models.ARGRequestPayload, additionalHeaders map[string]string) ([]models.ClusterOption, error)
 	table                 = &models.TableResponse{
 		Tables: []models.Table{
@@ -40,12 +40,10 @@ func TestDatasource(t *testing.T) {
 			TimeRange:     backend.TimeRange{},
 			JSON:          []byte(`{"resultFormat": "table","querySource": "schema"}`),
 		}
-		kustoRequestMock = func(url string, cluster string, payload models.RequestPayload, additionalHeaders map[string]string) (*models.TableResponse, error) {
+		kustoRequestMock = func(url string, cluster string, payload models.RequestPayload, enableUserTracking bool) (*models.TableResponse, error) {
 			require.Equal(t, "/v1/rest/query", url)
 			require.Equal(t, ClusterURL, cluster)
-			require.Contains(t, additionalHeaders, "x-ms-user-id")
-			require.Equal(t, UserLogin, additionalHeaders["x-ms-user-id"])
-			require.Contains(t, additionalHeaders["x-ms-client-request-id"], UserLogin)
+			require.Equal(t, enableUserTracking, true)
 			return table, nil
 		}
 		res := adx.handleQuery(context.Background(), query, &backend.User{Login: UserLogin})
@@ -63,8 +61,8 @@ func (c *fakeClient) TestARGsRequest(_ context.Context, _ *models.DatasourceSett
 	panic("not implemented")
 }
 
-func (c *fakeClient) KustoRequest(_ context.Context, cluster string, url string, payload models.RequestPayload, additionalHeaders map[string]string) (*models.TableResponse, error) {
-	return kustoRequestMock(url, cluster, payload, additionalHeaders)
+func (c *fakeClient) KustoRequest(_ context.Context, cluster string, url string, payload models.RequestPayload, enableUserTracking bool) (*models.TableResponse, error) {
+	return kustoRequestMock(url, cluster, payload, enableUserTracking)
 }
 
 func (c *fakeClient) ARGClusterRequest(_ context.Context, payload models.ARGRequestPayload, additionalHeaders map[string]string) ([]models.ClusterOption, error) {

--- a/pkg/azuredx/resource_handler.go
+++ b/pkg/azuredx/resource_handler.go
@@ -141,8 +141,8 @@ func (adx *AzureDataExplorer) getSchema(rw http.ResponseWriter, req *http.Reques
 		QuerySource: "schema",
 	}
 
-	headers := map[string]string{}
-	response, err := adx.client.KustoRequest(req.Context(), cluster.ClusterUri, ManagementApiPath, payload, headers)
+	// Default to not sending the user request headers for schema requests
+	response, err := adx.client.KustoRequest(req.Context(), cluster.ClusterUri, ManagementApiPath, payload, false)
 	if err != nil {
 		respondWithError(rw, http.StatusInternalServerError, "Azure query unsuccessful", err)
 		return
@@ -184,8 +184,8 @@ func (adx *AzureDataExplorer) getDatabases(rw http.ResponseWriter, req *http.Req
 		CSL: ".show databases",
 	}
 
-	headers := map[string]string{}
-	response, err := adx.client.KustoRequest(req.Context(), cluster.ClusterUri, ManagementApiPath, payload, headers)
+	// Default to not sending the user request headers for schema requests
+	response, err := adx.client.KustoRequest(req.Context(), cluster.ClusterUri, ManagementApiPath, payload, false)
 	if err != nil {
 		respondWithError(rw, http.StatusInternalServerError, "Azure query unsuccessful", err)
 		return

--- a/pkg/azuredx/resource_handler_test.go
+++ b/pkg/azuredx/resource_handler_test.go
@@ -82,7 +82,7 @@ func (c *failingClient) TestARGsRequest(_ context.Context, _ *models.DatasourceS
 	panic("not implemented")
 }
 
-func (c *failingClient) KustoRequest(_ context.Context, _ string, _ string, _ models.RequestPayload, _ map[string]string) (*models.TableResponse, error) {
+func (c *failingClient) KustoRequest(_ context.Context, _ string, _ string, _ models.RequestPayload, _ bool) (*models.TableResponse, error) {
 	return nil, fmt.Errorf("HTTP error: %v - %v", http.StatusBadRequest, "")
 }
 
@@ -100,7 +100,7 @@ func (c *workingClient) TestARGsRequest(_ context.Context, _ *models.DatasourceS
 	panic("not implemented")
 }
 
-func (c *workingClient) KustoRequest(_ context.Context, _ string, _ string, _ models.RequestPayload, _ map[string]string) (*models.TableResponse, error) {
+func (c *workingClient) KustoRequest(_ context.Context, _ string, _ string, _ models.RequestPayload, _ bool) (*models.TableResponse, error) {
 	return &models.TableResponse{
 		Tables: []models.Table{
 			{


### PR DESCRIPTION
As the `User` is now accessible via context the creation of the tracking headers can be done in the client rather than in the query logic.

Fixes #526