### PR TITLE
Improve setting of initial variables and undefined type-checking

### DIFF
--- a/src/components/QueryEditor/VisualQueryEditor/AggregateSection.test.tsx
+++ b/src/components/QueryEditor/VisualQueryEditor/AggregateSection.test.tsx
@@ -91,4 +91,20 @@ describe('AggregateSection', () => {
     rerender(<AggregateSection {...defaultProps} query={query} />);
     expect(screen.queryByText('foo')).not.toBeInTheDocument();
   });
+
+  it('renders with no expressions set ', async () => {
+    const updatedQuery = {
+      ...defaultProps.query,
+      expression: {
+        where: {},
+        groupBy: {},
+      },
+    };
+
+    const onChange = jest.fn();
+    // We use as any here because the query is missing the reduce property
+    render(<AggregateSection {...defaultProps} query={updatedQuery as any} onChange={onChange} />);
+
+    expect(await screen.findByText('Aggregate')).toBeInTheDocument();
+  });
 });

--- a/src/components/QueryEditor/VisualQueryEditor/AggregateSection.tsx
+++ b/src/components/QueryEditor/VisualQueryEditor/AggregateSection.tsx
@@ -3,7 +3,7 @@ import { QueryEditorProps, SelectableValue } from '@grafana/data';
 import { EditorField, EditorFieldGroup, EditorList, EditorRow } from '@grafana/plugin-ui';
 import { QueryEditorExpression, QueryEditorExpressionType, QueryEditorReduceExpression } from 'types/expressions';
 import { AdxDataSource } from 'datasource';
-import React, { useState, useEffect } from 'react';
+import React, { useState, useEffect, useMemo } from 'react';
 import { AdxColumnSchema, AdxDataSourceOptions, KustoQuery } from 'types';
 import { QueryEditorPropertyType } from 'schema/types';
 import { sanitizeAggregate } from './utils/utils';
@@ -25,7 +25,10 @@ const AggregateSection: React.FC<AggregateSectionProps> = ({
   templateVariableOptions,
   onChange: onQueryChange,
 }) => {
-  const expressions = query.expression?.reduce?.expressions;
+  const expressions = useMemo(
+    () => query.expression?.reduce?.expressions || [],
+    [query.expression?.reduce?.expressions]
+  );
   const [aggregates, setAggregates] = useState(expressions);
   const [currentTable, setCurrentTable] = useState(query.expression?.from?.property.name);
 
@@ -37,7 +40,7 @@ const AggregateSection: React.FC<AggregateSectionProps> = ({
 
   useEffect(() => {
     // New table
-    if (currentTable !== query.expression.from?.property.name) {
+    if (currentTable !== query.expression?.from?.property.name) {
       // Reset state
       setAggregates([]);
       setCurrentTable(query.expression?.from?.property.name);

--- a/src/components/QueryEditor/VisualQueryEditor/GroupBySection.test.tsx
+++ b/src/components/QueryEditor/VisualQueryEditor/GroupBySection.test.tsx
@@ -73,4 +73,20 @@ describe('GroupBySection', () => {
     rerender(<GroupBySection {...defaultProps} query={query} />);
     expect(screen.queryByText('foo')).not.toBeInTheDocument();
   });
+
+  it('renders with no groupBy set ', async () => {
+    const updatedQuery = {
+      ...defaultProps.query,
+      expression: {
+        where: {},
+        reduce: {},
+      },
+    };
+
+    const onChange = jest.fn();
+    // We use as any here because the query is missing the reduce property
+    render(<GroupBySection {...defaultProps} query={updatedQuery as any} onChange={onChange} />);
+
+    expect(await screen.findByText('Group by')).toBeInTheDocument();
+  });
 });

--- a/src/components/QueryEditor/VisualQueryEditor/GroupBySection.tsx
+++ b/src/components/QueryEditor/VisualQueryEditor/GroupBySection.tsx
@@ -3,7 +3,7 @@ import { QueryEditorProps, SelectableValue } from '@grafana/data';
 import { EditorField, EditorFieldGroup, EditorList, EditorRow } from '@grafana/plugin-ui';
 import { QueryEditorExpression, QueryEditorExpressionType, QueryEditorGroupByExpression } from 'types/expressions';
 import { AdxDataSource } from 'datasource';
-import React, { useState, useEffect } from 'react';
+import React, { useState, useEffect, useMemo } from 'react';
 import { AdxColumnSchema, AdxDataSourceOptions, KustoQuery } from 'types';
 import { QueryEditorPropertyType } from 'schema/types';
 import { sanitizeGroupBy } from './utils/utils';
@@ -25,12 +25,15 @@ const GroupBySection: React.FC<GroupBySectionProps> = ({
   templateVariableOptions,
   onChange: onQueryChange,
 }) => {
-  const expressions = query.expression?.groupBy?.expressions;
+  const expressions = useMemo(
+    () => query.expression?.groupBy?.expressions || [],
+    [query.expression?.groupBy?.expressions]
+  );
   const [groupBys, setGroupBys] = useState(expressions);
   const [currentTable, setCurrentTable] = useState(query.expression?.from?.property.name);
 
   useEffect(() => {
-    if (!groupBys.length && expressions?.length) {
+    if (!groupBys?.length && expressions?.length) {
       setGroupBys(expressions);
     }
   }, [groupBys?.length, expressions]);

--- a/src/components/QueryEditor/VisualQueryEditor/KQLFilter.tsx
+++ b/src/components/QueryEditor/VisualQueryEditor/KQLFilter.tsx
@@ -67,7 +67,7 @@ const KQLFilter: React.FC<KQLFilterProps> = ({
   const ref = React.createRef<HTMLButtonElement>();
 
   useEffect(() => {
-    if (!filters.length && expressions?.length) {
+    if (!filters?.length && expressions?.length) {
       setFilters(expressions);
     }
   }, [filters.length, expressions]);

--- a/src/components/QueryEditor/VisualQueryEditor/TableSection.test.tsx
+++ b/src/components/QueryEditor/VisualQueryEditor/TableSection.test.tsx
@@ -98,4 +98,22 @@ describe('TableSection', () => {
       })
     );
   });
+
+  it('will not call onChange if missing expression in query', async () => {
+    const onChange = jest.fn();
+    const updatedQuery = {
+      ...defaultProps.query,
+      expression: undefined,
+    };
+    render(
+      <TableSection
+        {...defaultProps}
+        query={updatedQuery as any}
+        onChange={onChange}
+        table={{ label: 'Test table', value: 'test-table' }}
+      />
+    );
+
+    expect(onChange).not.toHaveBeenCalled();
+  });
 });

--- a/src/components/QueryEditor/VisualQueryEditor/TableSection.tsx
+++ b/src/components/QueryEditor/VisualQueryEditor/TableSection.tsx
@@ -32,7 +32,11 @@ const TableSection: React.FC<TableSectionProps> = ({
   const [tableColumns, setTableColumns] = useState(tableSchema.value);
 
   useEffect(() => {
-    if (table?.value && (!query.expression.from || query.expression.from.property.name !== table.value)) {
+    if (
+      table?.value &&
+      query.expression &&
+      (!query.expression.from || query.expression.from?.property.name !== table.value)
+    ) {
       // New table
       onChange({
         ...query,


### PR DESCRIPTION
Some variables do not have the correct initial values set. This can lead to some kind of race condition which can cause the editor to fail to load if a user is switching between data sources quickly.

I've improved the type-checking and I've also set initial values that are memoised and will update when the relevant dependency is changed.