### PR TITLE
GHA: Harden workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,10 +10,11 @@ on:
 
 permissions:
   contents: read
-  id-token: write
 
 jobs:
   build:
+    permissions:
+      id-token: write
     runs-on: ubuntu-latest
     outputs:
       plugin-id: ${{ steps.metadata.outputs.plugin-id }}
@@ -21,7 +22,8 @@ jobs:
       archive: ${{ steps.metadata.outputs.archive }}
     steps:
       - uses: actions/checkout@v4
-
+        with:
+          persist-credentials: false
       - name: Setup Node.js environment
         uses: actions/setup-node@v4
         with:
@@ -49,13 +51,13 @@ jobs:
           go-version-file: go.mod
 
       - name: Test backend
-        uses: magefile/mage-action@v3
+        uses: magefile/mage-action@6f50bbb8ea47d56e62dee92392788acbc8192d0b
         with:
           version: latest
           args: coverage
 
       - name: Build backend
-        uses: magefile/mage-action@v3
+        uses: magefile/mage-action@6f50bbb8ea47d56e62dee92392788acbc8192d0b
         with:
           version: latest
           args: buildAll
@@ -75,15 +77,22 @@ jobs:
 
       - name: Package plugin
         id: package-plugin
+        env:
+          PLUGIN_ID: ${{ steps.metadata.outputs.plugin-id }}
+          PLUGIN_ARCHIVE: ${{ steps.metadata.outputs.archive }}
         run: |
-          mv dist ${{ steps.metadata.outputs.plugin-id }}
-          zip ${{ steps.metadata.outputs.archive }} ${{ steps.metadata.outputs.plugin-id }} -r
+          mv dist ${PLUGIN_ID}
+          zip ${PLUGIN_ARCHIVE} ${PLUGIN_ID} -r
 
       - name: Archive Build
         uses: actions/upload-artifact@v4
+        env:
+          PLUGIN_ID: ${{ steps.metadata.outputs.plugin-id }}
+          PLUGIN_VERSION: ${{ steps.metadata.outputs.plugin-version }}
+          PLUGIN_ARCHIVE: ${{ steps.metadata.outputs.archive }}
         with:
-          name: ${{ steps.metadata.outputs.plugin-id }}-${{ steps.metadata.outputs.plugin-version }}
-          path: ${{ steps.metadata.outputs.archive }}
+          name: ${PLUGIN_ID}-${PLUGIN_VERSION}
+          path: ${PLUGIN_ARCHIVE}
           retention-days: 5
 
   resolve-versions:
@@ -111,6 +120,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
 
       - name: Setup Node.js environment
         uses: actions/setup-node@v4
@@ -131,9 +142,12 @@ jobs:
           name: ${{ needs.build.outputs.plugin-id }}-${{ needs.build.outputs.plugin-version }}
 
       - name: Unpack build
+        env:
+          PLUGIN_ID: ${{ needs.build.outputs.plugin-id }}
+          PLUGIN_ARCHIVE: ${{ needs.build.outputs.archive }}
         run: |
-          unzip ${{ needs.build.outputs.archive }}
-          mv ${{ needs.build.outputs.plugin-id }} dist
+          unzip ${PLUGIN_ARCHIVE}
+          mv ${PLUGIN_ID} dist
 
       - name: Get secrets
         id: get-secrets
@@ -170,6 +184,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
 
       - name: Setup Node.js environment
         uses: actions/setup-node@v4
@@ -190,9 +206,12 @@ jobs:
           name: ${{ needs.build.outputs.plugin-id }}-${{ needs.build.outputs.plugin-version }}
 
       - name: Unpack build
+        env:
+          PLUGIN_ID: ${{ needs.build.outputs.plugin-id }}
+          PLUGIN_ARCHIVE: ${{ needs.build.outputs.archive }}
         run: |
-          unzip ${{ needs.build.outputs.archive }}
-          mv ${{ needs.build.outputs.plugin-id }} dist
+          unzip ${PLUGIN_ARCHIVE}
+          mv ${PLUGIN_ID} dist
 
       - name: Start Grafana
         shell: bash

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -100,7 +100,7 @@ jobs:
     steps:
       - name: Resolve Grafana E2E versions
         id: resolve-versions
-        uses: grafana/plugin-actions/e2e-version@main
+        uses: grafana/plugin-actions/e2e-version@bf335ac99375f0ba8828497abdf1a22897b5d888
         with:
           version-resolver-type: version-support-policy
 
@@ -147,7 +147,7 @@ jobs:
 
       - name: Get secrets
         id: get-secrets
-        uses: grafana/shared-workflows/actions/get-vault-secrets@main
+        uses: grafana/shared-workflows/actions/get-vault-secrets@5d7e361bc7e0a183cde8afe9899fb7b596d2659b
         with:
           repo_secrets: |
             TENANT_ID=e2e:tenantId

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -86,13 +86,9 @@ jobs:
 
       - name: Archive Build
         uses: actions/upload-artifact@v4
-        env:
-          PLUGIN_ID: ${{ steps.metadata.outputs.plugin-id }}
-          PLUGIN_VERSION: ${{ steps.metadata.outputs.plugin-version }}
-          PLUGIN_ARCHIVE: ${{ steps.metadata.outputs.archive }}
         with:
-          name: ${PLUGIN_ID}-${PLUGIN_VERSION}
-          path: ${PLUGIN_ARCHIVE}
+          name: ${{ steps.metadata.outputs.plugin-id }}-${{ steps.metadata.outputs.plugin-version }}
+          path: ${{ steps.metadata.outputs.archive }}
           retention-days: 5
 
   resolve-versions:

--- a/.github/workflows/dependabot-reviewer.yml
+++ b/.github/workflows/dependabot-reviewer.yml
@@ -1,6 +1,6 @@
 name: Dependabot reviewer
 
-on: pull_request_target
+on: pull_request_target # zizmor: ignore[dangerous-triggers]
 
 permissions:
   pull-requests: write

--- a/.github/workflows/dependabot-reviewer.yml
+++ b/.github/workflows/dependabot-reviewer.yml
@@ -1,6 +1,6 @@
 name: Dependabot reviewer
 
-on: pull_request_target # zizmor: ignore[dangerous-triggers]
+on: pull_request_target # zizmor: ignore[dangerous-triggers]   
 
 permissions:
   pull-requests: write

--- a/.github/workflows/detect-breaking-changes.yml
+++ b/.github/workflows/detect-breaking-changes.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Build plugin
         run: yarn build
       - name: Compatibility check
-        uses: grafana/plugin-actions/is-compatible@v1
+        uses: grafana/plugin-actions/is-compatible@f567fc6454619e6c8dbc2f91692197457c10a02b
         with:
           module: './src/module.ts'
           comment-pr: 'yes'

--- a/.github/workflows/detect-breaking-changes.yml
+++ b/.github/workflows/detect-breaking-changes.yml
@@ -6,6 +6,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+
       - uses: actions/setup-node@v4
         with:
           node-version-file: '.nvmrc'

--- a/.github/workflows/issue_commands.yml
+++ b/.github/workflows/issue_commands.yml
@@ -9,9 +9,10 @@ jobs:
       - name: Checkout Actions
         uses: actions/checkout@v4
         with:
-          repository: "grafana/grafana-github-actions"
+          repository: 'grafana/grafana-github-actions'
           path: ./actions
           ref: main
+          persist-credentials: false
       - name: Install Actions
         run: npm install --production --prefix ./actions
       - name: Run Commands

--- a/.github/workflows/pull-request-image.yml
+++ b/.github/workflows/pull-request-image.yml
@@ -9,10 +9,6 @@ on:
     branches:
       - main
 
-permissions:
-  pull-requests: write
-  issues: write
-
 jobs:
   build:
     name: Build and archive plugin build artifacts
@@ -22,6 +18,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
 
       - name: Setup Node.js environment
         uses: actions/setup-node@v4
@@ -67,10 +65,15 @@ jobs:
 
       - name: Generate Dockerfile
         shell: bash
+        env:
+          GITHUB_REPOSITORY_NAME: ${{ github.event.repository.name }}
+          EVENT_NAME: ${{ github.event_name }}
+          PR_SHA: ${{ github.event.pull_request.head.sha }}
+          PR_NUMBER: ${{ github.event.number }}
         run: |
-          if [ "${{ github.event_name }}" == "pull_request" ]; then
-            SHA="${{ github.event.pull_request.head.sha }}"
-            NUMBER="${{ github.event.number }}"
+          if [ "${EVENT_NAME}" == "pull_request" ]; then
+            SHA="${PR_SHA}"
+            NUMBER="${PR_NUMBER}"
           else
             SHA=${GITHUB_SHA}
             NUMBER="main"
@@ -90,21 +93,21 @@ jobs:
           # TODO: Cleanup script should remove images from closed PRs using these labels
           LABEL gh-sha=${SHA}
 
-          LABEL gh-repo="${{ github.event.repository.name }}"
+          LABEL gh-repo="${GITHUB_REPOSITORY_NAME}"
 
           LABEL gh-pr-number=${NUMBER}
 
           # Copy plugin build artifacts into the image
-          COPY . /var/lib/grafana/plugins/${{ github.event.repository.name }}/" > Dockerfile
+          COPY . /var/lib/grafana/plugins/${GITHUB_REPOSITORY_NAME}/" > Dockerfile
 
       - name: Log in to Docker Hub
-        uses: docker/login-action@v3
+        uses: docker/login-action@74a5d142397b4f367a81961eba4e8cd7edddf772
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
       - name: Build and push Docker image for PRs
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@14487ce63c7a62a4a324b0bfb37086795e31c6c1
         if: ${{ github.event_name == 'pull_request' }}
         with:
           context: .
@@ -113,7 +116,7 @@ jobs:
           tags: grafana/plugin-builds:${{ github.event.pull_request.head.sha }}pre
 
       - name: Build and push Docker image for main branch
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@14487ce63c7a62a4a324b0bfb37086795e31c6c1
         if: ${{ github.event_name == 'push' }}
         with:
           context: .
@@ -123,12 +126,15 @@ jobs:
 
   add_pr_comment:
     name: Add PR comment
+    permissions:
+      pull-requests: write
+      issues: write
     runs-on: ubuntu-latest
     needs: push_to_registry
     if: ${{ github.event_name == 'pull_request' }} && false
     steps:
       - name: Find previous comment (if any)
-        uses: peter-evans/find-comment@v3
+        uses: peter-evans/find-comment@3eae4d37986fb5a8592848f6a574fdf654e61f9e
         id: fc
         with:
           issue-number: ${{ github.event.number }}
@@ -136,7 +142,7 @@ jobs:
 
       - name: Update comment on PR
         if: steps.fc.outputs.comment-id != ''
-        uses: peter-evans/create-or-update-comment@v4
+        uses: peter-evans/create-or-update-comment@71345be0265236311c031f5c7866368bd1eff043
         with:
           comment-id: ${{ steps.fc.outputs.comment-id }}
           edit-mode: replace
@@ -150,7 +156,7 @@ jobs:
 
       - name: Add comment to PR
         if: steps.fc.outputs.comment-id == ''
-        uses: peter-evans/create-or-update-comment@v4
+        uses: peter-evans/create-or-update-comment@71345be0265236311c031f5c7866368bd1eff043
         with:
           issue-number: ${{ github.event.number }}
           body: |


### PR DESCRIPTION
Fixing a bunch of issues reported by `zizmor`.

- Fix template injection issues.
- Pin third-party GitHub actions to specific SHAs. Excluding GitHub owned actions.
- Appropriately set permissions in workflows.
- Improve safety of checkout action.