### PR TITLE
Add context to the user when Kusto returns an error

### DIFF
--- a/pkg/azuredx/client/client.go
+++ b/pkg/azuredx/client/client.go
@@ -215,7 +215,7 @@ func (c *Client) KustoRequest(ctx context.Context, cluster string, url string, p
 		if err != nil {
 			return nil, fmt.Errorf("azure HTTP %q with malformed error response: %s", resp.Status, err)
 		}
-		return nil, fmt.Errorf("azure HTTP %q: %q", resp.Status, r.Error.Message)
+		return nil, fmt.Errorf("azure HTTP %q: %q. %q: %q", resp.Status, r.Error.Message, r.Error.Type, r.Error.Description)
 	}
 
 	return models.TableFromJSON(resp.Body)
@@ -263,7 +263,7 @@ func (c *Client) ARGClusterRequest(ctx context.Context, payload models.ARGReques
 		if err != nil {
 			return nil, fmt.Errorf("azure HTTP %q with malformed error response: %s", resp.Status, err)
 		}
-		return nil, fmt.Errorf("azure HTTP %q: %q", resp.Status, r.Error.Message)
+		return nil, fmt.Errorf("azure HTTP %q: %q. %q: %q", resp.Status, r.Error.Message)
 	}
 	var clusterData struct {
 		Data []struct {

--- a/pkg/azuredx/client/client.go
+++ b/pkg/azuredx/client/client.go
@@ -263,7 +263,7 @@ func (c *Client) ARGClusterRequest(ctx context.Context, payload models.ARGReques
 		if err != nil {
 			return nil, fmt.Errorf("azure HTTP %q with malformed error response: %s", resp.Status, err)
 		}
-		return nil, fmt.Errorf("azure HTTP %q: %q. %q: %q", resp.Status, r.Error.Message)
+		return nil, fmt.Errorf("azure HTTP %q: %q", resp.Status, r.Error.Message)
 	}
 	var clusterData struct {
 		Data []struct {

--- a/pkg/azuredx/client/client.go
+++ b/pkg/azuredx/client/client.go
@@ -215,7 +215,7 @@ func (c *Client) KustoRequest(ctx context.Context, cluster string, url string, p
 		if err != nil {
 			return nil, fmt.Errorf("azure HTTP %q with malformed error response: %s", resp.Status, err)
 		}
-		return nil, fmt.Errorf("azure HTTP %q: %q. %q: %q", resp.Status, r.Error.Message, r.Error.Type, r.Error.Description)
+		return nil, fmt.Errorf("azure HTTP %q: %q.\nReceived %q: %q", resp.Status, r.Error.Message, r.Error.Type, r.Error.Description)
 	}
 
 	return models.TableFromJSON(resp.Body)

--- a/pkg/azuredx/models/types.go
+++ b/pkg/azuredx/models/types.go
@@ -29,7 +29,9 @@ type AzureFrameMD struct {
 // error body,
 type ErrorResponse struct {
 	Error struct {
-		Message string `json:"message"`
+		Message     string `json:"message"`
+		Type        string `json:"@type"`
+		Description string `json:"@message"`
 	} `json:"error"`
 }
 


### PR DESCRIPTION
<!-- To surface this PR in the changelog add the label: changelog -->
<!-- If this PR is going in the changelog please make sure the title of the PR explains the feature in a user-centric way: -->
<!-- Bad: fix state bug in hooks -->
<!-- Good: Fix crash when switching from Query Builder -->

Hi, 
Currently if a user writes a malformed Kusto query, or the Kusto service is having a bad time with the query the user sends - the error you get back is a bit meaningless, and doesn't help the user resolve its issue:
![image](https://github.com/user-attachments/assets/0754b808-642a-48ef-99c8-eac23a4d9ad5)

I added the error's short description and type to the `Error` struct so we could propagate the error properly to show something like that (please note that the final formatting in the PR is a bit different):
![image](https://github.com/user-attachments/assets/cbbbcefa-e446-42a2-abdf-92fada0eeee3)

Thanks!
