### PR TITLE
Fix the evaluation of `playwright-config` and `playwright-docker-compose-file` variables in `push.yml`

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -20,8 +20,8 @@ jobs:
       go-version: '1.24'
       golangci-lint-version: '2.1.6'
       run-playwright: true
-      playwright-config: ${{ github.event.pull_request.head.repo.fork == true || github.actor == 'dependabot[bot]' && 'playwright-fork.config.ts' || 'playwright.config.ts' }}
-      playwright-docker-compose-file: ${{ github.event.pull_request.head.repo.fork == true || github.actor == 'dependabot[bot]' && 'compose-fork.yaml' || 'docker-compose.yaml' }}
+      playwright-config: ${{ (github.event_name == 'pull_request' && (github.event.pull_request.head.repo.fork || github.actor == 'dependabot[bot]')) && 'playwright-fork.config.ts' || 'playwright.config.ts' }}
+      playwright-docker-compose-file: ${{ (github.event_name == 'pull_request' && (github.event.pull_request.head.repo.fork || github.actor == 'dependabot[bot]')) && 'compose-fork.yaml' || 'docker-compose.yaml' }}
       playwright-secrets: |
         TENANT_ID=e2e:tenantId
         CLIENT_ID=e2e:clientId


### PR DESCRIPTION
This PR fixes the condition for `playwright-docker-compose-file` in `push.yml` short-circuiting on the first `||`. When the PR is from a fork, `github.event.pull_request.head.repo.fork == true` evaluates to the boolean `true`, and `true || ...` returns `true` (which is not the filename as desired). 

That’s why in this [workflow run](https://github.com/grafana/azure-data-explorer-datasource/actions/runs/20716215577/job/59468524659?pr=1566), it tries to open a file literally named `true`.