### PR TITLE
Add `errorsource`

### DIFF
--- a/cspell.config.json
+++ b/cspell.config.json
@@ -65,6 +65,7 @@
     "endswith",
     "Entra",
     "errgroup",
+    "errorsource",
     "Expan",
     "Fabrikam",
     "fieldandoperator",

--- a/pkg/azuredx/client/client.go
+++ b/pkg/azuredx/client/client.go
@@ -246,7 +246,7 @@ func (c *Client) KustoRequest(ctx context.Context, clusterUrl string, path strin
 		if err != nil {
 			return nil, fmt.Errorf("azure HTTP %q with malformed error response: %s", resp.Status, err)
 		}
-		return nil, errorsource.DownstreamError(fmt.Errorf("azure HTTP %q: %q.\nReceived %q: %q", resp.Status, r.Error.Message, r.Error.Type, r.Error.Description), false)
+		return nil, errorsource.SourceError(backend.ErrorSourceFromHTTPStatus(resp.StatusCode), fmt.Errorf("azure HTTP %q: %q.\nReceived %q: %q", resp.Status, r.Error.Message, r.Error.Type, r.Error.Description), false)
 	}
 
 	return models.TableFromJSON(resp.Body)
@@ -306,7 +306,7 @@ func (c *Client) ARGClusterRequest(ctx context.Context, payload models.ARGReques
 		if err != nil {
 			return nil, fmt.Errorf("azure HTTP %q with malformed error response: %s", resp.Status, err)
 		}
-		return nil, errorsource.DownstreamError(fmt.Errorf("azure HTTP %q: %q", resp.Status, r.Error.Message), false)
+		return nil, errorsource.SourceError(backend.ErrorSourceFromHTTPStatus(resp.StatusCode), fmt.Errorf("azure HTTP %q: %q", resp.Status, r.Error.Message), false)
 	}
 	var clusterData struct {
 		Data []struct {

--- a/pkg/azuredx/client/client.go
+++ b/pkg/azuredx/client/client.go
@@ -14,6 +14,7 @@ import (
 	"github.com/grafana/grafana-azure-sdk-go/v2/azsettings"
 	"github.com/grafana/grafana-azure-sdk-go/v2/azusercontext"
 	"github.com/grafana/grafana-plugin-sdk-go/backend"
+	"github.com/grafana/grafana-plugin-sdk-go/experimental/errorsource"
 
 	// 100% compatible drop-in replacement of "encoding/json"
 	json "github.com/json-iterator/go"
@@ -237,7 +238,7 @@ func (c *Client) KustoRequest(ctx context.Context, clusterUrl string, path strin
 	switch {
 	case resp.StatusCode == http.StatusUnauthorized:
 		// HTTP 401 has no error body
-		return nil, fmt.Errorf("azure HTTP %q", resp.Status)
+		return nil, errorsource.DownstreamError(fmt.Errorf("azure HTTP %q", resp.Status), false)
 
 	case resp.StatusCode/100 != 2:
 		var r models.ErrorResponse
@@ -245,7 +246,7 @@ func (c *Client) KustoRequest(ctx context.Context, clusterUrl string, path strin
 		if err != nil {
 			return nil, fmt.Errorf("azure HTTP %q with malformed error response: %s", resp.Status, err)
 		}
-		return nil, fmt.Errorf("azure HTTP %q: %q.\nReceived %q: %q", resp.Status, r.Error.Message, r.Error.Type, r.Error.Description)
+		return nil, errorsource.DownstreamError(fmt.Errorf("azure HTTP %q: %q.\nReceived %q: %q", resp.Status, r.Error.Message, r.Error.Type, r.Error.Description), false)
 	}
 
 	return models.TableFromJSON(resp.Body)
@@ -297,7 +298,7 @@ func (c *Client) ARGClusterRequest(ctx context.Context, payload models.ARGReques
 	switch {
 	case resp.StatusCode == http.StatusUnauthorized:
 		// HTTP 401 has no error body
-		return nil, fmt.Errorf("azure HTTP %q", resp.Status)
+		return nil, errorsource.DownstreamError(fmt.Errorf("azure HTTP %q", resp.Status), false)
 
 	case resp.StatusCode/100 != 2:
 		var r models.ErrorResponse
@@ -305,7 +306,7 @@ func (c *Client) ARGClusterRequest(ctx context.Context, payload models.ARGReques
 		if err != nil {
 			return nil, fmt.Errorf("azure HTTP %q with malformed error response: %s", resp.Status, err)
 		}
-		return nil, fmt.Errorf("azure HTTP %q: %q", resp.Status, r.Error.Message)
+		return nil, errorsource.DownstreamError(fmt.Errorf("azure HTTP %q: %q", resp.Status, r.Error.Message), false)
 	}
 	var clusterData struct {
 		Data []struct {

--- a/pkg/azuredx/datasource.go
+++ b/pkg/azuredx/datasource.go
@@ -14,6 +14,7 @@ import (
 	"github.com/grafana/grafana-plugin-sdk-go/backend/instancemgmt"
 	"github.com/grafana/grafana-plugin-sdk-go/backend/resource/httpadapter"
 	"github.com/grafana/grafana-plugin-sdk-go/data"
+	"github.com/grafana/grafana-plugin-sdk-go/experimental/errorsource"
 
 	"github.com/grafana/azure-data-explorer-datasource/pkg/azuredx/client"
 	"github.com/grafana/azure-data-explorer-datasource/pkg/azuredx/models"
@@ -140,6 +141,10 @@ func (adx *AzureDataExplorer) handleQuery(ctx context.Context, q backend.DataQue
 			Meta:  &data.FrameMeta{ExecutedQueryString: qm.Query},
 		})
 		resp.Error = err
+		errWithSource, ok := err.(errorsource.Error)
+		if ok {
+			resp.ErrorSource = errWithSource.ErrorSource()
+		}
 	}
 	return resp
 }
@@ -163,14 +168,15 @@ func (adx *AzureDataExplorer) modelQuery(ctx context.Context, q models.QueryMode
 	database := q.Database
 	if database == "" {
 		if adx.settings.DefaultDatabase == "" {
-			return backend.DataResponse{}, fmt.Errorf("query submitted without database specified and data source does not have a default database")
+			return backend.DataResponse{}, errorsource.DownstreamError(fmt.Errorf("query submitted without database specified and data source does not have a default database"), false)
 		}
 		database = adx.settings.DefaultDatabase
 	}
 
 	sanitized, err := helpers.SanitizeClusterUri(clusterURL)
 	if err != nil {
-		return backend.DataResponse{}, fmt.Errorf("invalid clusterUri: %w", err)
+		// errorsource set in SanitizeClusterUri
+		return backend.DataResponse{}, err
 	}
 
 	tableRes, err := adx.client.KustoRequest(ctx, sanitized, "/v1/rest/query", models.RequestPayload{
@@ -181,6 +187,7 @@ func (adx *AzureDataExplorer) modelQuery(ctx context.Context, q models.QueryMode
 	}, adx.settings.EnableUserTracking)
 	if err != nil {
 		backend.Logger.Debug("error building kusto request", "error", err.Error())
+		// errorsource set in KustoRequest
 		return backend.DataResponse{}, err
 	}
 

--- a/pkg/azuredx/datasource_test.go
+++ b/pkg/azuredx/datasource_test.go
@@ -2,7 +2,6 @@ package azuredx
 
 import (
 	"context"
-	"fmt"
 	"testing"
 
 	"github.com/grafana/azure-data-explorer-datasource/pkg/azuredx/models"
@@ -86,7 +85,8 @@ func TestDatasource(t *testing.T) {
 
 		res := adx.handleQuery(context.Background(), query, &backend.User{Login: UserLogin})
 		require.Error(t, res.Error)
-		require.Equal(t, res.Error, fmt.Errorf("query submitted without database specified and data source does not have a default database"))
+		require.Equal(t, res.ErrorSource, backend.ErrorSourceDownstream)
+		require.Equal(t, res.Error.Error(), "query submitted without database specified and data source does not have a default database")
 	})
 }
 

--- a/pkg/azuredx/helpers/helpers.go
+++ b/pkg/azuredx/helpers/helpers.go
@@ -2,34 +2,37 @@ package helpers
 
 import (
 	"errors"
+	"fmt"
 	"net/url"
 	"strings"
+
+	"github.com/grafana/grafana-plugin-sdk-go/experimental/errorsource"
 )
 
 // SanitizeClusterUri ensures the URI does not contain a query or fragment part
 func SanitizeClusterUri(clusterUri string) (string, error) {
 	// check for trailing question mark before parsing
 	if strings.HasSuffix(clusterUri, "?") {
-		return "", errors.New("clusterUri contains invalid query characters")
+		return "", errorsource.DownstreamError(errors.New("invalid clusterUri: clusterUri contains invalid query characters"), false)
 	}
 
 	// check for trailing question mark before parsing
 	if strings.HasSuffix(clusterUri, "#") {
-		return "", errors.New("clusterUri contains invalid fragment characters")
+		return "", errorsource.DownstreamError(errors.New("invalid clusterUri: clusterUri contains invalid fragment characters"), false)
 	}
 
 	parsedUrl, err := url.Parse(clusterUri)
 	if err != nil {
-		return "", err
+		return "", fmt.Errorf("invalid clusterUri: %w", err)
 	}
 
 	// check if the URL contains a query part or fragment
 	if parsedUrl.RawQuery != "" {
-		return "", errors.New("clusterUri contains invalid query characters")
+		return "", errorsource.DownstreamError(errors.New("invalid clusterUri: clusterUri contains invalid query characters"), false)
 	}
 
 	if parsedUrl.Fragment != "" {
-		return "", errors.New("clusterUri contains invalid fragment characters")
+		return "", errorsource.DownstreamError(errors.New("invalid clusterUri: clusterUri contains invalid fragment characters"), false)
 	}
 
 	return parsedUrl.String(), nil

--- a/src/components/QueryEditor/QueryEditor.tsx
+++ b/src/components/QueryEditor/QueryEditor.tsx
@@ -78,7 +78,11 @@ export const QueryEditor: React.FC<Props> = (props) => {
 
 function parseSchemaError(error: Error) {
   // error may be an object with a message
-  return get(error, 'data.Message', String(error));
+  let msg = get(error, 'data.Message', '');
+  if (msg === '') {
+    msg = get(error, 'data.message', '');
+  }
+  return msg || String(error);
 }
 
 const useTemplateVariables = (datasource: AdxDataSource) => {


### PR DESCRIPTION
Add `errorsource` to any errors that are downstream and may be returned at some point in the `QueryData` endpoint. A downstream error is anything that is _not_ due to the plugin directly.

Also fixed a minor bug I found when testing this where the schema retrieval would fail and an object would be returned that couldn't be parsed.