### PR TITLE
Fix variable identification with Scenes

### DIFF
--- a/src/KustoExpressionParser.test.ts
+++ b/src/KustoExpressionParser.test.ts
@@ -853,6 +853,7 @@ describe('KustoExpressionParser', () => {
               text: 'usa',
               value: 'USA',
             },
+            name: 'country',
             multi: false,
           },
         ]),
@@ -894,6 +895,7 @@ describe('KustoExpressionParser', () => {
         getVariables: jest.fn().mockReturnValue([
           {
             id: 'country',
+            name: 'country',
             current: {
               text: 'usa',
               value: 'USA',

--- a/src/KustoExpressionParser.ts
+++ b/src/KustoExpressionParser.ts
@@ -384,7 +384,7 @@ export class KustoExpressionParser {
     const val = typeof value === 'string' ? value : value.value || '';
 
     return !!this.templateSrv.getVariables().find((variable: any) => {
-      return `$${variable?.id}` === val || `'$${variable?.id}'` === val || val.startsWith(`\$\{${variable?.id}:`);
+      return `$${variable?.name}` === val || `'$${variable?.name}'` === val || val.startsWith(`\$\{${variable?.name}:`);
     });
   }
 }


### PR DESCRIPTION
The enablement of scenes has removed the `id` property from template variables. In order to support correctly identifying template variable values I've swapped the logic to use `name` which seems to be consistent across the old and new implementations.

Needed for https://github.com/grafana/support-escalations/issues/18114

Fixes #1459