### PR TITLE
Fix docker compose for forks

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -40,4 +40,4 @@ jobs:
       golangci-lint-version: '2.1.6'
       run-playwright: true
       playwright-config: playwright-fork.config.ts
-      playwright-docker-compose-file: docker-compose-fork.yaml
+      playwright-docker-compose-file: compose-fork.yaml

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -40,3 +40,4 @@ jobs:
       golangci-lint-version: '2.1.6'
       run-playwright: true
       playwright-config: playwright-fork.config.ts
+      playwright-docker-compose-file: docker-compose-fork.yaml

--- a/compose-fork.yaml
+++ b/compose-fork.yaml
@@ -1,5 +1,3 @@
-version: '3.0'
-
 services:
   grafana:
     container_name: 'azure-data-explorer-datasource'

--- a/docker-compose-fork.yaml
+++ b/docker-compose-fork.yaml
@@ -1,0 +1,15 @@
+version: '3.0'
+
+services:
+  grafana:
+    container_name: 'azure-data-explorer-datasource'
+    build:
+      context: ./.config
+      args:
+        grafana_image: ${GRAFANA_IMAGE:-grafana-enterprise}
+        grafana_version: ${GRAFANA_VERSION:-9.1.2}
+    ports:
+      - 3000:3000/tcp
+    volumes:
+      - ./dist:/var/lib/grafana/plugins/azure-data-explorer-datasource
+      - ./provisioning:/etc/grafana/provisioning

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,5 +1,3 @@
-version: '3.0'
-
 services:
   grafana:
     container_name: 'azure-data-explorer-datasource'


### PR DESCRIPTION
Docker compose for PRs from forks or dependabot should not reference the `.env` file.