### PR TITLE
Fix bug where query row was not showing properly

### DIFF
--- a/src/components/QueryEditor/QueryEditor.tsx
+++ b/src/components/QueryEditor/QueryEditor.tsx
@@ -64,7 +64,7 @@ export const QueryEditor: React.FC<Props> = (props) => {
           setDirty={() => !dirty && setDirty(true)}
         />
       ) : null}
-      {!query.rawMode && !query.OpenAI && query.expression ? (
+      {!query.rawMode && !query.OpenAI ? (
         <VisualQueryEditor
           {...props}
           schema={schema.value}

--- a/src/components/QueryEditor/VisualQueryEditor/AggregateSection.tsx
+++ b/src/components/QueryEditor/VisualQueryEditor/AggregateSection.tsx
@@ -23,24 +23,24 @@ const AggregateSection: React.FC<AggregateSectionProps> = ({
   templateVariableOptions,
   onChange: onQueryChange,
 }) => {
-  const expressions = query.expression.reduce.expressions;
+  const expressions = query.expression?.reduce?.expressions;
   const [aggregates, setAggregates] = useState(expressions);
-  const [currentTable, setCurrentTable] = useState(query.expression.from?.property.name);
+  const [currentTable, setCurrentTable] = useState(query.expression?.from?.property.name);
 
   useEffect(() => {
     if (!aggregates.length && expressions?.length) {
       setAggregates(expressions);
     }
-  }, [aggregates.length, expressions]);
+  }, [aggregates?.length, expressions]);
 
   useEffect(() => {
     // New table
     if (currentTable !== query.expression.from?.property.name) {
       // Reset state
       setAggregates([]);
-      setCurrentTable(query.expression.from?.property.name);
+      setCurrentTable(query.expression?.from?.property.name);
     }
-  }, [currentTable, query.expression.from?.property.name]);
+  }, [currentTable, query.expression?.from?.property.name]);
 
   const onChange = (newItems: Array<Partial<QueryEditorReduceExpression>>) => {
     const cleaned = newItems.map((v): QueryEditorReduceExpression => {
@@ -67,7 +67,7 @@ const AggregateSection: React.FC<AggregateSectionProps> = ({
 
     const newExpression = {
       ...query.expression,
-      reduce: { ...query.expression.reduce, expressions: validExpressions },
+      reduce: { ...query.expression?.reduce, expressions: validExpressions },
     };
     onQueryChange({
       ...query,

--- a/src/components/QueryEditor/VisualQueryEditor/FilterSection.tsx
+++ b/src/components/QueryEditor/VisualQueryEditor/FilterSection.tsx
@@ -32,9 +32,9 @@ const FilterSection: React.FC<FilterSectionProps> = ({
         <EditorFieldGroup>
           <EditorField label="Filters" optional={true}>
             <>
-              {query.expression.where.expressions.length ? (
+              {query.expression?.where?.expressions.length ? (
                 <div className={styles.filters}>
-                  {query.expression.where.expressions.map((_, i) => (
+                  {query.expression?.where?.expressions.map((_, i) => (
                     <div key={`filter${i}`}>
                       <KQLFilter
                         index={i}

--- a/src/components/QueryEditor/VisualQueryEditor/GroupBySection.tsx
+++ b/src/components/QueryEditor/VisualQueryEditor/GroupBySection.tsx
@@ -23,24 +23,24 @@ const GroupBySection: React.FC<GroupBySectionProps> = ({
   templateVariableOptions,
   onChange: onQueryChange,
 }) => {
-  const expressions = query.expression.groupBy.expressions;
+  const expressions = query.expression?.groupBy?.expressions;
   const [groupBys, setGroupBys] = useState(expressions);
-  const [currentTable, setCurrentTable] = useState(query.expression.from?.property.name);
+  const [currentTable, setCurrentTable] = useState(query.expression?.from?.property.name);
 
   useEffect(() => {
     if (!groupBys.length && expressions?.length) {
       setGroupBys(expressions);
     }
-  }, [groupBys.length, expressions]);
+  }, [groupBys?.length, expressions]);
 
   useEffect(() => {
     // New table
-    if (currentTable !== query.expression.from?.property.name) {
+    if (currentTable !== query.expression?.from?.property.name) {
       // Reset state
       setGroupBys([]);
-      setCurrentTable(query.expression.from?.property.name);
+      setCurrentTable(query.expression?.from?.property.name);
     }
-  }, [currentTable, query.expression.from?.property.name]);
+  }, [currentTable, query.expression?.from?.property.name]);
 
   const onChange = (newItems: Array<Partial<QueryEditorGroupByExpression>>) => {
     const cleaned = newItems.map((v): QueryEditorGroupByExpression => {
@@ -66,7 +66,7 @@ const GroupBySection: React.FC<GroupBySectionProps> = ({
 
     const newExpression = {
       ...query.expression,
-      groupBy: { ...query.expression.groupBy, expressions: validExpressions },
+      groupBy: { ...query.expression?.groupBy, expressions: validExpressions },
     };
     onQueryChange({
       ...query,

--- a/src/components/QueryEditor/VisualQueryEditor/TableSection.tsx
+++ b/src/components/QueryEditor/VisualQueryEditor/TableSection.tsx
@@ -115,7 +115,7 @@ const TableSection: React.FC<TableSectionProps> = ({
           <Select
             aria-label="Columns"
             isMulti
-            value={query.expression.columns?.columns ? query.expression.columns.columns : []}
+            value={query.expression?.columns?.columns ? query.expression?.columns?.columns : []}
             options={toColumnNames(tableSchema.value || [])
               .map((c) => ({ label: c, value: c }))
               .concat({


### PR DESCRIPTION
This PR fixes a bug where the query row was not loading when a user tried to create a dashboard with ADX. In order to get the query row to show, a user would need to click on the "collapse query row" button twice which is not the intended behavior.

Closes #940 