### PR TITLE
Support user-trusted endpoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,17 +13,6 @@ This plugin has the following minimum requirements:
 For detailed instructions on how to install the plugin on Grafana Cloud or
 locally, please check out the [Plugin installation docs](https://grafana.com/docs/grafana/latest/plugins/installation/).
 
-### Enforcing trusted Azure Data Explorer endpoints
-
-For additional security, enforcing a list of trusted ADX endpoints against which the cluster URL will be verified is possible. This prevents a request from being redirected to a third-party endpoint.
-
-This can be enabled by setting `enforce_trusted_endpoints` in your Grafana configuration under the `[plugin.grafana-azure-data-explorer-datasource]` section:
-
-```ini
-[plugin.grafana-azure-data-explorer-datasource]
-enforce_trusted_endpoints = true
-```
-
 ## Configure the Azure Data Explorer data source
 
 To configure ADX for using this data source:
@@ -33,7 +22,7 @@ To configure ADX for using this data source:
 1. Use the AAD Application to configure the data source connection in Grafana.
 1. (Optional) To use the dropdown cluster select when creating queries, add reader access to the subscription(s) that contain the clusters.
 
-### Creating an Azure Active Directory Service Principle
+### Creating an Azure Active Directory Service Principal
 
 For detailed instructions on how to set up a Microsoft Entra application and service principal that can access resources, please follow this guide from Microsoft: [Create a Microsoft Entra application and service principal that can access resources](https://docs.microsoft.com/en-us/azure/azure-resource-manager/resource-group-create-service-principal-portal)
 
@@ -79,6 +68,34 @@ A real example with a client/app id and tenant id:
 If the command succeeds, you should get a result like this:
 
 ![Azure Data Web Explorer Add result](https://raw.githubusercontent.com/grafana/azure-data-explorer-datasource/main/src/img/config_3_web_ui.png)
+
+### Enforcing trusted Azure Data Explorer endpoints
+
+For additional security, enforcing a list of trusted ADX endpoints against which the cluster URL will be verified is possible. This prevents a request from being redirected to a third-party endpoint.
+
+This can be enabled by setting `enforce_trusted_endpoints` in your Grafana configuration under the `[plugin.grafana-azure-data-explorer-datasource]` section:
+
+```ini
+[plugin.grafana-azure-data-explorer-datasource]
+enforce_trusted_endpoints = true
+```
+
+### Allow user-specified trusted endpoints
+
+There may be cases where an ADX cluster is behind a proxy or load balancer. In this case, it may be necessary to specify a trusted endpoint that is not in the default endpoint allow list.
+
+This functionality can be enabled by setting `allow_user_trusted_endpoints` to `true` and specifying the required endpoints as a comma separated list with the key `user_trusted_endpoints` in your Grafana configuration under the `[plugin.grafana-azure-data-explorer-datasource]` section:
+
+```ini
+[plugin.grafana-azure-data-explorer-datasource]
+enforce_trusted_endpoints = true
+allow_user_trusted_endpoints = true
+user_trusted_endpoints = https://first.endpoint.com,https://endpoint.second.com
+```
+
+{{%/* admonition type="caution" */%}}
+This feature should be used with caution as requests sent to untrusted endpoints may expose authentication tokens to unintended 3rd parties.
+{{%/* /admonition */%}}
 
 ## Configuring Grafana
 

--- a/pkg/azuredx/client/endpoints.go
+++ b/pkg/azuredx/client/endpoints.go
@@ -55,19 +55,18 @@ var azureDataExplorerEndpoints = map[string][]string{
 }
 
 func getAdxEndpoints(azureCloud string, settings *azsettings.AzureSettings) ([]string, error) {
-	if endpoints, ok := azureDataExplorerEndpoints[azureCloud]; !ok {
-		// Check if the cloud is a custom cloud (we don't need to check the error as if the cloud is non-nil the error will be nil)
-		if cloud, _ := settings.GetCloud(azureCloud); cloud != nil {
-			// The format of the suffix should be ".SUB_DOMAIN.DOMAIN.TLD" (e.g., ".kusto.windows.net")
-			adxEndpoint := fmt.Sprintf("https://*%s", cloud.Properties["azureDataExplorerSuffix"])
-			_, err := url.Parse(adxEndpoint)
-			if err != nil {
-				return nil, fmt.Errorf("failed to parse ADX endpoint URL: %w", err)
-			}
-			return []string{adxEndpoint}, nil
-		}
-		return nil, fmt.Errorf("the Azure cloud '%s' not supported by Azure Data Explorer datasource", azureCloud)
-	} else {
+	if endpoints, ok := azureDataExplorerEndpoints[azureCloud]; ok {
 		return endpoints, nil
 	}
+	cloud, err := settings.GetCloud(azureCloud)
+	if err != nil {
+		return nil, fmt.Errorf("the Azure cloud '%s' not supported by Azure Data Explorer datasource", azureCloud)
+	}
+	// The format of the suffix should be ".SUB_DOMAIN.DOMAIN.TLD" (e.g., ".kusto.windows.net")
+	adxEndpoint := fmt.Sprintf("https://*%s", cloud.Properties["azureDataExplorerSuffix"])
+	_, err = url.Parse(adxEndpoint)
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse ADX endpoint URL: %w", err)
+	}
+	return []string{adxEndpoint}, nil
 }

--- a/pkg/azuredx/client/httpclient.go
+++ b/pkg/azuredx/client/httpclient.go
@@ -81,6 +81,11 @@ func getAuthOpts(azureSettings *azsettings.AzureSettings, dsSettings *models.Dat
 		if err != nil {
 			return nil, err
 		}
+
+		if dsSettings.AllowUserTrustedEndpoints && len(dsSettings.UserTrustedEndpoints) > 0 {
+			endpoints = append(endpoints, dsSettings.UserTrustedEndpoints...)
+		}
+
 		err = authOpts.AllowedEndpoints(endpoints)
 		if err != nil {
 			return nil, err

--- a/pkg/azuredx/client/httpclient.go
+++ b/pkg/azuredx/client/httpclient.go
@@ -77,7 +77,7 @@ func getAuthOpts(azureSettings *azsettings.AzureSettings, dsSettings *models.Dat
 
 	// Enforce only trusted Azure Data Explorer endpoints if enabled
 	if userProvidedEndpoint && dsSettings.EnforceTrustedEndpoints {
-		endpoints, err := getAdxEndpoints(azureCloud)
+		endpoints, err := getAdxEndpoints(azureCloud, azureSettings)
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/azuredx/client/httpclient_test.go
+++ b/pkg/azuredx/client/httpclient_test.go
@@ -1,0 +1,252 @@
+package client
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/grafana/azure-data-explorer-datasource/pkg/azuredx/models"
+	"github.com/grafana/grafana-azure-sdk-go/v2/azcredentials"
+	"github.com/grafana/grafana-azure-sdk-go/v2/azhttpclient"
+	"github.com/grafana/grafana-azure-sdk-go/v2/azsettings"
+	"github.com/grafana/grafana-plugin-sdk-go/backend"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNewHttpClientAzureCloud(t *testing.T) {
+	tests := []struct {
+		name        string
+		azureCloud  string
+		clusterURL  string
+		expectError bool
+		setupMocks  func() (*backend.DataSourceInstanceSettings, *models.DatasourceSettings, *azsettings.AzureSettings, azcredentials.AzureCredentials)
+	}{
+		{
+			name:        "successful creation with public cloud",
+			azureCloud:  azsettings.AzurePublic,
+			clusterURL:  "https://test.kusto.windows.net",
+			expectError: false,
+			setupMocks: func() (*backend.DataSourceInstanceSettings, *models.DatasourceSettings, *azsettings.AzureSettings, azcredentials.AzureCredentials) {
+				instanceSettings := &backend.DataSourceInstanceSettings{
+					ID:       1,
+					Name:     "test-datasource",
+					URL:      "https://test.kusto.windows.net",
+					JSONData: []byte(`{}`),
+				}
+
+				dsSettings := &models.DatasourceSettings{
+					ClusterURL:              "https://test.kusto.windows.net",
+					QueryTimeout:            time.Minute,
+					EnforceTrustedEndpoints: false,
+				}
+
+				azureSettings := &azsettings.AzureSettings{
+					Cloud: azsettings.AzurePublic,
+				}
+
+				credentials := &azcredentials.AzureManagedIdentityCredentials{}
+
+				return instanceSettings, dsSettings, azureSettings, credentials
+			},
+		},
+		{
+			name:        "successful creation with US Government cloud",
+			azureCloud:  azsettings.AzureUSGovernment,
+			clusterURL:  "https://test.usgovtexas.kusto.usgovvirginia.net",
+			expectError: false,
+			setupMocks: func() (*backend.DataSourceInstanceSettings, *models.DatasourceSettings, *azsettings.AzureSettings, azcredentials.AzureCredentials) {
+				instanceSettings := &backend.DataSourceInstanceSettings{
+					ID:       1,
+					Name:     "test-datasource",
+					URL:      "https://test.usgovtexas.kusto.usgovvirginia.net",
+					JSONData: []byte(`{}`),
+				}
+
+				dsSettings := &models.DatasourceSettings{
+					ClusterURL:              "https://test.usgovtexas.kusto.usgovvirginia.net",
+					QueryTimeout:            time.Minute,
+					EnforceTrustedEndpoints: false,
+				}
+
+				azureSettings := &azsettings.AzureSettings{
+					Cloud: azsettings.AzureUSGovernment,
+				}
+
+				credentials := &azcredentials.AzureManagedIdentityCredentials{}
+
+				return instanceSettings, dsSettings, azureSettings, credentials
+			},
+		},
+		{
+			name:        "with trusted endpoints enforcement",
+			azureCloud:  azsettings.AzurePublic,
+			clusterURL:  "https://test.kusto.windows.net",
+			expectError: false,
+			setupMocks: func() (*backend.DataSourceInstanceSettings, *models.DatasourceSettings, *azsettings.AzureSettings, azcredentials.AzureCredentials) {
+				instanceSettings := &backend.DataSourceInstanceSettings{
+					ID:       1,
+					Name:     "test-datasource",
+					URL:      "https://test.kusto.windows.net",
+					JSONData: []byte(`{}`),
+				}
+
+				dsSettings := &models.DatasourceSettings{
+					ClusterURL:                "https://test.kusto.windows.net",
+					QueryTimeout:              time.Minute,
+					EnforceTrustedEndpoints:   true,
+					AllowUserTrustedEndpoints: false,
+				}
+
+				azureSettings := &azsettings.AzureSettings{
+					Cloud: azsettings.AzurePublic,
+				}
+
+				credentials := &azcredentials.AzureManagedIdentityCredentials{}
+
+				return instanceSettings, dsSettings, azureSettings, credentials
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			instanceSettings, dsSettings, azureSettings, credentials := tt.setupMocks()
+
+			client, err := newHttpClientAzureCloud(context.Background(), instanceSettings, dsSettings, azureSettings, credentials)
+
+			if tt.expectError {
+				require.Error(t, err)
+				assert.Nil(t, client)
+			} else {
+				require.NoError(t, err)
+				assert.NotNil(t, client)
+			}
+		})
+	}
+}
+
+func TestNewHttpClientManagement(t *testing.T) {
+	tests := []struct {
+		name        string
+		azureCloud  string
+		expectError bool
+		setupMocks  func() (*backend.DataSourceInstanceSettings, *models.DatasourceSettings, *azsettings.AzureSettings, azcredentials.AzureCredentials)
+	}{
+		{
+			name:        "successful creation of management client",
+			azureCloud:  azsettings.AzurePublic,
+			expectError: false,
+			setupMocks: func() (*backend.DataSourceInstanceSettings, *models.DatasourceSettings, *azsettings.AzureSettings, azcredentials.AzureCredentials) {
+				instanceSettings := &backend.DataSourceInstanceSettings{
+					ID:       1,
+					Name:     "test-datasource",
+					URL:      "https://test.kusto.windows.net",
+					JSONData: []byte(`{}`),
+				}
+
+				dsSettings := &models.DatasourceSettings{
+					ClusterURL:   "https://test.kusto.windows.net",
+					QueryTimeout: time.Minute,
+				}
+
+				azureSettings := &azsettings.AzureSettings{
+					Cloud: azsettings.AzurePublic,
+				}
+
+				credentials := &azcredentials.AzureManagedIdentityCredentials{}
+
+				return instanceSettings, dsSettings, azureSettings, credentials
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			instanceSettings, dsSettings, azureSettings, credentials := tt.setupMocks()
+
+			client, err := newHttpClientManagement(context.Background(), instanceSettings, dsSettings, azureSettings, credentials)
+
+			if tt.expectError {
+				require.Error(t, err)
+				assert.Nil(t, client)
+			} else {
+				require.NoError(t, err)
+				assert.NotNil(t, client)
+			}
+		})
+	}
+}
+
+func TestGetAuthOpts(t *testing.T) {
+	tests := []struct {
+		name                 string
+		azureCloud           string
+		userProvidedEndpoint bool
+		dsSettings           *models.DatasourceSettings
+		expectError          bool
+		expectedEndpoints    []string
+	}{
+		{
+			name:                 "basic auth options without endpoint enforcement",
+			azureCloud:           azsettings.AzurePublic,
+			userProvidedEndpoint: false,
+			dsSettings: &models.DatasourceSettings{
+				ClusterURL:              "https://test.kusto.windows.net",
+				EnforceTrustedEndpoints: false,
+			},
+			expectError: false,
+		},
+		{
+			name:                 "auth options with trusted endpoints enforcement",
+			azureCloud:           azsettings.AzurePublic,
+			userProvidedEndpoint: true,
+			dsSettings: &models.DatasourceSettings{
+				ClusterURL:              "https://test.kusto.windows.net",
+				EnforceTrustedEndpoints: true,
+			},
+			expectError: false,
+		},
+		{
+			name:                 "auth options with trusted endpoints and user endpoints",
+			azureCloud:           azsettings.AzurePublic,
+			userProvidedEndpoint: true,
+			dsSettings: &models.DatasourceSettings{
+				ClusterURL:                "https://test.kusto.windows.net",
+				EnforceTrustedEndpoints:   true,
+				AllowUserTrustedEndpoints: true,
+				UserTrustedEndpoints:      []string{"https://custom.endpoint.com", "https://another.endpoint.com"},
+			},
+			expectError: false,
+		},
+		{
+			name:                 "auth options with unsupported cloud",
+			azureCloud:           "unsupported-cloud",
+			userProvidedEndpoint: true,
+			dsSettings: &models.DatasourceSettings{
+				ClusterURL:              "https://test.kusto.windows.net",
+				EnforceTrustedEndpoints: true,
+			},
+			expectError: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			azureSettings := &azsettings.AzureSettings{
+				Cloud: tt.azureCloud,
+			}
+
+			authOpts, err := getAuthOpts(azureSettings, tt.dsSettings, tt.azureCloud, tt.userProvidedEndpoint)
+
+			if tt.expectError {
+				require.Error(t, err)
+				assert.Nil(t, authOpts)
+			} else {
+				require.NoError(t, err)
+				assert.NotNil(t, authOpts)
+				assert.IsType(t, &azhttpclient.AuthOptions{}, authOpts)
+			}
+		})
+	}
+}

--- a/pkg/azuredx/models/settings.go
+++ b/pkg/azuredx/models/settings.go
@@ -117,9 +117,9 @@ func envBoolOrDefault(key string, defaultValue bool) (bool, error) {
 }
 
 func envStringSliceOrDefault(key string, defaultValue []string) ([]string, error) {
-	if strValue := os.Getenv(key); strValue == "" {
+	strValue := os.Getenv(key)
+	if strValue == "" {
 		return defaultValue, nil
-	} else {
-		return strings.Split(strValue, ","), nil
 	}
+	return strings.Split(strValue, ","), nil
 }

--- a/pkg/azuredx/models/settings_test.go
+++ b/pkg/azuredx/models/settings_test.go
@@ -230,12 +230,24 @@ func (s *TestSettingsSuite) TestLoad() {
 				}`),
 			},
 			setupEnv: func() {
-				os.Setenv("GF_PLUGIN_ENFORCE_TRUSTED_ENDPOINTS", "true")
-				os.Setenv("GF_PLUGIN_ALLOW_USER_TRUSTED_ENDPOINTS", "false")
+				err := os.Setenv("GF_PLUGIN_ENFORCE_TRUSTED_ENDPOINTS", "true")
+				if err != nil {
+					panic(err)
+				}
+				err = os.Setenv("GF_PLUGIN_ALLOW_USER_TRUSTED_ENDPOINTS", "false")
+				if err != nil {
+					panic(err)
+				}
 			},
 			cleanupEnv: func() {
-				os.Unsetenv("GF_PLUGIN_ENFORCE_TRUSTED_ENDPOINTS")
-				os.Unsetenv("GF_PLUGIN_ALLOW_USER_TRUSTED_ENDPOINTS")
+				err := os.Unsetenv("GF_PLUGIN_ENFORCE_TRUSTED_ENDPOINTS")
+				if err != nil {
+					panic(err)
+				}
+				err = os.Unsetenv("GF_PLUGIN_ALLOW_USER_TRUSTED_ENDPOINTS")
+				if err != nil {
+					panic(err)
+				}
 			},
 			expectedResult: &DatasourceSettings{
 				ClusterURL:                "https://test.kusto.windows.net",
@@ -252,10 +264,16 @@ func (s *TestSettingsSuite) TestLoad() {
 				JSONData: []byte(`{}`),
 			},
 			setupEnv: func() {
-				os.Setenv("GF_PLUGIN_ENFORCE_TRUSTED_ENDPOINTS", "invalid-bool")
+				err := os.Setenv("GF_PLUGIN_ENFORCE_TRUSTED_ENDPOINTS", "invalid-bool")
+				if err != nil {
+					panic(err)
+				}
 			},
 			cleanupEnv: func() {
-				os.Unsetenv("GF_PLUGIN_ENFORCE_TRUSTED_ENDPOINTS")
+				err := os.Unsetenv("GF_PLUGIN_ENFORCE_TRUSTED_ENDPOINTS")
+				if err != nil {
+					panic(err)
+				}
 			},
 			expectedError: "invalid datasource endpoint configuration",
 		},
@@ -265,12 +283,24 @@ func (s *TestSettingsSuite) TestLoad() {
 				JSONData: []byte(`{}`),
 			},
 			setupEnv: func() {
-				os.Setenv("GF_PLUGIN_ENFORCE_TRUSTED_ENDPOINTS", "true")
-				os.Setenv("GF_PLUGIN_ALLOW_USER_TRUSTED_ENDPOINTS", "invalid-bool")
+				err := os.Setenv("GF_PLUGIN_ENFORCE_TRUSTED_ENDPOINTS", "true")
+				if err != nil {
+					panic(err)
+				}
+				err = os.Setenv("GF_PLUGIN_ALLOW_USER_TRUSTED_ENDPOINTS", "invalid-bool")
+				if err != nil {
+					panic(err)
+				}
 			},
 			cleanupEnv: func() {
-				os.Unsetenv("GF_PLUGIN_ENFORCE_TRUSTED_ENDPOINTS")
-				os.Unsetenv("GF_PLUGIN_ALLOW_USER_TRUSTED_ENDPOINTS")
+				err := os.Unsetenv("GF_PLUGIN_ENFORCE_TRUSTED_ENDPOINTS")
+				if err != nil {
+					panic(err)
+				}
+				err = os.Unsetenv("GF_PLUGIN_ALLOW_USER_TRUSTED_ENDPOINTS")
+				if err != nil {
+					panic(err)
+				}
 			},
 			expectedError: "invalid value for ALLOW_USER_TRUSTED_ENDPOINTS",
 		},
@@ -373,8 +403,16 @@ func (s *TestSettingsSuite) TestEnvBoolOrDefault() {
 		s.Run(tt.name, func() {
 			// Set up environment variable
 			if tt.envValue != "" {
-				os.Setenv(tt.envKey, tt.envValue)
-				defer os.Unsetenv(tt.envKey)
+				err := os.Setenv(tt.envKey, tt.envValue)
+				if err != nil {
+					panic(err)
+				}
+				defer func() {
+					err := os.Unsetenv(tt.envKey)
+					if err != nil {
+						panic(err)
+					}
+				}()
 			}
 
 			result, err := envBoolOrDefault(tt.envKey, tt.defaultValue)
@@ -434,8 +472,16 @@ func (s *TestSettingsSuite) TestEnvStringSliceOrDefault() {
 		s.Run(tt.name, func() {
 			// Set up environment variable
 			if tt.envValue != "" {
-				os.Setenv(tt.envKey, tt.envValue)
-				defer os.Unsetenv(tt.envKey)
+				err := os.Setenv(tt.envKey, tt.envValue)
+				if err != nil {
+					panic(err)
+				}
+				defer func() {
+					err := os.Unsetenv(tt.envKey)
+					if err != nil {
+						panic(err)
+					}
+				}()
 			}
 
 			result, err := envStringSliceOrDefault(tt.envKey, tt.defaultValue)

--- a/pkg/azuredx/models/settings_test.go
+++ b/pkg/azuredx/models/settings_test.go
@@ -186,14 +186,32 @@ func (s *TestSettingsSuite) TestLoad() {
 				}`),
 			},
 			setupEnv: func() {
-				os.Setenv("GF_PLUGIN_ENFORCE_TRUSTED_ENDPOINTS", "true")
-				os.Setenv("GF_PLUGIN_ALLOW_USER_TRUSTED_ENDPOINTS", "true")
-				os.Setenv("GF_PLUGIN_USER_TRUSTED_ENDPOINTS", "https://custom1.com,https://custom2.com")
+				err := os.Setenv("GF_PLUGIN_ENFORCE_TRUSTED_ENDPOINTS", "true")
+				if err != nil {
+					panic(err)
+				}
+				err = os.Setenv("GF_PLUGIN_ALLOW_USER_TRUSTED_ENDPOINTS", "true")
+				if err != nil {
+					panic(err)
+				}
+				err = os.Setenv("GF_PLUGIN_USER_TRUSTED_ENDPOINTS", "https://custom1.com,https://custom2.com")
+				if err != nil {
+					panic(err)
+				}
 			},
 			cleanupEnv: func() {
-				os.Unsetenv("GF_PLUGIN_ENFORCE_TRUSTED_ENDPOINTS")
-				os.Unsetenv("GF_PLUGIN_ALLOW_USER_TRUSTED_ENDPOINTS")
-				os.Unsetenv("GF_PLUGIN_USER_TRUSTED_ENDPOINTS")
+				err := os.Unsetenv("GF_PLUGIN_ENFORCE_TRUSTED_ENDPOINTS")
+				if err != nil {
+					panic(err)
+				}
+				err = os.Unsetenv("GF_PLUGIN_ALLOW_USER_TRUSTED_ENDPOINTS")
+				if err != nil {
+					panic(err)
+				}
+				err = os.Unsetenv("GF_PLUGIN_USER_TRUSTED_ENDPOINTS")
+				if err != nil {
+					panic(err)
+				}
 			},
 			expectedResult: &DatasourceSettings{
 				ClusterURL:                "https://test.kusto.windows.net",

--- a/pkg/azuredx/models/settings_test.go
+++ b/pkg/azuredx/models/settings_test.go
@@ -2,9 +2,11 @@ package models
 
 import (
 	"fmt"
+	"os"
 	"testing"
 	"time"
 
+	"github.com/grafana/grafana-plugin-sdk-go/backend"
 	"github.com/stretchr/testify/suite"
 )
 
@@ -54,6 +56,374 @@ func (s *TestSettingsSuite) TestFormatTimeout() {
 			result, err := formatTimeout(tt.duration)
 			r.Equal(tt.expected, result)
 			r.Equal(tt.err, err)
+		})
+	}
+}
+
+func (s *TestSettingsSuite) TestLoad() {
+	r := s.Require()
+
+	tests := []struct {
+		name           string
+		config         backend.DataSourceInstanceSettings
+		expectedError  string
+		expectedResult *DatasourceSettings
+		setupEnv       func()
+		cleanupEnv     func()
+	}{
+		{
+			name: "valid JSON with all fields",
+			config: backend.DataSourceInstanceSettings{
+				JSONData: []byte(`{
+					"clusterUrl": "https://test.kusto.windows.net",
+					"defaultDatabase": "testdb",
+					"dataConsistency": "strong",
+					"cacheMaxAge": "5m",
+					"dynamicCaching": true,
+					"enableUserTracking": true,
+					"application": "grafana",
+					"queryTimeout": "30s"
+				}`),
+			},
+			expectedResult: &DatasourceSettings{
+				ClusterURL:         "https://test.kusto.windows.net",
+				DefaultDatabase:    "testdb",
+				DataConsistency:    "strong",
+				CacheMaxAge:        "5m",
+				DynamicCaching:     true,
+				EnableUserTracking: true,
+				Application:        "grafana",
+				QueryTimeoutRaw:    "30s",
+				QueryTimeout:       30 * time.Second,
+				ServerTimeoutValue: "00:00:30",
+			},
+		},
+		{
+			name: "minimal valid JSON",
+			config: backend.DataSourceInstanceSettings{
+				JSONData: []byte(`{
+					"clusterUrl": "https://minimal.kusto.windows.net"
+				}`),
+			},
+			expectedResult: &DatasourceSettings{
+				ClusterURL:         "https://minimal.kusto.windows.net",
+				QueryTimeout:       30 * time.Second,
+				ServerTimeoutValue: "00:00:30",
+			},
+		},
+		{
+			name: "empty JSON data",
+			config: backend.DataSourceInstanceSettings{
+				JSONData: []byte(`{}`),
+			},
+			expectedResult: &DatasourceSettings{
+				QueryTimeout:       30 * time.Second,
+				ServerTimeoutValue: "00:00:30",
+			},
+		},
+		{
+			name: "no JSON data",
+			config: backend.DataSourceInstanceSettings{
+				JSONData: []byte(``),
+			},
+			expectedResult: &DatasourceSettings{
+				QueryTimeout:       30 * time.Second,
+				ServerTimeoutValue: "00:00:30",
+			},
+		},
+		{
+			name: "invalid JSON",
+			config: backend.DataSourceInstanceSettings{
+				JSONData: []byte(`{invalid json`),
+			},
+			expectedError: "could not unmarshal DatasourceSettings json",
+		},
+		{
+			name: "cluster URL with trailing slash",
+			config: backend.DataSourceInstanceSettings{
+				JSONData: []byte(`{
+					"clusterUrl": "https://test.kusto.windows.net/"
+				}`),
+			},
+			expectedResult: &DatasourceSettings{
+				ClusterURL:         "https://test.kusto.windows.net/",
+				QueryTimeout:       30 * time.Second,
+				ServerTimeoutValue: "00:00:30",
+			},
+		},
+		{
+			name: "invalid cluster URL",
+			config: backend.DataSourceInstanceSettings{
+				JSONData: []byte(`{
+					"clusterUrl": "https://test.kusto.windows.net?invalid=query"
+				}`),
+			},
+			expectedError: "invalid datasource endpoint configuration",
+		},
+		{
+			name: "invalid query timeout",
+			config: backend.DataSourceInstanceSettings{
+				JSONData: []byte(`{
+					"queryTimeout": "invalid-duration"
+				}`),
+			},
+			expectedError: "time: invalid duration",
+		},
+		{
+			name: "query timeout over one hour",
+			config: backend.DataSourceInstanceSettings{
+				JSONData: []byte(`{
+					"queryTimeout": "2h"
+				}`),
+			},
+			expectedError: "timeout must be one hour or less",
+		},
+		{
+			name: "with environment variables for trusted endpoints",
+			config: backend.DataSourceInstanceSettings{
+				JSONData: []byte(`{
+					"clusterUrl": "https://test.kusto.windows.net"
+				}`),
+			},
+			setupEnv: func() {
+				os.Setenv("GF_PLUGIN_ENFORCE_TRUSTED_ENDPOINTS", "true")
+				os.Setenv("GF_PLUGIN_ALLOW_USER_TRUSTED_ENDPOINTS", "true")
+				os.Setenv("GF_PLUGIN_USER_TRUSTED_ENDPOINTS", "https://custom1.com,https://custom2.com")
+			},
+			cleanupEnv: func() {
+				os.Unsetenv("GF_PLUGIN_ENFORCE_TRUSTED_ENDPOINTS")
+				os.Unsetenv("GF_PLUGIN_ALLOW_USER_TRUSTED_ENDPOINTS")
+				os.Unsetenv("GF_PLUGIN_USER_TRUSTED_ENDPOINTS")
+			},
+			expectedResult: &DatasourceSettings{
+				ClusterURL:                "https://test.kusto.windows.net",
+				QueryTimeout:              30 * time.Second,
+				ServerTimeoutValue:        "00:00:30",
+				EnforceTrustedEndpoints:   true,
+				AllowUserTrustedEndpoints: true,
+				UserTrustedEndpoints:      []string{"https://custom1.com", "https://custom2.com"},
+			},
+		},
+		{
+			name: "enforce trusted endpoints only",
+			config: backend.DataSourceInstanceSettings{
+				JSONData: []byte(`{
+					"clusterUrl": "https://test.kusto.windows.net"
+				}`),
+			},
+			setupEnv: func() {
+				os.Setenv("GF_PLUGIN_ENFORCE_TRUSTED_ENDPOINTS", "true")
+				os.Setenv("GF_PLUGIN_ALLOW_USER_TRUSTED_ENDPOINTS", "false")
+			},
+			cleanupEnv: func() {
+				os.Unsetenv("GF_PLUGIN_ENFORCE_TRUSTED_ENDPOINTS")
+				os.Unsetenv("GF_PLUGIN_ALLOW_USER_TRUSTED_ENDPOINTS")
+			},
+			expectedResult: &DatasourceSettings{
+				ClusterURL:                "https://test.kusto.windows.net",
+				QueryTimeout:              30 * time.Second,
+				ServerTimeoutValue:        "00:00:30",
+				EnforceTrustedEndpoints:   true,
+				AllowUserTrustedEndpoints: false,
+				UserTrustedEndpoints:      nil,
+			},
+		},
+		{
+			name: "invalid environment variable for enforce trusted endpoints",
+			config: backend.DataSourceInstanceSettings{
+				JSONData: []byte(`{}`),
+			},
+			setupEnv: func() {
+				os.Setenv("GF_PLUGIN_ENFORCE_TRUSTED_ENDPOINTS", "invalid-bool")
+			},
+			cleanupEnv: func() {
+				os.Unsetenv("GF_PLUGIN_ENFORCE_TRUSTED_ENDPOINTS")
+			},
+			expectedError: "invalid datasource endpoint configuration",
+		},
+		{
+			name: "invalid environment variable for allow user trusted endpoints",
+			config: backend.DataSourceInstanceSettings{
+				JSONData: []byte(`{}`),
+			},
+			setupEnv: func() {
+				os.Setenv("GF_PLUGIN_ENFORCE_TRUSTED_ENDPOINTS", "true")
+				os.Setenv("GF_PLUGIN_ALLOW_USER_TRUSTED_ENDPOINTS", "invalid-bool")
+			},
+			cleanupEnv: func() {
+				os.Unsetenv("GF_PLUGIN_ENFORCE_TRUSTED_ENDPOINTS")
+				os.Unsetenv("GF_PLUGIN_ALLOW_USER_TRUSTED_ENDPOINTS")
+			},
+			expectedError: "invalid value for ALLOW_USER_TRUSTED_ENDPOINTS",
+		},
+	}
+
+	for _, tt := range tests {
+		s.Run(tt.name, func() {
+			// Setup environment if needed
+			if tt.setupEnv != nil {
+				tt.setupEnv()
+			}
+
+			// Cleanup environment after test
+			if tt.cleanupEnv != nil {
+				defer tt.cleanupEnv()
+			}
+
+			ds := &DatasourceSettings{}
+			err := ds.Load(tt.config)
+
+			if tt.expectedError != "" {
+				r.Error(err)
+				r.Contains(err.Error(), tt.expectedError)
+			} else {
+				r.NoError(err)
+				r.Equal(tt.expectedResult.ClusterURL, ds.ClusterURL)
+				r.Equal(tt.expectedResult.DefaultDatabase, ds.DefaultDatabase)
+				r.Equal(tt.expectedResult.DataConsistency, ds.DataConsistency)
+				r.Equal(tt.expectedResult.CacheMaxAge, ds.CacheMaxAge)
+				r.Equal(tt.expectedResult.DynamicCaching, ds.DynamicCaching)
+				r.Equal(tt.expectedResult.EnableUserTracking, ds.EnableUserTracking)
+				r.Equal(tt.expectedResult.Application, ds.Application)
+				r.Equal(tt.expectedResult.QueryTimeoutRaw, ds.QueryTimeoutRaw)
+				r.Equal(tt.expectedResult.QueryTimeout, ds.QueryTimeout)
+				r.Equal(tt.expectedResult.ServerTimeoutValue, ds.ServerTimeoutValue)
+				r.Equal(tt.expectedResult.EnforceTrustedEndpoints, ds.EnforceTrustedEndpoints)
+				r.Equal(tt.expectedResult.AllowUserTrustedEndpoints, ds.AllowUserTrustedEndpoints)
+				r.Equal(tt.expectedResult.UserTrustedEndpoints, ds.UserTrustedEndpoints)
+			}
+		})
+	}
+}
+
+func (s *TestSettingsSuite) TestEnvBoolOrDefault() {
+	r := s.Require()
+
+	tests := []struct {
+		name          string
+		envKey        string
+		envValue      string
+		defaultValue  bool
+		expectedValue bool
+		expectedError string
+	}{
+		{
+			name:          "environment variable not set",
+			envKey:        "TEST_BOOL_UNSET",
+			envValue:      "",
+			defaultValue:  true,
+			expectedValue: true,
+		},
+		{
+			name:          "environment variable set to true",
+			envKey:        "TEST_BOOL_TRUE",
+			envValue:      "true",
+			defaultValue:  false,
+			expectedValue: true,
+		},
+		{
+			name:          "environment variable set to false",
+			envKey:        "TEST_BOOL_FALSE",
+			envValue:      "false",
+			defaultValue:  true,
+			expectedValue: false,
+		},
+		{
+			name:          "environment variable set to 1",
+			envKey:        "TEST_BOOL_ONE",
+			envValue:      "1",
+			defaultValue:  false,
+			expectedValue: true,
+		},
+		{
+			name:          "environment variable set to 0",
+			envKey:        "TEST_BOOL_ZERO",
+			envValue:      "0",
+			defaultValue:  true,
+			expectedValue: false,
+		},
+		{
+			name:          "invalid environment variable",
+			envKey:        "TEST_BOOL_INVALID",
+			envValue:      "invalid",
+			defaultValue:  false,
+			expectedError: "environment variable 'TEST_BOOL_INVALID' is invalid bool value 'invalid'",
+		},
+	}
+
+	for _, tt := range tests {
+		s.Run(tt.name, func() {
+			// Set up environment variable
+			if tt.envValue != "" {
+				os.Setenv(tt.envKey, tt.envValue)
+				defer os.Unsetenv(tt.envKey)
+			}
+
+			result, err := envBoolOrDefault(tt.envKey, tt.defaultValue)
+
+			if tt.expectedError != "" {
+				r.Error(err)
+				r.Contains(err.Error(), tt.expectedError)
+			} else {
+				r.NoError(err)
+				r.Equal(tt.expectedValue, result)
+			}
+		})
+	}
+}
+
+func (s *TestSettingsSuite) TestEnvStringSliceOrDefault() {
+	r := s.Require()
+
+	tests := []struct {
+		name          string
+		envKey        string
+		envValue      string
+		defaultValue  []string
+		expectedValue []string
+	}{
+		{
+			name:          "environment variable not set",
+			envKey:        "TEST_SLICE_UNSET",
+			envValue:      "",
+			defaultValue:  []string{"default1", "default2"},
+			expectedValue: []string{"default1", "default2"},
+		},
+		{
+			name:          "environment variable set to single value",
+			envKey:        "TEST_SLICE_SINGLE",
+			envValue:      "value1",
+			defaultValue:  []string{"default"},
+			expectedValue: []string{"value1"},
+		},
+		{
+			name:          "environment variable set to multiple values",
+			envKey:        "TEST_SLICE_MULTIPLE",
+			envValue:      "value1,value2,value3",
+			defaultValue:  []string{"default"},
+			expectedValue: []string{"value1", "value2", "value3"},
+		},
+		{
+			name:          "environment variable set to empty string",
+			envKey:        "TEST_SLICE_EMPTY",
+			envValue:      "",
+			defaultValue:  []string{"default"},
+			expectedValue: []string{"default"},
+		},
+	}
+
+	for _, tt := range tests {
+		s.Run(tt.name, func() {
+			// Set up environment variable
+			if tt.envValue != "" {
+				os.Setenv(tt.envKey, tt.envValue)
+				defer os.Unsetenv(tt.envKey)
+			}
+
+			result, err := envStringSliceOrDefault(tt.envKey, tt.defaultValue)
+
+			r.NoError(err)
+			r.Equal(tt.expectedValue, result)
 		})
 	}
 }


### PR DESCRIPTION
Adds support for users to specify their own trusted endpoints. This can be useful in cases where multiple ADX clusters may be sitting behind a load-balancer or proxy but the Grafana server admin still wishes to restrict what endpoints the user can send requests to.

This feature must be enabled by setting the relevant flags in the Grafana config as below (where `user_trusted_endpoints` is a comma delimited list):

```ini
[plugin.grafana-azure-data-explorer-datasource]
enforce_trusted_endpoints = true
allow_user_trusted_endpoints = true
user_trusted_endpoints = https://first.endpoint.com,https://endpoint.second.com
```

Added a note in the README that this feature should be used with caution to avoid unintended sharing of auth tokens with 3rd parties.

Fixes #864