### PR TITLE
Load custom clouds from context and remove hard coded URLs

### DIFF
--- a/pkg/azuredx/datasource.go
+++ b/pkg/azuredx/datasource.go
@@ -46,7 +46,7 @@ func NewDatasource(ctx context.Context, instanceSettings backend.DataSourceInsta
 	adx.settings = datasourceSettings
 	adx.settings.OpenAIAPIKey = strings.TrimSpace(instanceSettings.DecryptedSecureJSONData["OpenAIAPIKey"])
 
-	azureSettings, err := azsettings.ReadFromEnv()
+	azureSettings, err := azsettings.ReadSettings(ctx)
 	if err != nil {
 		backend.Logger.Error("failed to read Azure settings from Grafana", "error", err.Error())
 		return nil, err


### PR DESCRIPTION
This change fixes a problem where the ADX Plugin doesn't load the custom clouds list into the backend from grafana.  It also removes some hard coded URLs and uses the ones from the custom cloud list instead.