### PR TITLE
Improve OBO related error messages

### DIFF
--- a/pkg/azuredx/adxauth/obo_token_provider.go
+++ b/pkg/azuredx/adxauth/obo_token_provider.go
@@ -87,7 +87,7 @@ func (provider *onBehalfOfTokenProvider) GetAccessToken(ctx context.Context, sco
 	}
 
 	if currentUser.IdToken == "" {
-		err := fmt.Errorf("user context doesn't have ID token, , are you signed in with Azure AD?")
+		err := fmt.Errorf("user context doesn't have ID token, are you signed in with Azure AD?")
 		return "", err
 	}
 


### PR DESCRIPTION
Improve error messaging related to OBO authentication issues and return early with an appropriate error if the toggle is not enabled.

Fixes #538 