### PR TITLE
Wrap `module.ts` in `async` function to allow translations to be loaded before datasource init

### DIFF
--- a/src/module.ts
+++ b/src/module.ts
@@ -10,34 +10,43 @@ import { AdxDataSourceOptions, AdxDataSourceSecureOptions, KustoQuery } from './
 import EditorHelp from 'components/QueryEditor/EditorHelp';
 import { analyzeQueries, trackADXMonitorDashboardLoaded } from 'tracking';
 
-// don't load plugin translations in test environments
-// we don't use them anyway, and top-level await won't work currently in jest
-if (process.env.NODE_ENV !== 'test') {
-  await initPluginTranslations(pluginJson.id);
-}
-
-export const plugin = new DataSourcePlugin<AdxDataSource, KustoQuery, AdxDataSourceOptions, AdxDataSourceSecureOptions>(
-  AdxDataSource
-)
-  .setConfigEditor(ConfigEditor)
-  .setQueryEditorHelp(EditorHelp)
-  .setQueryEditor(QueryEditor);
-
-// Track dashboard loads to RudderStack
-getAppEvents().subscribe<DashboardLoadedEvent<KustoQuery>>(
-  DashboardLoadedEvent,
-  ({ payload: { dashboardId, orgId, grafanaVersion, queries } }) => {
-    const adxQueries = queries[pluginJson.id]?.filter((q) => !q.hide);
-    if (!adxQueries?.length) {
-      return;
-    }
-
-    trackADXMonitorDashboardLoaded({
-      adx_plugin_version: plugin.meta.info.version,
-      grafana_version: grafanaVersion,
-      dashboard_id: dashboardId,
-      org_id: orgId,
-      ...analyzeQueries(adxQueries, getDataSourceSrv()),
-    });
+// we wrap the plugin in an async function to allow top-level await
+// this is needed to load translations in the plugin
+// @TODO: remove this when top-level await is supported in jest/@grafana runtime
+export const plugin = (async () => {
+  // don't load plugin translations in test environments
+  // we don't use them anyway, and top-level await won't work currently in jest
+  if (process.env.NODE_ENV !== 'test') {
+    await initPluginTranslations(pluginJson.id);
   }
-);
+
+  const ds = new DataSourcePlugin<AdxDataSource, KustoQuery, AdxDataSourceOptions, AdxDataSourceSecureOptions>(
+    AdxDataSource
+  )
+    .setConfigEditor(ConfigEditor)
+    .setQueryEditorHelp(EditorHelp)
+    .setQueryEditor(QueryEditor);
+
+  // Track dashboard loads to RudderStack
+  getAppEvents().subscribe<DashboardLoadedEvent<KustoQuery>>(
+    DashboardLoadedEvent,
+    ({ payload: { dashboardId, orgId, grafanaVersion, queries } }) => {
+      const adxQueries = queries[pluginJson.id]?.filter((q) => !q.hide);
+      if (!adxQueries?.length) {
+        return;
+      }
+
+      trackADXMonitorDashboardLoaded({
+        adx_plugin_version: ds.meta.info.version,
+        grafana_version: grafanaVersion,
+        dashboard_id: dashboardId,
+        org_id: orgId,
+        ...analyzeQueries(adxQueries, getDataSourceSrv()),
+      });
+    }
+  );
+
+  return ds;
+})();
+
+


### PR DESCRIPTION
As top-level `await` appears to not be supported by the runtime of older versions of Grafana, this PR allows the intended order of execution in `module.ts` to remain the same, while keeping the intended export of `DataSourcePlugin`. 