### PR TITLE
Reset database on cluster switch

### DIFF
--- a/src/components/QueryEditor/QueryHeader.test.tsx
+++ b/src/components/QueryEditor/QueryHeader.test.tsx
@@ -126,6 +126,26 @@ describe('QueryEditor', () => {
       });
       expect(onRunQuery).toHaveBeenCalledTimes(1);
     });
+
+    it('should reset database when cluster changes', async () => {
+      const onChange = jest.fn();
+      const ds = mockDatasource();
+      ds.getClusters = jest.fn().mockResolvedValue([
+        { name: 'cluster-a', uri: 'https://cluster-a.kusto.windows.net' },
+        { name: 'cluster-b', uri: 'https://cluster-b.kusto.windows.net' },
+      ]);
+      const query = { ...mockQuery, database: 'foo', clusterUri: 'https://cluster-a.kusto.windows.net' };
+      await waitFor(async () => {
+        render(<QueryHeader {...defaultProps} datasource={ds} query={query} databases={databases} onChange={onChange} />);
+        await screen.getByText('foo');
+        const sel = screen.getByLabelText('Cluster:');
+        act(() => openMenu(sel));
+        screen.getByText('cluster-b').click();
+      });
+      expect(onChange).toHaveBeenCalledWith(
+        expect.objectContaining({ clusterUri: 'https://cluster-b.kusto.windows.net', database: '', expression: defaultQuery.expression })
+      );
+    });
   });
 
   describe('format selector', () => {

--- a/src/components/QueryEditor/QueryHeader.tsx
+++ b/src/components/QueryEditor/QueryHeader.tsx
@@ -126,7 +126,7 @@ export const QueryHeader = (props: QueryEditorHeaderProps) => {
 
   const onClusterChange = ({ value }: SelectableValue) => {
     setClusterUri(value);
-    onChange({ ...query, clusterUri: value, expression: defaultQuery.expression });
+    onChange({ ...query, clusterUri: value, database: '', expression: defaultQuery.expression });
   };
 
   const onDatabaseChange = ({ value }: SelectableValue) => {


### PR DESCRIPTION
This fixes https://github.com/grafana/azure-data-explorer-datasource/issues/1521

I am not sure if we want to do this because users could have the same databases set up on different clusters. This would require them to reselect the database