### PR TITLE
Mark error as downstream

### DIFF
--- a/pkg/azuredx/models/table.go
+++ b/pkg/azuredx/models/table.go
@@ -45,7 +45,7 @@ func (ar *TableResponse) getTableByName(name string) (Table, error) {
 			return t, nil
 		}
 	}
-	return Table{}, fmt.Errorf("no data as %v table is missing from the the response", name)
+	return Table{}, backend.DownstreamError(fmt.Errorf("no data as %v table is missing from the the response", name))
 }
 
 func (tr *TableResponse) ToDataFrames(executedQueryString string, format string) (data.Frames, error) {


### PR DESCRIPTION
Marking the table name error as downstream. We expect the first table in the result set to be called `Table_0` which is the default for the API.