### PR TITLE
Downgrade monaco-editor and exclude from dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,42 +1,42 @@
 version: 2
 updates:
-  - package-ecosystem: "gomod"
-    directory: "/"
+  - package-ecosystem: 'gomod'
+    directory: '/'
     schedule:
-      interval: "daily"
+      interval: 'daily'
   # Maintain dependencies for GitHub Actions
-  - package-ecosystem: "github-actions"
-    directory: "/"
+  - package-ecosystem: 'github-actions'
+    directory: '/'
     schedule:
-      interval: "daily"
-  - package-ecosystem: "npm"
-    directory: "/"
+      interval: 'daily'
+  - package-ecosystem: 'npm'
+    directory: '/'
     schedule:
-      interval: "daily"
+      interval: 'daily'
     groups:
       dependencies:
         patterns:
-          - "@grafana/*"
+          - '@grafana/*'
       dev-dependencies:
         patterns:
-          - "@grafana/e2e*"
+          - '@grafana/e2e*'
 
     # Ignore most dependencies that are maintained via the create-plugin tool
     # See https://github.com/grafana/plugin-tools/blob/main/packages/create-plugin/templates/common/package.json
     ignore:
-      - dependency-name: "@babel/core"
-      - dependency-name: "@emotion/css"
-      - dependency-name: "@grafana/eslint-config"
-      - dependency-name: "@grafana/tsconfig"
-      - dependency-name: "@swc/core"
-      - dependency-name: "@swc/helpers"
-      - dependency-name: "@swc/jest"
-      - dependency-name: "@testing-library/jest-dom"
-      - dependency-name: "@testing-library/react"
-      - dependency-name: "@types/jest"
-      - dependency-name: "@types/lodash"
-      - dependency-name: "@types/node"
-      - dependency-name: "@types/react-router-dom"
+      - dependency-name: '@babel/core'
+      - dependency-name: '@emotion/css'
+      - dependency-name: '@grafana/eslint-config'
+      - dependency-name: '@grafana/tsconfig'
+      - dependency-name: '@swc/core'
+      - dependency-name: '@swc/helpers'
+      - dependency-name: '@swc/jest'
+      - dependency-name: '@testing-library/jest-dom'
+      - dependency-name: '@testing-library/react'
+      - dependency-name: '@types/jest'
+      - dependency-name: '@types/lodash'
+      - dependency-name: '@types/node'
+      - dependency-name: '@types/react-router-dom'
       - dependency-name: react
       - dependency-name: react-dom
       - dependency-name: react-router-dom
@@ -62,3 +62,5 @@ updates:
       - dependency-name: webpack
       - dependency-name: webpack-cli
       - dependency-name: webpack-livereload-plug
+      # monaco-editor version is tied to the version of grafana/ui - it should at least match the minor version specified by grafana/ui
+      - dependency-name: monaco-editor

--- a/package.json
+++ b/package.json
@@ -67,7 +67,7 @@
     "identity-obj-proxy": "3.0.0",
     "jest": "^29.5.0",
     "jest-environment-jsdom": "^29.5.0",
-    "monaco-editor": "0.49.0",
+    "monaco-editor": "0.34.1",
     "node-notifier": "^10.0.1",
     "prettier": "^3.2.5",
     "prismjs": "1.29.0",

--- a/src/components/ConfigEditor/AzureCredentialsConfig.test.ts
+++ b/src/components/ConfigEditor/AzureCredentialsConfig.test.ts
@@ -118,7 +118,8 @@ describe('updateCredentials', () => {
 
       const updatedOptions = updateCredentials(options, credentials);
 
-      expect(updatedOptions.secureJsonData['azureClientSecret']).toEqual('fake-secret');
+      expect(updatedOptions.secureJsonData).toBeDefined();
+      expect(updatedOptions.secureJsonData!['azureClientSecret']).toEqual('fake-secret');
       expect(updatedOptions.secureJsonFields['azureClientSecret']).toBeFalsy();
       expect(updatedOptions.secureJsonFields['clientSecret']).toBeFalsy();
     });
@@ -148,7 +149,8 @@ describe('updateCredentials', () => {
 
         const updatedOptions = updateCredentials(options, credentials);
 
-        expect(updatedOptions.secureJsonData['azureClientSecret']).toBeUndefined();
+        expect(updatedOptions.secureJsonData).toBeDefined();
+        expect(updatedOptions.secureJsonData!['azureClientSecret']).toBeUndefined();
         expect(updatedOptions.secureJsonFields['azureClientSecret']).toBeTruthy();
         expect(updatedOptions.secureJsonFields['clientSecret']).toBeFalsy();
       });
@@ -161,7 +163,8 @@ describe('updateCredentials', () => {
 
         const updatedOptions = updateCredentials(options, credentials);
 
-        expect(updatedOptions.secureJsonData['azureClientSecret']).toEqual('new-fake-secret');
+        expect(updatedOptions.secureJsonData).toBeDefined();
+        expect(updatedOptions.secureJsonData!['azureClientSecret']).toEqual('new-fake-secret');
         expect(updatedOptions.secureJsonFields['azureClientSecret']).toBeFalsy();
         expect(updatedOptions.secureJsonFields['clientSecret']).toBeFalsy();
       });
@@ -189,7 +192,8 @@ describe('updateCredentials', () => {
 
         const updatedOptions = updateCredentials(options, credentials!);
 
-        expect(updatedOptions.secureJsonData['azureClientSecret']).toBeUndefined();
+        expect(updatedOptions.secureJsonData).toBeDefined();
+        expect(updatedOptions.secureJsonData!['azureClientSecret']).toBeUndefined();
         expect(updatedOptions.secureJsonFields['azureClientSecret']).toBeFalsy();
         expect(updatedOptions.secureJsonFields['clientSecret']).toBeTruthy();
       });
@@ -202,7 +206,8 @@ describe('updateCredentials', () => {
 
         const updatedOptions = updateCredentials(options, credentials!);
 
-        expect(updatedOptions.secureJsonData['azureClientSecret']).toEqual('new-fake-secret');
+        expect(updatedOptions.secureJsonData).toBeDefined();
+        expect(updatedOptions.secureJsonData!['azureClientSecret']).toEqual('new-fake-secret');
         expect(updatedOptions.secureJsonFields['azureClientSecret']).toBeFalsy();
         expect(updatedOptions.secureJsonFields['clientSecret']).toBeFalsy();
       });

--- a/yarn.lock
+++ b/yarn.lock
@@ -8508,10 +8508,10 @@ monaco-editor@0.34.0:
   resolved "https://registry.yarnpkg.com/monaco-editor/-/monaco-editor-0.34.0.tgz#b1749870a1f795dbfc4dc03d8e9b646ddcbeefa7"
   integrity sha512-VF+S5zG8wxfinLKLrWcl4WUizMx+LeJrG4PM/M78OhcwocpV0jiyhX/pG6Q9jIOhrb/ckYi6nHnaR5OojlOZCQ==
 
-monaco-editor@0.49.0:
-  version "0.49.0"
-  resolved "https://registry.yarnpkg.com/monaco-editor/-/monaco-editor-0.49.0.tgz#4e80e9859feb2c421def3cef194d12d822606472"
-  integrity sha512-2I8/T3X/hLxB2oPHgqcNYUVdA/ZEFShT7IAujifIPMfKkNbLOqY8XCoyHCXrsdjb36dW9MwoTwBCFpXKMwNwaQ==
+monaco-editor@0.34.1:
+  version "0.34.1"
+  resolved "https://registry.yarnpkg.com/monaco-editor/-/monaco-editor-0.34.1.tgz#1b75c4ad6bc4c1f9da656d740d98e0b850a22f87"
+  integrity sha512-FKc80TyiMaruhJKKPz5SpJPIjL+dflGvz4CpuThaPMc94AyN7SeC9HQ8hrvaxX7EyHdJcUY5i4D0gNyJj1vSZQ==
 
 ms@2.0.0:
   version "2.0.0"


### PR DESCRIPTION
We exclude `monaco-editor` from dependabot as it needs to be tied to the version included by `grafana/ui` to avoid compilation issues.