### PR TITLE
Update E2E tests

### DIFF
--- a/e2e/frontend/query.spec.ts
+++ b/e2e/frontend/query.spec.ts
@@ -46,7 +46,7 @@ test.describe('Azure Data Explorer queries', () => {
     await page.keyboard.insertText('timeFilter(timestamp) | order by timestamp asc');
     await page.getByTestId(selectors.components.queryEditor.runQuery.button).click();
     await page.waitForTimeout(6000);
-    expect(panel.panel.fieldNames).toContainText(['timestamp', 'name', 'index', 'jsonData', 'array', 'static']);
+    expect(panel.panel.fieldNames).toContainText(['timestamp', 'name', 'index', 'jsonData', 'array']);
   });
 
   test('Create a KQL query and run using Shift+Enter', async ({
@@ -96,7 +96,7 @@ test.describe('Azure Data Explorer queries', () => {
     await page.keyboard.insertText('timeFilter(timestamp) | order by timestamp asc');
     await page.keyboard.press('Shift+Enter');
     await page.waitForTimeout(6000);
-    expect(panel.panel.fieldNames).toContainText(['timestamp', 'name', 'index', 'jsonData', 'array', 'static']);
+    expect(panel.panel.fieldNames).toContainText(['timestamp', 'name', 'index', 'jsonData', 'array']);
   });
 
   test('Create a builder query', async ({ dashboardPage, page, readProvisionedDataSource, grafanaVersion }) => {
@@ -138,6 +138,6 @@ test.describe('Azure Data Explorer queries', () => {
 
     await page.getByTestId(selectors.components.queryEditor.runQuery.button).click();
     await page.waitForTimeout(6000);
-    expect(panel.panel.fieldNames).toContainText(['timestamp', 'name', 'index', 'jsonData', 'array', 'static']);
+    expect(panel.panel.fieldNames).toContainText(['timestamp', 'name', 'index', 'jsonData', 'array']);
   });
 });

--- a/e2e/smoke/query.spec.ts
+++ b/e2e/smoke/query.spec.ts
@@ -111,7 +111,7 @@ test.describe('Azure Data Explorer queries - smoke', () => {
     await panelEditPage.mockResourceResponse('clusters', mockClustersResponse);
     await panelEditPage.mockResourceResponse('databases', mockDatabasesResponse);
     await panelEditPage.mockResourceResponse('schema', mockSchemaResponse);
-    await panelEditPage.datasource.set('Azure Data Explorer');
+    await panelEditPage.datasource.set('Azure Data Explorer (Smoke)');
 
     const versionValue = isVersionGtOrEq(grafanaVersion, '11.1.0');
 
@@ -142,7 +142,7 @@ test.describe('Azure Data Explorer queries - smoke', () => {
     await panelEditPage.mockResourceResponse('clusters', mockClustersResponse);
     await panelEditPage.mockResourceResponse('databases', mockDatabasesResponse);
     await panelEditPage.mockResourceResponse('schema', mockSchemaResponse);
-    await panelEditPage.datasource.set('Azure Data Explorer');
+    await panelEditPage.datasource.set('Azure Data Explorer (Smoke)');
 
     const versionValue = isVersionGtOrEq(grafanaVersion, '11.1.0');
 

--- a/e2e/smoke/query.spec.ts
+++ b/e2e/smoke/query.spec.ts
@@ -2,104 +2,115 @@ import { expect, test } from '@grafana/plugin-e2e';
 import { selectors } from '../../src/test/selectors';
 import { isVersionGtOrEq } from '../../src/version';
 
+const mockClustersResponse = [
+  {
+    name: 'datasourcesgrafana',
+    uri: 'https://datasourcesgrafana.eastus2.kusto.windows.net',
+  },
+];
+const mockDatabasesResponse = {
+  Tables: [
+    {
+      TableName: 'Table_0',
+      Columns: [
+        {
+          ColumnName: 'DatabaseName',
+          DataType: 'String',
+          ColumnType: 'string',
+        },
+        {
+          ColumnName: 'PersistentStorage',
+          DataType: 'String',
+          ColumnType: 'string',
+        },
+        {
+          ColumnName: 'Version',
+          DataType: 'String',
+          ColumnType: 'string',
+        },
+        {
+          ColumnName: 'IsCurrent',
+          DataType: 'Boolean',
+          ColumnType: 'bool',
+        },
+        {
+          ColumnName: 'DatabaseAccessMode',
+          DataType: 'String',
+          ColumnType: 'string',
+        },
+        {
+          ColumnName: 'PrettyName',
+          DataType: 'String',
+          ColumnType: 'string',
+        },
+        {
+          ColumnName: 'ReservedSlot1',
+          DataType: 'Boolean',
+          ColumnType: 'bool',
+        },
+        {
+          ColumnName: 'DatabaseId',
+          DataType: 'Guid',
+          ColumnType: 'guid',
+        },
+        {
+          ColumnName: 'InTransitionTo',
+          DataType: 'String',
+          ColumnType: 'string',
+        },
+        {
+          ColumnName: 'SuspensionState',
+          DataType: 'String',
+          ColumnType: 'string',
+        },
+      ],
+      Rows: [['test-db', '', '', false, 'ReadWrite', null, null, '', '', null]],
+    },
+  ],
+  Exceptions: null,
+};
+const mockSchemaResponse = {
+  Tables: [
+    {
+      TableName: 'Table_0',
+      Columns: [
+        {
+          ColumnName: 'DatabaseSchema',
+          DataType: 'String',
+          ColumnType: 'string',
+        },
+      ],
+      Rows: [
+        [
+          JSON.stringify({
+            Databases: {
+              'test-db': {
+                Name: 'test-db',
+                Tables: { WORLD_DATA: {} },
+                MajorVersion: 158,
+                MinorVersion: 2896,
+                Functions: {},
+                DatabaseAccessMode: 'ReadWrite',
+                ExternalTables: {},
+                MaterializedViews: {},
+                EntityGroups: {},
+                Graphs: {},
+                StoredQueryResults: {},
+              },
+            },
+          }),
+        ],
+      ],
+    },
+  ],
+  Exceptions: null,
+};
+
 test.describe('Azure Data Explorer queries - smoke', () => {
   test('renders KQL editor', async ({ panelEditPage, page, grafanaVersion }) => {
-    await page.route('*/**/clusters', async (route) => {
-      const json = [
-        {
-          name: 'datasourcesgrafana',
-          uri: 'https://datasourcesgrafana.eastus2.kusto.windows.net',
-        },
-      ];
-      await route.fulfill({ json });
-    });
-    await page.route('*/**/databases', async (route) => {
-      const json = {
-        Tables: [
-          {
-            TableName: 'Table_0',
-            Columns: [
-              {
-                ColumnName: 'DatabaseName',
-                DataType: 'String',
-                ColumnType: 'string',
-              },
-              {
-                ColumnName: 'PersistentStorage',
-                DataType: 'String',
-                ColumnType: 'string',
-              },
-              {
-                ColumnName: 'Version',
-                DataType: 'String',
-                ColumnType: 'string',
-              },
-              {
-                ColumnName: 'IsCurrent',
-                DataType: 'Boolean',
-                ColumnType: 'bool',
-              },
-              {
-                ColumnName: 'DatabaseAccessMode',
-                DataType: 'String',
-                ColumnType: 'string',
-              },
-              {
-                ColumnName: 'PrettyName',
-                DataType: 'String',
-                ColumnType: 'string',
-              },
-              {
-                ColumnName: 'ReservedSlot1',
-                DataType: 'Boolean',
-                ColumnType: 'bool',
-              },
-              {
-                ColumnName: 'DatabaseId',
-                DataType: 'Guid',
-                ColumnType: 'guid',
-              },
-              {
-                ColumnName: 'InTransitionTo',
-                DataType: 'String',
-                ColumnType: 'string',
-              },
-              {
-                ColumnName: 'SuspensionState',
-                DataType: 'String',
-                ColumnType: 'string',
-              },
-            ],
-            Rows: [['test-db', '', '', false, 'ReadWrite', null, null, '', '', null]],
-          },
-        ],
-        Exceptions: null,
-      };
-      await route.fulfill({ json });
-    });
-    await page.route('*/**/schema', async (route) => {
-      const json = {
-        Tables: [
-          {
-            TableName: 'Table_0',
-            Columns: [
-              {
-                ColumnName: 'DatabaseSchema',
-                DataType: 'String',
-                ColumnType: 'string',
-              },
-            ],
-            Rows: [
-              [
-                '{"Databases":{"test-db":{"Name":"test-db","Tables":{"WORLD_DATA":{}},"MajorVersion":158,"MinorVersion":2896,"Functions":{},"DatabaseAccessMode":"ReadWrite","ExternalTables":{},"MaterializedViews":{},"EntityGroups":{},"Graphs":{},"StoredQueryResults":{}}}',
-              ],
-            ],
-          },
-        ],
-        Exceptions: null,
-      };
-      await route.fulfill({ json });
-    });
+    await panelEditPage.mockResourceResponse('clusters', mockClustersResponse);
+    await panelEditPage.mockResourceResponse('databases', mockDatabasesResponse);
+    await panelEditPage.mockResourceResponse('schema', mockSchemaResponse);
     await panelEditPage.datasource.set('Azure Data Explorer');
 
     const versionValue = isVersionGtOrEq(grafanaVersion, '11.1.0');
@@ -128,102 +139,9 @@ test.describe('Azure Data Explorer queries - smoke', () => {
   });
 
   test('renders builder', async ({ panelEditPage, page, grafanaVersion }) => {
-    await page.route('*/**/clusters', async (route) => {
-      const json = [
-        {
-          name: 'datasourcesgrafana',
-          uri: 'https://datasourcesgrafana.eastus2.kusto.windows.net',
-        },
-      ];
-      await route.fulfill({ json });
-    });
-    await page.route('*/**/databases', async (route) => {
-      const json = {
-        Tables: [
-          {
-            TableName: 'Table_0',
-            Columns: [
-              {
-                ColumnName: 'DatabaseName',
-                DataType: 'String',
-                ColumnType: 'string',
-              },
-              {
-                ColumnName: 'PersistentStorage',
-                DataType: 'String',
-                ColumnType: 'string',
-              },
-              {
-                ColumnName: 'Version',
-                DataType: 'String',
-                ColumnType: 'string',
-              },
-              {
-                ColumnName: 'IsCurrent',
-                DataType: 'Boolean',
-                ColumnType: 'bool',
-              },
-              {
-                ColumnName: 'DatabaseAccessMode',
-                DataType: 'String',
-                ColumnType: 'string',
-              },
-              {
-                ColumnName: 'PrettyName',
-                DataType: 'String',
-                ColumnType: 'string',
-              },
-              {
-                ColumnName: 'ReservedSlot1',
-                DataType: 'Boolean',
-                ColumnType: 'bool',
-              },
-              {
-                ColumnName: 'DatabaseId',
-                DataType: 'Guid',
-                ColumnType: 'guid',
-              },
-              {
-                ColumnName: 'InTransitionTo',
-                DataType: 'String',
-                ColumnType: 'string',
-              },
-              {
-                ColumnName: 'SuspensionState',
-                DataType: 'String',
-                ColumnType: 'string',
-              },
-            ],
-            Rows: [['test-db', '', '', false, 'ReadWrite', null, null, '', '', null]],
-          },
-        ],
-        Exceptions: null,
-      };
-      await route.fulfill({ json });
-    });
-    await page.route('*/**/schema', async (route) => {
-      const json = {
-        Tables: [
-          {
-            TableName: 'Table_0',
-            Columns: [
-              {
-                ColumnName: 'DatabaseSchema',
-                DataType: 'String',
-                ColumnType: 'string',
-              },
-            ],
-            Rows: [
-              [
-                '{"Databases":{"test-db":{"Name":"test-db","Tables":{"WORLD_DATA":{}},"MajorVersion":158,"MinorVersion":2896,"Functions":{},"DatabaseAccessMode":"ReadWrite","ExternalTables":{},"MaterializedViews":{},"EntityGroups":{},"Graphs":{},"StoredQueryResults":{}}}',
-              ],
-            ],
-          },
-        ],
-        Exceptions: null,
-      };
-      await route.fulfill({ json });
-    });
+    await panelEditPage.mockResourceResponse('clusters', mockClustersResponse);
+    await panelEditPage.mockResourceResponse('databases', mockDatabasesResponse);
+    await panelEditPage.mockResourceResponse('schema', mockSchemaResponse);
     await panelEditPage.datasource.set('Azure Data Explorer');
 
     const versionValue = isVersionGtOrEq(grafanaVersion, '11.1.0');

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -5,7 +5,7 @@ import { dirname } from 'path';
 const pluginE2eAuth = `${dirname(require.resolve('@grafana/plugin-e2e'))}/auth`;
 
 export default defineConfig<PluginOptions>({
-  testDir: './e2e/frontend',
+  testDir: './e2e',
   /* Run tests in files in parallel */
   fullyParallel: true,
   /* Fail the build on CI if you accidentally left test.only in the source code. */

--- a/provisioning/datasources/adx.yaml
+++ b/provisioning/datasources/adx.yaml
@@ -40,3 +40,19 @@ datasources:
       clientSecret: $CLIENT_SECRET
     type: grafana-azure-data-explorer-datasource
     version: 1
+
+  - editable: true
+    enabled: true
+    uid: ADX1234SMOKE
+    jsonData:
+      clientId: CLIENT_ID
+      tenantId: TENANT_ID
+      tlsAuth: false
+      tlsAuthWithCACert: false
+      clusterUrl: CLUSTER_URL
+      defaultDatabase: 'test-db'
+    name: Azure Data Explorer (Smoke)
+    secureJsonData:
+      clientSecret: CLIENT_SECRET
+    type: grafana-azure-data-explorer-datasource
+    version: 1


### PR DESCRIPTION
Introducing some improvements to the E2E tests.

The non-smoke tests now validate the first 5 fields returned only. This is due to the fact that certain Grafana 12 versions truncate the table earlier. In the future we could potentially validate the returned data frame instead.

The smoke tests now have their resource calls correctly mocked. The smoke tests are also run on every PR now and I've added a provisioned data source to support this.