### PR TITLE
Prepare to release 7.2.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # CHANGELOG
 
+
+## [7.2.5]
+
+- Escape columns when building KQL ([#1677](https://github.com/grafana/azure-data-explorer-datasource/pull/1677))
+- Reset database on cluster switch ([#1676](https://github.com/grafana/azure-data-explorer-datasource/pull/1676))
+- Dependency updates
+
 ## [7.2.4]
 
 - Dependency updates

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "grafana-azure-data-explorer-datasource",
-  "version": "7.2.4",
+  "version": "7.2.5",
   "description": "Grafana data source for Azure Data Explorer",
   "scripts": {
     "build": "webpack -c ./webpack.config.ts --env production",


### PR DESCRIPTION
## [7.2.5]

- Escape columns when building KQL ([#1677](https://github.com/grafana/azure-data-explorer-datasource/pull/1677))
- Reset database on cluster switch ([#1676](https://github.com/grafana/azure-data-explorer-datasource/pull/1676))
- Dependency updates