### PR TITLE
Internationalisation: don't load plugin translations in test environments

### DIFF
--- a/src/module.ts
+++ b/src/module.ts
@@ -10,7 +10,7 @@ import { AdxDataSourceOptions, AdxDataSourceSecureOptions, KustoQuery } from './
 import EditorHelp from 'components/QueryEditor/EditorHelp';
 import { analyzeQueries, trackADXMonitorDashboardLoaded } from 'tracking';
 
-initPluginTranslations(pluginJson.id);
+await initPluginTranslations(pluginJson.id);
 
 export const plugin = new DataSourcePlugin<AdxDataSource, KustoQuery, AdxDataSourceOptions, AdxDataSourceSecureOptions>(
   AdxDataSource

--- a/src/module.ts
+++ b/src/module.ts
@@ -10,7 +10,11 @@ import { AdxDataSourceOptions, AdxDataSourceSecureOptions, KustoQuery } from './
 import EditorHelp from 'components/QueryEditor/EditorHelp';
 import { analyzeQueries, trackADXMonitorDashboardLoaded } from 'tracking';
 
-await initPluginTranslations(pluginJson.id);
+// don't load plugin translations in test environments
+// we don't use them anyway, and top-level await won't work currently in jest
+if (process.env.NODE_ENV !== 'test') {
+  await initPluginTranslations(pluginJson.id);
+}
 
 export const plugin = new DataSourcePlugin<AdxDataSource, KustoQuery, AdxDataSourceOptions, AdxDataSourceSecureOptions>(
   AdxDataSource


### PR DESCRIPTION
<!-- To surface this PR in the changelog add the label: changelog -->
<!-- If this PR is going in the changelog please make sure the title of the PR explains the feature in a user-centric way: -->
<!-- Bad: fix state bug in hooks -->
<!-- Good: Fix crash when switching from Query Builder -->

- don't load plugin translations in test environments
- we don't use them anyway, and top-level await won't work currently in jest

For https://github.com/grafana/grafana/issues/107039