### PR TITLE
Improve accounting for fragments

### DIFF
--- a/pkg/azuredx/helpers/helpers.go
+++ b/pkg/azuredx/helpers/helpers.go
@@ -13,6 +13,11 @@ func SanitizeClusterUri(clusterUri string) (string, error) {
 		return "", errors.New("clusterUri contains invalid query characters")
 	}
 
+	// check for trailing question mark before parsing
+	if strings.HasSuffix(clusterUri, "#") {
+		return "", errors.New("clusterUri contains invalid fragment characters")
+	}
+
 	parsedUrl, err := url.Parse(clusterUri)
 	if err != nil {
 		return "", err

--- a/pkg/azuredx/helpers/helpers_test.go
+++ b/pkg/azuredx/helpers/helpers_test.go
@@ -28,6 +28,16 @@ func Test_SanitizeClusterUri(t *testing.T) {
 			expectErr:  true,
 		},
 		{
+			name:       "URI with query part in path",
+			clusterUri: "http://example.com/?",
+			expectErr:  true,
+		},
+		{
+			name:       "URI with query part and params in path",
+			clusterUri: "http://example.com/test?grafana=test",
+			expectErr:  true,
+		},
+		{
 			name:       "URI with query part and parameters",
 			clusterUri: "http://example.com?param=value",
 			expectErr:  true,
@@ -35,6 +45,16 @@ func Test_SanitizeClusterUri(t *testing.T) {
 		{
 			name:       "URI with fragment part",
 			clusterUri: "http://example.com#fragment",
+			expectErr:  true,
+		},
+		{
+			name:       "URI with fragment part in path",
+			clusterUri: "http://example.com/#",
+			expectErr:  true,
+		},
+		{
+			name:       "URI with complete fragment part in path",
+			clusterUri: "http://example.com/#fragment",
 			expectErr:  true,
 		},
 		{


### PR DESCRIPTION
URL fragments were potentially missed, this PR accounts for them in the same manner as query params.