### PR TITLE
Release 5.0.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG
 
+## [5.0.4]
+
+- Fix: Custom clouds are now loaded from context [#921](https://github.com/grafana/azure-data-explorer-datasource/pull/921)
+
 ## [5.0.3]
 
 - Upgrade dependencies

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "grafana-azure-data-explorer-datasource",
-  "version": "5.0.3",
+  "version": "5.0.4",
   "description": "Grafana data source for Azure Data Explorer",
   "scripts": {
     "build": "webpack -c ./.config/webpack/webpack.config.ts --env production",


### PR DESCRIPTION
Fix: Custom clouds are now loaded from context [#921](https://github.com/grafana/azure-data-explorer-datasource/pull/921)