### PR TITLE
Sanitise URL when creating a new Kusto API request

### DIFF
--- a/pkg/azuredx/client/client.go
+++ b/pkg/azuredx/client/client.go
@@ -8,6 +8,7 @@ import (
 	"io"
 	"math/rand"
 	"net/http"
+	"net/url"
 
 	"github.com/grafana/grafana-azure-sdk-go/v2/azcredentials"
 	"github.com/grafana/grafana-azure-sdk-go/v2/azsettings"
@@ -17,6 +18,7 @@ import (
 	// 100% compatible drop-in replacement of "encoding/json"
 	json "github.com/json-iterator/go"
 
+	"github.com/grafana/azure-data-explorer-datasource/pkg/azuredx/helpers"
 	"github.com/grafana/azure-data-explorer-datasource/pkg/azuredx/models"
 )
 
@@ -86,7 +88,12 @@ func (c *Client) TestKustoRequest(ctx context.Context, datasourceSettings *model
 		clusterURL = clusters[0].Uri
 	}
 
-	if err := c.testKustoClient(ctx, datasourceSettings, clusterURL, properties, additionalHeaders); err != nil {
+	sanitized, err := helpers.SanitizeClusterUri(clusterURL)
+	if err != nil {
+		return fmt.Errorf("invalid clusterUri: %w", err)
+	}
+
+	if err := c.testKustoClient(ctx, datasourceSettings, sanitized, properties, additionalHeaders); err != nil {
 		return err
 	}
 
@@ -103,7 +110,12 @@ func (c *Client) testKustoClient(ctx context.Context, datasourceSettings *models
 		return err
 	}
 
-	req, err := http.NewRequestWithContext(ctx, "POST", clusterURL+"/v1/rest/query", bytes.NewReader(buf))
+	fullUrl, err := url.JoinPath(clusterURL, "/v1/rest/query")
+	if err != nil {
+		return fmt.Errorf("invalid Azure request URL: %w", err)
+	}
+
+	req, err := http.NewRequestWithContext(ctx, "POST", fullUrl, bytes.NewReader(buf))
 	if err != nil {
 		return err
 	}
@@ -130,7 +142,7 @@ func (c *Client) testKustoClient(ctx context.Context, datasourceSettings *models
 	return nil
 }
 
-func (c *Client) testManagementClient(ctx context.Context, datasourceSettings *models.DatasourceSettings, additionalHeaders map[string]string) error {
+func (c *Client) testManagementClient(ctx context.Context, _ *models.DatasourceSettings, additionalHeaders map[string]string) error {
 	buf, err := json.Marshal(models.ARGRequestPayload{Query: "resources | where type == \"microsoft.kusto/clusters\""})
 	if err != nil {
 		return fmt.Errorf("no Azure request serial: %w", err)
@@ -141,10 +153,23 @@ func (c *Client) testManagementClient(ctx context.Context, datasourceSettings *m
 		return fmt.Errorf("the Azure cloud '%s' doesn't have the required property for 'resourceManager'", c.cloudSettings.Name)
 	}
 
-	req, err := http.NewRequestWithContext(ctx, http.MethodPost, resourceManager+"/providers/Microsoft.ResourceGraph/resources?api-version=2021-03-01", bytes.NewReader(buf))
+	u, err := url.Parse(resourceManager)
+	if err != nil {
+		return fmt.Errorf("invalid Azure request URL: %w", err)
+	}
+
+	// the default path for Azure Resource Graph
+	u = u.JoinPath("/providers/Microsoft.ResourceGraph/resources")
+
+	params := u.Query()
+	params.Add("api-version", "2021-03-01")
+	u.RawQuery = params.Encode()
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, u.String(), bytes.NewReader(buf))
 	if err != nil {
 		return fmt.Errorf("no Azure request instance: %w", err)
 	}
+
 	req.Header.Set("Content-Type", "application/json")
 	for key, value := range additionalHeaders {
 		req.Header.Set(key, value)
@@ -170,13 +195,18 @@ func (c *Client) testManagementClient(ctx context.Context, datasourceSettings *m
 // KustoRequest executes a Kusto Query language request to Azure's Data Explorer V1 REST API
 // and returns a TableResponse. If there is a query syntax error, the error message inside
 // the API's JSON error response is returned as well (if available).
-func (c *Client) KustoRequest(ctx context.Context, cluster string, url string, payload models.RequestPayload, userTrackingEnabled bool) (*models.TableResponse, error) {
+func (c *Client) KustoRequest(ctx context.Context, clusterUrl string, path string, payload models.RequestPayload, userTrackingEnabled bool) (*models.TableResponse, error) {
 	buf, err := json.Marshal(payload)
 	if err != nil {
 		return nil, fmt.Errorf("no Azure request serial: %w", err)
 	}
 
-	req, err := http.NewRequestWithContext(ctx, http.MethodPost, cluster+url, bytes.NewReader(buf))
+	fullUrl, err := url.JoinPath(clusterUrl, path)
+	if err != nil {
+		return nil, fmt.Errorf("invalid Azure request URL: %w", err)
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, fullUrl, bytes.NewReader(buf))
 	if err != nil {
 		return nil, fmt.Errorf("no Azure request instance: %w", err)
 	}
@@ -232,7 +262,19 @@ func (c *Client) ARGClusterRequest(ctx context.Context, payload models.ARGReques
 		return nil, fmt.Errorf("the Azure cloud '%s' doesn't have the required property for 'resourceManager'", c.cloudSettings.Name)
 	}
 
-	req, err := http.NewRequestWithContext(ctx, http.MethodPost, resourceManager+"/providers/Microsoft.ResourceGraph/resources?api-version=2021-03-01", bytes.NewReader(buf))
+	u, err := url.Parse(resourceManager)
+	if err != nil {
+		return nil, fmt.Errorf("invalid Azure request URL: %w", err)
+	}
+
+	// the default path for Azure Resource Graph
+	u = u.JoinPath("/providers/Microsoft.ResourceGraph/resources")
+
+	params := u.Query()
+	params.Add("api-version", "2021-03-01")
+	u.RawQuery = params.Encode()
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, u.String(), bytes.NewReader(buf))
 	if err != nil {
 		return nil, fmt.Errorf("no Azure request instance: %w", err)
 	}

--- a/pkg/azuredx/client/client_test.go
+++ b/pkg/azuredx/client/client_test.go
@@ -37,7 +37,7 @@ func TestClient(t *testing.T) {
 		}
 
 		client := &Client{httpClientKusto: server.Client()}
-		table, err := client.KustoRequest(context.Background(), "", server.URL, payload, false)
+		table, err := client.KustoRequest(context.Background(), server.URL, "", payload, false)
 		require.NoError(t, err)
 		require.NotNil(t, table)
 	})
@@ -64,7 +64,7 @@ func TestClient(t *testing.T) {
 		}
 
 		client := &Client{httpClientKusto: server.Client()}
-		table, err := client.KustoRequest(context.Background(), "", server.URL, payload, false)
+		table, err := client.KustoRequest(context.Background(), server.URL, "", payload, false)
 		require.Nil(t, table)
 		require.NotNil(t, err)
 		require.Contains(t, err.Error(), "Request is invalid and cannot be processed: Syntax error: SYN0002: A recognition error occurred. [line:position=1:9]. Query: 'PerfTest take 5'")
@@ -85,7 +85,7 @@ func TestClient(t *testing.T) {
 		}
 
 		client := &Client{httpClientKusto: server.Client()}
-		table, err := client.KustoRequest(context.Background(), "", server.URL, payload, false)
+		table, err := client.KustoRequest(context.Background(), server.URL, "", payload, false)
 		require.Nil(t, table)
 		require.NotNil(t, err)
 	})
@@ -113,7 +113,7 @@ func TestClient(t *testing.T) {
 				Login: "test-user",
 			},
 		})
-		table, err := client.KustoRequest(ctxWithUser, "", server.URL, payload, true)
+		table, err := client.KustoRequest(ctxWithUser, server.URL, "", payload, true)
 		require.Nil(t, table)
 		require.NotNil(t, err)
 	})

--- a/pkg/azuredx/datasource.go
+++ b/pkg/azuredx/datasource.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 
 	"github.com/grafana/azure-data-explorer-datasource/pkg/azuredx/adxauth/adxcredentials"
+	"github.com/grafana/azure-data-explorer-datasource/pkg/azuredx/helpers"
 	"github.com/grafana/grafana-azure-sdk-go/v2/azsettings"
 	"github.com/grafana/grafana-azure-sdk-go/v2/azusercontext"
 	"github.com/grafana/grafana-plugin-sdk-go/backend"
@@ -167,7 +168,12 @@ func (adx *AzureDataExplorer) modelQuery(ctx context.Context, q models.QueryMode
 		database = adx.settings.DefaultDatabase
 	}
 
-	tableRes, err := adx.client.KustoRequest(ctx, clusterURL, "/v1/rest/query", models.RequestPayload{
+	sanitized, err := helpers.SanitizeClusterUri(clusterURL)
+	if err != nil {
+		return backend.DataResponse{}, fmt.Errorf("invalid clusterUri: %w", err)
+	}
+
+	tableRes, err := adx.client.KustoRequest(ctx, sanitized, "/v1/rest/query", models.RequestPayload{
 		CSL:         q.Query,
 		DB:          database,
 		Properties:  props,

--- a/pkg/azuredx/helpers/helpers.go
+++ b/pkg/azuredx/helpers/helpers.go
@@ -1,0 +1,31 @@
+package helpers
+
+import (
+	"errors"
+	"net/url"
+	"strings"
+)
+
+// SanitizeClusterUri ensures the URI does not contain a query or fragment part
+func SanitizeClusterUri(clusterUri string) (string, error) {
+	// check for trailing question mark before parsing
+	if strings.HasSuffix(clusterUri, "?") {
+		return "", errors.New("clusterUri contains invalid query characters")
+	}
+
+	parsedUrl, err := url.Parse(clusterUri)
+	if err != nil {
+		return "", err
+	}
+
+	// check if the URL contains a query part or fragment
+	if parsedUrl.RawQuery != "" {
+		return "", errors.New("clusterUri contains invalid query characters")
+	}
+
+	if parsedUrl.Fragment != "" {
+		return "", errors.New("clusterUri contains invalid fragment characters")
+	}
+
+	return parsedUrl.String(), nil
+}

--- a/pkg/azuredx/helpers/helpers_test.go
+++ b/pkg/azuredx/helpers/helpers_test.go
@@ -1,0 +1,55 @@
+package helpers_test
+
+import (
+	"testing"
+
+	"github.com/grafana/azure-data-explorer-datasource/pkg/azuredx/helpers"
+)
+
+func Test_SanitizeClusterUri(t *testing.T) {
+	tests := []struct {
+		name       string
+		clusterUri string
+		expectErr  bool
+	}{
+		{
+			name:       "Valid URI without query",
+			clusterUri: "http://example.com",
+			expectErr:  false,
+		},
+		{
+			name:       "Valid URI with path",
+			clusterUri: "http://example.com/path",
+			expectErr:  false,
+		},
+		{
+			name:       "URI with query part",
+			clusterUri: "http://example.com?",
+			expectErr:  true,
+		},
+		{
+			name:       "URI with query part and parameters",
+			clusterUri: "http://example.com?param=value",
+			expectErr:  true,
+		},
+		{
+			name:       "URI with fragment part",
+			clusterUri: "http://example.com#fragment",
+			expectErr:  true,
+		},
+		{
+			name:       "Invalid URI",
+			clusterUri: ":invalid",
+			expectErr:  true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := helpers.SanitizeClusterUri(tt.clusterUri)
+			if (err != nil) != tt.expectErr {
+				t.Fatalf("expected error: %v, got: %v", tt.expectErr, err)
+			}
+		})
+	}
+}

--- a/pkg/azuredx/models/settings.go
+++ b/pkg/azuredx/models/settings.go
@@ -7,6 +7,7 @@ import (
 	"strconv"
 	"time"
 
+	"github.com/grafana/azure-data-explorer-datasource/pkg/azuredx/helpers"
 	"github.com/grafana/grafana-plugin-sdk-go/backend"
 )
 
@@ -45,6 +46,15 @@ func (d *DatasourceSettings) Load(config backend.DataSourceInstanceSettings) err
 		if err := json.Unmarshal(config.JSONData, d); err != nil {
 			return fmt.Errorf("could not unmarshal DatasourceSettings json: %w", err)
 		}
+	}
+
+	if d.ClusterURL != "" {
+		sanitized, err := helpers.SanitizeClusterUri(d.ClusterURL)
+		if err != nil {
+			return fmt.Errorf("invalid datasource endpoint configuration: %w", err)
+		}
+
+		d.ClusterURL = sanitized
 	}
 
 	if d.QueryTimeoutRaw == "" {


### PR DESCRIPTION
This PR adds logic to sanitise cluster URLs when creating a `KustoRequest`.