### PR TITLE
Internationalisation: Add crowdin-download GHA workflow

### DIFF
--- a/.github/workflows/i18n-crowdin-download.yml
+++ b/.github/workflows/i18n-crowdin-download.yml
@@ -1,0 +1,14 @@
+name: Crowdin Download Action
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: "0 0 * * *"
+
+jobs:
+  download-sources-from-crowdin:
+    uses: grafana/grafana-github-actions/.github/workflows/crowdin-download.yml@main
+    with:
+      crowdin_project_id: 32
+      pr_labels: 'i18n'
+      github_board_id: 190 # Partner Datasources project


### PR DESCRIPTION
~Can't merge until the Github App is installed for the right permissions.~ should be done ✅ 

Part of https://github.com/grafana/grafana/issues/106703