### PR TITLE
Fixed query timeout formatting for timeout > 1m

### DIFF
--- a/pkg/azuredx/models/settings.go
+++ b/pkg/azuredx/models/settings.go
@@ -7,8 +7,9 @@ import (
 	"strconv"
 	"time"
 
-	"github.com/grafana/azure-data-explorer-datasource/pkg/azuredx/helpers"
 	"github.com/grafana/grafana-plugin-sdk-go/backend"
+
+	"github.com/grafana/azure-data-explorer-datasource/pkg/azuredx/helpers"
 )
 
 // DatasourceSettings holds the datasource configuration information for Azure Data Explorer's API

--- a/pkg/azuredx/models/settings.go
+++ b/pkg/azuredx/models/settings.go
@@ -87,13 +87,8 @@ func formatTimeout(d time.Duration) (string, error) {
 	if d > time.Hour {
 		return "", fmt.Errorf("timeout must be one hour or less")
 	}
-	hours := d / time.Hour
-	d -= hours * time.Hour
-	minutes := d / time.Minute
-	d -= minutes * time.Minute
-	seconds := d / time.Second
 
-	return fmt.Sprintf("%02d:%02d:%02d", hours, minutes, seconds), nil
+	return fmt.Sprintf("%02d:%02d:%02d", int(d.Hours()), int(d.Minutes())%60, int(d.Seconds())%60), nil
 }
 
 func envBoolOrDefault(key string, defaultValue bool) (bool, error) {

--- a/pkg/azuredx/models/settings.go
+++ b/pkg/azuredx/models/settings.go
@@ -21,7 +21,6 @@ type DatasourceSettings struct {
 	DynamicCaching     bool   `json:"dynamicCaching"`
 	EnableUserTracking bool   `json:"enableUserTracking"`
 	Application        string `json:"application"`
-	
 
 	// QueryTimeoutRaw is a duration string set in the datasource settings and corresponds
 	// to the server execution timeout.
@@ -87,16 +86,13 @@ func formatTimeout(d time.Duration) (string, error) {
 	if d > time.Hour {
 		return "", fmt.Errorf("timeout must be one hour or less")
 	}
-	if d == time.Hour {
-		return "01:00:00", nil
-	}
-	if d < time.Minute {
-		return fmt.Sprintf("00:00:%02.0f", d.Seconds()), nil
-	}
-	tMinutes := d.Truncate(time.Minute)
+	hours := d / time.Hour
+	d -= hours * time.Hour
+	minutes := d / time.Minute
+	d -= minutes * time.Minute
+	seconds := d / time.Second
 
-	tSeconds := d - tMinutes
-	return fmt.Sprintf("00:%02.0f:%02.0f)", tMinutes.Minutes(), tSeconds.Seconds()), nil
+	return fmt.Sprintf("%02.0f:%02.0f:%02.0f", hours, minutes, seconds), nil
 }
 
 func envBoolOrDefault(key string, defaultValue bool) (bool, error) {

--- a/pkg/azuredx/models/settings.go
+++ b/pkg/azuredx/models/settings.go
@@ -92,7 +92,7 @@ func formatTimeout(d time.Duration) (string, error) {
 	d -= minutes * time.Minute
 	seconds := d / time.Second
 
-	return fmt.Sprintf("%02.0f:%02.0f:%02.0f", hours, minutes, seconds), nil
+	return fmt.Sprintf("%02d:%02d:%02d", hours, minutes, seconds), nil
 }
 
 func envBoolOrDefault(key string, defaultValue bool) (bool, error) {

--- a/pkg/azuredx/models/settings_test.go
+++ b/pkg/azuredx/models/settings_test.go
@@ -1,0 +1,60 @@
+package models
+
+import (
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/suite"
+)
+
+type TestSettingsSuite struct {
+	suite.Suite
+}
+
+func Test(t *testing.T) {
+	suite.Run(t, new(TestSettingsSuite))
+}
+
+func (s *TestSettingsSuite) TestFormatTimeout() {
+	r := s.Require()
+	// create all tests for the function formatTimeout
+	tests := []struct {
+		name     string
+		duration time.Duration
+		expected string
+		err      error
+	}{
+		{
+			name:     "one hour",
+			duration: time.Hour,
+			expected: "01:00:00",
+			err:      nil,
+		},
+		{
+			name:     "less than one minute",
+			duration: time.Second * 30,
+			expected: "00:00:30",
+			err:      nil,
+		},
+		{
+			name:     "more than one minute",
+			duration: time.Minute * 2,
+			expected: "00:02:00",
+			err:      nil,
+		},
+		{
+			name:     "more than one hour",
+			duration: time.Hour * 2,
+			expected: "",
+			err:      fmt.Errorf("timeout must be one hour or less"),
+		},
+	}
+	for _, tt := range tests {
+		s.Run(tt.name, func() {
+			result, err := formatTimeout(tt.duration)
+			r.Equal(tt.expected, result)
+			r.Equal(tt.err, err)
+		})
+	}
+}

--- a/pkg/azuredx/models/settings_test.go
+++ b/pkg/azuredx/models/settings_test.go
@@ -18,7 +18,6 @@ func TestSettings(t *testing.T) {
 
 func (s *TestSettingsSuite) TestFormatTimeout() {
 	r := s.Require()
-	// create all tests for the function formatTimeout
 	tests := []struct {
 		name     string
 		duration time.Duration

--- a/pkg/azuredx/models/settings_test.go
+++ b/pkg/azuredx/models/settings_test.go
@@ -12,7 +12,7 @@ type TestSettingsSuite struct {
 	suite.Suite
 }
 
-func Test(t *testing.T) {
+func TestSettings(t *testing.T) {
 	suite.Run(t, new(TestSettingsSuite))
 }
 


### PR DESCRIPTION
Setting query timeout value that is larger than a minute caused the value that is sent to the server to have a trailing ")" in the end of it. This causes the timeout value to be ignored and fallback to the default value.

Notice the trailing comma in line 99 of the source file