### PR TITLE
Added loading indicator

### DIFF
--- a/src/components/QueryEditor/QueryEditor.tsx
+++ b/src/components/QueryEditor/QueryEditor.tsx
@@ -1,5 +1,5 @@
-import { QueryEditorProps } from '@grafana/data';
-import { Alert } from '@grafana/ui';
+import { LoadingState, QueryEditorProps } from '@grafana/data';
+import { Alert, LoadingBar } from '@grafana/ui';
 import { get } from 'lodash';
 import { migrateQuery, needsToBeMigrated } from 'migrations/query';
 import React, { useMemo, useState } from 'react';
@@ -19,6 +19,7 @@ export const QueryEditor: React.FC<Props> = (props) => {
   const schema = useAsync(() => datasource.getSchema(query.clusterUri, false), [datasource.id, query.clusterUri]);
   const templateVariables = useTemplateVariables(datasource);
   const [dirty, setDirty] = useState(false);
+  const isLoading = useMemo(()=> props.data?.state === LoadingState.Loading, [props.data?.state]);
 
   useEffectOnce(() => {
     let processedQuery = query;
@@ -35,6 +36,7 @@ export const QueryEditor: React.FC<Props> = (props) => {
   return (
     <>
       {schema.error && <Alert title="Could not load datasource schema">{parseSchemaError(schema.error)}</Alert>}
+      {isLoading ? <LoadingBar width={window.innerWidth} /> : <div style={{ height: 1 }} />}
       <QueryHeader
         query={query}
         onChange={onChange}
@@ -44,6 +46,7 @@ export const QueryEditor: React.FC<Props> = (props) => {
         setDirty={setDirty}
         onRunQuery={onRunQuery}
         templateVariableOptions={templateVariables}
+        isLoading={isLoading}
       />
       {query.OpenAI ? (
         <OpenAIEditor

--- a/src/components/QueryEditor/QueryHeader.tsx
+++ b/src/components/QueryEditor/QueryHeader.tsx
@@ -1,5 +1,7 @@
-import React, { useMemo, useState, useEffect } from 'react';
+import React, { useEffect, useMemo, useState } from 'react';
 
+import { openai } from '@grafana/llm';
+import { EditorHeader, FlexItem, InlineSelect } from '@grafana/plugin-ui';
 import {
   Alert,
   Button,
@@ -8,22 +10,20 @@ import {
   CustomScrollbar,
   LoadingPlaceholder,
   RadioButtonGroup,
-  useStyles2,
+  useStyles2
 } from '@grafana/ui';
-import { EditorHeader, FlexItem, InlineSelect } from '@grafana/plugin-ui';
-import { openai } from '@grafana/llm';
 
-import { AdxSchema, ClusterOption, defaultQuery, EditorMode, FormatOptions, KustoQuery } from '../../types';
-import { AsyncState } from 'react-use/lib/useAsyncFn';
-import { AdxDataSource } from 'datasource';
-import { QueryEditorPropertyDefinition, QueryEditorPropertyType } from 'schema/types';
-import { useAsync } from 'react-use';
-import { databaseToDefinition } from 'schema/mapper';
+import { css } from '@emotion/css';
 import { GrafanaTheme2, renderMarkdown, SelectableValue } from '@grafana/data';
 import { reportInteraction } from '@grafana/runtime';
+import { AdxDataSource } from 'datasource';
+import { useAsync } from 'react-use';
+import { AsyncState } from 'react-use/lib/useAsyncFn';
 import { parseClustersResponse } from 'response_parser';
-import { css } from '@emotion/css';
+import { databaseToDefinition } from 'schema/mapper';
+import { QueryEditorPropertyDefinition, QueryEditorPropertyType } from 'schema/types';
 import { selectors } from 'test/selectors';
+import { AdxSchema, ClusterOption, defaultQuery, EditorMode, FormatOptions, KustoQuery } from '../../types';
 
 export interface QueryEditorHeaderProps {
   datasource: AdxDataSource;
@@ -34,6 +34,7 @@ export interface QueryEditorHeaderProps {
   onChange: (value: KustoQuery) => void;
   onRunQuery: () => void;
   templateVariableOptions: SelectableValue<string>;
+  isLoading?: boolean;
 }
 
 const EDITOR_MODES = [
@@ -56,7 +57,7 @@ const adxTimeFormat: SelectableValue<string> = {
 
 export const QueryHeader = (props: QueryEditorHeaderProps) => {
   const TOKEN_NOT_FOUND = 'An error occurred generating your query, tweak your prompt and try again.';
-  const { query, onChange, schema, datasource, dirty, setDirty, onRunQuery, templateVariableOptions } = props;
+  const { query, onChange, schema, datasource, dirty, setDirty, onRunQuery, templateVariableOptions, isLoading } = props;
   const { rawMode, OpenAI } = query;
   const [clusterUri, setClusterUri] = useState(query.clusterUri);
   const [clusters, setClusters] = useState<Array<SelectableValue<string>>>([]);
@@ -230,7 +231,7 @@ export const QueryHeader = (props: QueryEditorHeaderProps) => {
       {!query.OpenAI && (
         <Button
           variant="primary"
-          icon="play"
+          icon={isLoading ? 'spinner' : 'play'}
           size="sm"
           onClick={onRunQuery}
           data-testid={selectors.components.queryEditor.runQuery.button}


### PR DESCRIPTION
There's no indication when the data source is loading new data. 
That might cause the user to click "Run Query" in frustration and wonder why their computer is not working correctly.
That could lead to them addressing IT and demanding a new MacBook pro (the M4 kind) only later to have this request rejected. Furious, they might be addressing the site manager to file a formal complaint only to discover the IT guy had already file a similar complaint about them wasting company resources. 
This could lead to a huge argument, resulting with the firing of said individual.

So I thought I could save them the hassle and just add a loading indicator. 👍 