### PR TITLE
Improve performance of schema loading

### DIFF
--- a/pkg/azuredx/resource_handler.go
+++ b/pkg/azuredx/resource_handler.go
@@ -3,6 +3,7 @@ package azuredx
 import (
 	"bytes"
 	"encoding/json"
+	"fmt"
 	"io"
 	"net/http"
 	"strings"
@@ -126,6 +127,7 @@ func (adx *AzureDataExplorer) getSchema(rw http.ResponseWriter, req *http.Reques
 
 	var cluster struct {
 		ClusterUri string `json:"clusterUri,omitempty"`
+		Database   string `json:"database,omitempty"`
 	}
 
 	err = json.Unmarshal(body, &cluster)
@@ -137,8 +139,14 @@ func (adx *AzureDataExplorer) getSchema(rw http.ResponseWriter, req *http.Reques
 		cluster.ClusterUri = adx.settings.ClusterURL
 	}
 
+	query := fmt.Sprintf(".show databases (['%s']) schema as json", cluster.Database)
+
+	if cluster.Database == "" {
+		query = ".show databases schema as json"
+	}
+
 	payload := models.RequestPayload{
-		CSL:         ".show databases schema as json",
+		CSL:         query,
 		QuerySource: "schema",
 	}
 

--- a/pkg/azuredx/resource_handler.go
+++ b/pkg/azuredx/resource_handler.go
@@ -139,12 +139,11 @@ func (adx *AzureDataExplorer) getSchema(rw http.ResponseWriter, req *http.Reques
 		cluster.ClusterUri = adx.settings.ClusterURL
 	}
 
-	query := fmt.Sprintf(".show databases (['%s']) schema as json", cluster.Database)
+	query := ".show databases schema as json"
 
-	if cluster.Database == "" {
-		query = ".show databases schema as json"
+	if cluster.Database != "" {
+		query = fmt.Sprintf(".show databases (['%s']) schema as json", cluster.Database)
 	}
-
 	payload := models.RequestPayload{
 		CSL:         query,
 		QuerySource: "schema",

--- a/src/components/ConfigEditor/refreshSchema.ts
+++ b/src/components/ConfigEditor/refreshSchema.ts
@@ -13,7 +13,7 @@ export async function refreshSchema(datasource: AdxDataSource): Promise<Schema> 
   const databases: Array<{ label: string; value: string }> = [];
   const schemaMappingOptions: SchemaMappingOption[] = [];
 
-  const schema = await datasource.getSchema('');
+  const schema = await datasource.getSchema('', '');
   for (const database of Object.values(schema.Databases)) {
     databases.push({
       label: database.Name,

--- a/src/components/QueryEditor/QueryEditor.test.tsx
+++ b/src/components/QueryEditor/QueryEditor.test.tsx
@@ -3,7 +3,6 @@ import React from 'react';
 import { QueryEditor } from './QueryEditor';
 import { render, screen, waitFor } from '@testing-library/react';
 import { AdxQueryType, defaultQuery, EditorMode } from 'types';
-import { QueryEditorExpressionType } from 'types/expressions';
 
 jest.mock('@grafana/runtime', () => {
   const original = jest.requireActual('@grafana/runtime');

--- a/src/components/QueryEditor/QueryEditor.test.tsx
+++ b/src/components/QueryEditor/QueryEditor.test.tsx
@@ -3,6 +3,7 @@ import React from 'react';
 import { QueryEditor } from './QueryEditor';
 import { render, screen, waitFor } from '@testing-library/react';
 import { AdxQueryType, defaultQuery, EditorMode } from 'types';
+import { QueryEditorExpressionType } from 'types/expressions';
 
 jest.mock('@grafana/runtime', () => {
   const original = jest.requireActual('@grafana/runtime');
@@ -28,7 +29,7 @@ describe('QueryEditor', () => {
       const onChange = jest.fn();
       const ds = mockDatasource();
       ds.getClusters = jest.fn().mockResolvedValue([]);
-      const query = { ...mockQuery, pluginVersion: '', queryType: '' as AdxQueryType };
+      const query = { ...mockQuery, database: 'test-db', pluginVersion: '', queryType: '' as AdxQueryType };
       render(<QueryEditor {...defaultProps} onChange={onChange} query={query} datasource={ds} />);
       expect(onChange).toHaveBeenCalledWith(expect.objectContaining({ pluginVersion: defaultQuery.pluginVersion }));
       // wait to load
@@ -37,7 +38,7 @@ describe('QueryEditor', () => {
 
     it('should set the default raw mode', async () => {
       const onChange = jest.fn();
-      const query = { ...mockQuery, rawMode: undefined };
+      const query = { ...mockQuery, rawMode: undefined, database: 'test-db' };
       const ds = mockDatasource();
       ds.getDefaultEditorMode = jest.fn().mockReturnValue(EditorMode.Raw);
       ds.getClusters = jest.fn().mockResolvedValue([]);
@@ -62,7 +63,16 @@ describe('QueryEditor', () => {
         },
       });
       ds.getClusters = jest.fn().mockResolvedValue([]);
-      render(<QueryEditor {...defaultProps} datasource={ds} />);
+      render(
+        <QueryEditor
+          {...defaultProps}
+          datasource={ds}
+          query={{
+            ...mockQuery,
+            database: 'test-db',
+          }}
+        />
+      );
       await waitFor(() => screen.getByText('Could not load datasource schema'));
       await waitFor(() => screen.getByText('Boom!'));
     });
@@ -71,7 +81,16 @@ describe('QueryEditor', () => {
       const ds = mockDatasource();
       ds.getClusters = jest.fn().mockResolvedValue([]);
       ds.getSchema = jest.fn().mockRejectedValue('Boom!');
-      render(<QueryEditor {...defaultProps} datasource={ds} />);
+      render(
+        <QueryEditor
+          {...defaultProps}
+          datasource={ds}
+          query={{
+            ...mockQuery,
+            database: 'test-db',
+          }}
+        />
+      );
       await waitFor(() => screen.getByText('Could not load datasource schema'));
       await waitFor(() => screen.getByText('Boom!'));
     });

--- a/src/components/QueryEditor/QueryEditor.tsx
+++ b/src/components/QueryEditor/QueryEditor.tsx
@@ -17,8 +17,18 @@ type Props = QueryEditorProps<AdxDataSource, KustoQuery, AdxDataSourceOptions>;
 
 export const QueryEditor: React.FC<Props> = (props) => {
   const { onChange, onRunQuery, query, datasource } = props;
-  const schema = useAsync(() => datasource.getSchema(query.clusterUri, query.database, false), [datasource.id, query.clusterUri, query.database]);
-  const databases = useAsync(() => datasource.getDatabases(query.clusterUri), [datasource.id, query.clusterUri, query.database]);
+  const schema = useAsync(() => {
+    if (query.database) {
+      const schema = datasource.getSchema(query.clusterUri, query.database, false);
+      return schema;
+    }
+
+    return Promise.resolve(undefined);
+  }, [datasource.id, query.clusterUri, query.database]);
+  const databases = useAsync(
+    () => datasource.getDatabases(query.clusterUri),
+    [datasource.id, query.clusterUri, query.database]
+  );
 
   const templateVariables = useTemplateVariables(datasource);
   const [dirty, setDirty] = useState(false);

--- a/src/components/QueryEditor/QueryEditor.tsx
+++ b/src/components/QueryEditor/QueryEditor.tsx
@@ -1,11 +1,11 @@
 import { t } from '@grafana/i18n';
 import { LoadingState, QueryEditorProps } from '@grafana/data';
 import { Alert, LoadingBar } from '@grafana/ui';
-import { get, set } from 'lodash';
+import { get } from 'lodash';
 import { migrateQuery, needsToBeMigrated } from 'migrations/query';
-import React, { useEffect, useMemo, useState } from 'react';
+import React, { useMemo, useState } from 'react';
 import { useAsync, useEffectOnce } from 'react-use';
-import { AdxDataSourceOptions, AdxSchema, EditorMode, KustoQuery } from 'types';
+import { AdxDataSourceOptions, EditorMode, KustoQuery } from 'types';
 
 import { AdxDataSource } from '../../datasource';
 import { OpenAIEditor } from './OpenAIEditor';
@@ -18,11 +18,7 @@ type Props = QueryEditorProps<AdxDataSource, KustoQuery, AdxDataSourceOptions>;
 export const QueryEditor: React.FC<Props> = (props) => {
   const { onChange, onRunQuery, query, datasource } = props;
   const schema = useAsync(() => datasource.getSchema(query.clusterUri, query.database, false), [datasource.id, query.clusterUri, query.database]);
-
-  const databases = useAsync(
-    () => datasource.getDatabases(query.clusterUri),
-    [datasource.id, query.clusterUri, query.database]
-  );
+  const databases = useAsync(() => datasource.getDatabases(query.clusterUri), [datasource.id, query.clusterUri, query.database]);
 
   const templateVariables = useTemplateVariables(datasource);
   const [dirty, setDirty] = useState(false);
@@ -39,7 +35,6 @@ export const QueryEditor: React.FC<Props> = (props) => {
     onChange(processedQuery);
     onRunQuery();
   });
-
 
   return (
     <>

--- a/src/components/QueryEditor/QueryHeader.test.tsx
+++ b/src/components/QueryEditor/QueryHeader.test.tsx
@@ -6,7 +6,6 @@ import { openMenu } from 'react-select-event';
 import { mockDatasource, mockQuery } from '../__fixtures__/Datasource';
 import { AsyncState } from 'react-use/lib/useAsyncFn';
 import { defaultQuery } from 'types';
-import schema from 'components/__fixtures__/schema';
 import { DatabaseItem } from 'response_parser';
 
 jest.mock('@grafana/runtime', () => {
@@ -175,18 +174,7 @@ describe('QueryEditor', () => {
               rawMode: true,
             }}
             onChange={onChange}
-            databases={{
-              loading: false,
-              value: Object.values(schema().Databases).map((db) => ({
-                text: db.Name,
-                value: db.Name,
-                name: db.Name,
-                tables: db.Tables,
-                externalTables: db.ExternalTables,
-                functions: db.Functions,
-                materializedViews: db.MaterializedViews,
-              })),
-            }}
+            databases={databases}
           />
         )
       );

--- a/src/datasource.test.ts
+++ b/src/datasource.test.ts
@@ -99,7 +99,7 @@ describe('AdxDataSource', () => {
     });
 
     it('should return a parsed schema', () => {
-      return ctx.ds.getSchema('clusterUri').then((result) => {
+      return ctx.ds.getSchema('clusterUri', 'database').then((result) => {
         expect(Object.keys(result.Databases.Grafana.Tables).length).toBe(1);
         expect(result.Databases.Grafana.Tables.MyLogs.Name).toBe('MyLogs');
       });

--- a/src/datasource.ts
+++ b/src/datasource.ts
@@ -175,7 +175,7 @@ export class AdxDataSource extends DataSourceWithBackend<KustoQuery, AdxDataSour
     const replacedClusterUri = this.templateSrv.replace(clusterUri, this.templateSrv.getVariables() as any);
     const replacedDatabase = this.templateSrv.replace(database, this.templateSrv.getVariables() as any);
     return cache<AdxSchema>(
-      `${this.id}.${replacedClusterUri}.schema.overview`,
+      `${this.id}.${replacedClusterUri}.${replacedDatabase}.schema.overview`,
       () =>
         this.postResource(`schema`, { clusterUri: replacedClusterUri, database: replacedDatabase }).then(
           new ResponseParser().parseSchemaResult

--- a/src/datasource.ts
+++ b/src/datasource.ts
@@ -7,13 +7,14 @@ import {
   TimeRange,
 } from '@grafana/data';
 import { BackendSrv, DataSourceWithBackend, getBackendSrv, getTemplateSrv, TemplateSrv } from '@grafana/runtime';
-import { QueryEditorPropertyType } from './schema/types';
-import { KustoExpressionParser, escapeColumn } from 'KustoExpressionParser';
+import { escapeColumn, KustoExpressionParser } from 'KustoExpressionParser';
 import { map } from 'lodash';
 import { AdxSchemaMapper } from 'schema/AdxSchemaMapper';
 import { cache } from 'schema/cache';
 import { toPropertyType } from 'schema/mapper';
+import { QueryEditorPropertyType } from './schema/types';
 
+import { VariableSupport } from 'variables';
 import { migrateAnnotation } from './migrations/annotation';
 import interpolateKustoQuery from './query_builder';
 import { DatabaseItem, KustoDatabaseList, ResponseParser } from './response_parser';
@@ -29,15 +30,14 @@ import {
   KustoQuery,
   QueryExpression,
 } from './types';
-import { VariableSupport } from 'variables';
 
+import { createOperator } from 'components/QueryEditor/VisualQueryEditor/utils/utils';
 import { lastValueFrom } from 'rxjs';
 import {
   QueryEditorExpressionType,
   QueryEditorOperatorExpression,
   QueryEditorWhereExpression,
 } from 'types/expressions';
-import { createOperator } from 'components/QueryEditor/VisualQueryEditor/utils/utils';
 
 export class AdxDataSource extends DataSourceWithBackend<KustoQuery, AdxDataSourceOptions> {
   private backendSrv: BackendSrv;
@@ -161,17 +161,25 @@ export class AdxDataSource extends DataSourceWithBackend<KustoQuery, AdxDataSour
     });
   }
 
-  async getSchema(clusterUri: string, refreshCache = false): Promise<AdxSchema> {
-    if (!clusterUri && !this.instanceSettings?.jsonData?.clusterUrl) {
+  async getSchema(clusterUri: string, database: string, refreshCache = false): Promise<AdxSchema> {
+    if (
+      !clusterUri &&
+      !this.instanceSettings?.jsonData?.clusterUrl &&
+      !database &&
+      !this.instanceSettings?.jsonData?.defaultDatabase
+    ) {
       return new Promise((resolve) => {
         resolve({} as AdxSchema);
       });
     }
     const replacedClusterUri = this.templateSrv.replace(clusterUri, this.templateSrv.getVariables() as any);
+    const replacedDatabase = this.templateSrv.replace(database, this.templateSrv.getVariables() as any);
     return cache<AdxSchema>(
       `${this.id}.${replacedClusterUri}.schema.overview`,
       () =>
-        this.postResource(`schema`, { clusterUri: replacedClusterUri }).then(new ResponseParser().parseSchemaResult),
+        this.postResource(`schema`, { clusterUri: replacedClusterUri, database: replacedDatabase }).then(
+          new ResponseParser().parseSchemaResult
+        ),
       refreshCache
     );
   }
@@ -316,7 +324,7 @@ export class AdxDataSource extends DataSourceWithBackend<KustoQuery, AdxDataSour
     return this.defaultEditorMode;
   }
   getApplication(): string {
-    return this.application
+    return this.application;
   }
 
   async autoCompleteQuery(query: AutoCompleteQuery, columns: AdxColumnSchema[] | undefined): Promise<string[]> {
@@ -334,7 +342,7 @@ export class AdxDataSource extends DataSourceWithBackend<KustoQuery, AdxDataSour
       query: autoQuery,
       resultFormat: 'table',
       querySource: 'autocomplete',
-      clusterUri: query.clusterUri
+      clusterUri: query.clusterUri,
     };
 
     const response = await lastValueFrom(

--- a/src/datasource.ts
+++ b/src/datasource.ts
@@ -164,7 +164,7 @@ export class AdxDataSource extends DataSourceWithBackend<KustoQuery, AdxDataSour
   async getSchema(clusterUri: string, database: string, refreshCache = false): Promise<AdxSchema> {
     if (
       !clusterUri &&
-      !this.instanceSettings?.jsonData?.clusterUrl &&
+      !this.instanceSettings?.jsonData?.clusterUrl ||
       !database &&
       !this.instanceSettings?.jsonData?.defaultDatabase
     ) {

--- a/src/schema/AdxSchemaResolver.test.ts
+++ b/src/schema/AdxSchemaResolver.test.ts
@@ -14,7 +14,7 @@ describe('Test schema resolution', () => {
   });
 
   it('Will correctly retrieve databases', async () => {
-    const databases = await schemaResolver.getDatabases('testClusterUri');
+    const databases = await schemaResolver.getSchemaForDatabase('testClusterUri');
     expect(databases).toHaveLength(1);
     expect(databases[0]).toEqual(schema.Databases['testdb']);
   });

--- a/src/schema/AdxSchemaResolver.test.ts
+++ b/src/schema/AdxSchemaResolver.test.ts
@@ -2,19 +2,24 @@ import { mockDatasource } from 'components/__fixtures__/Datasource';
 import createMockSchema from 'components/__fixtures__/schema';
 
 import { AdxSchemaResolver } from './AdxSchemaResolver';
+import { DatabaseItem } from 'response_parser';
 
 describe('Test schema resolution', () => {
   const datasource = mockDatasource();
   const schemaResolver = new AdxSchemaResolver(datasource);
   const schema = createMockSchema();
+  const databaseItems: DatabaseItem[] = [
+    { text: 'foo', value: 'foo' },
+  ];
 
   beforeEach(() => {
     datasource.getSchema = jest.fn().mockResolvedValue(schema);
+    datasource.getDatabases = jest.fn().mockResolvedValue(databaseItems);
     datasource.getDynamicSchema = jest.fn().mockResolvedValue([{ Name: 'testprop', CslType: 'string' }]);
   });
 
   it('Will correctly retrieve databases', async () => {
-    const databases = schemaResolver.getDatabaseSchema('testClusterUri', 'test');
+    const databases = await schemaResolver.getDatabaseSchema('testClusterUri', 'test');
     expect(databases).toHaveLength(1);
     expect(databases[0]).toEqual(schema.Databases['testdb']);
   });

--- a/src/schema/AdxSchemaResolver.test.ts
+++ b/src/schema/AdxSchemaResolver.test.ts
@@ -14,7 +14,7 @@ describe('Test schema resolution', () => {
   });
 
   it('Will correctly retrieve databases', async () => {
-    const databases = await schemaResolver.getSchemaForDatabase('testClusterUri');
+    const databases = schemaResolver.getDatabaseSchema('testClusterUri', 'test');
     expect(databases).toHaveLength(1);
     expect(databases[0]).toEqual(schema.Databases['testdb']);
   });

--- a/src/schema/AdxSchemaResolver.ts
+++ b/src/schema/AdxSchemaResolver.ts
@@ -1,3 +1,4 @@
+import { AdxDataSource } from '../datasource';
 import {
   AdxColumnSchema,
   AdxDatabaseSchema,
@@ -6,7 +7,6 @@ import {
   SchemaMapping,
   SchemaMappingType,
 } from '../types';
-import { AdxDataSource } from '../datasource';
 import { cache } from './cache';
 
 const schemaKey = 'AdxSchemaResolver';
@@ -18,13 +18,13 @@ export class AdxSchemaResolver {
     return `${schemaKey}.${this.datasource.id}.${addition}`;
   }
 
-  async getDatabases(clusterUri: string): Promise<AdxDatabaseSchema[]> {
-    const schema = await this.datasource.getSchema(clusterUri);
+  async getDatabaseSchema(clusterUri: string, database: string): Promise<AdxDatabaseSchema[]> {
+    const schema = await this.datasource.getSchema(clusterUri, database);
     return Object.keys(schema.Databases).map((key) => schema.Databases[key]);
   }
 
   async getTablesForDatabase(databaseName: string, clusterUri: string): Promise<AdxTableSchema[]> {
-    const databases = await this.getDatabases(clusterUri);
+    const databases = await this.getDatabaseSchema(clusterUri, databaseName);
     const database = databases.find((db) => db.Name === databaseName);
 
     if (!database) {
@@ -34,7 +34,7 @@ export class AdxSchemaResolver {
   }
 
   async getViewsForDatabase(databaseName: string, clusterUri: string): Promise<AdxTableSchema[]> {
-    const databases = await this.getDatabases(clusterUri);
+    const databases = await this.getDatabaseSchema(clusterUri, databaseName);
     const database = databases.find((db) => db.Name === databaseName);
 
     if (!database) {
@@ -44,7 +44,7 @@ export class AdxSchemaResolver {
   }
 
   async getFunctionsForDatabase(databaseName: string, clusterUri: string): Promise<AdxFunctionSchema[]> {
-    const databases = await this.getDatabases(clusterUri);
+    const databases = await this.getDatabaseSchema(clusterUri, databaseName);
     const database = databases.find((db) => db.Name === databaseName);
 
     if (!database) {


### PR DESCRIPTION
Schemas were previously loaded at a cluster level. For large clusters, this can prove highly inefficient, causing the plugin process to consume excessive amounts of memory.

This change loads the schema at a database level and will correctly update the schema in both the visual and raw editors when the database or cluster is updated.

Fixes #1269 
Fixes #1263
Fixes #1259