### PR TITLE
ci: bump plugin-ci-workflows to ci-cd-workflows/v8.0.1

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -29,7 +29,7 @@ jobs:
       matrix:
         environment: [dev, ops, prod]
     name: CD
-    uses: grafana/plugin-ci-workflows/.github/workflows/cd.yml@ci-cd-workflows/v6.1.1
+    uses: grafana/plugin-ci-workflows/.github/workflows/cd.yml@ci-cd-workflows/v8.0.1
     permissions:
       contents: write
       id-token: write

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -11,7 +11,7 @@ permissions: {}
 jobs:
   ci:
     name: CI
-    uses: grafana/plugin-ci-workflows/.github/workflows/ci.yml@ci-cd-workflows/v6.1.1
+    uses: grafana/plugin-ci-workflows/.github/workflows/ci.yml@ci-cd-workflows/v8.0.1
     permissions:
       contents: read
       id-token: write


### PR DESCRIPTION
## Summary

- Bumps the CI workflow ref in `.github/workflows/push.yml` from `ci-cd-workflows/v6.1.1` to `ci-cd-workflows/v8.0.1`.
- Bumps the CD workflow ref in `.github/workflows/publish.yml` from `ci-cd-workflows/v6.1.1` to `ci-cd-workflows/v8.0.1`.

## Why

The v8 line of `plugin-ci-workflows` switches from a broad long-lived GitHub App token to short-lived tokens issued per workflow. Older versions will stop working once the long-lived token is revoked, so the bump is required.

## Breaking-change walk between v6.1.1 → v8.0.1

- **v7.0.0** — `mage-version` input no longer takes a `v` prefix. Not used in either of this plugin's workflow files, so no impact.
- **v8.0.0** — GATB short-lived token rollout. This plugin uses none of the features that require additional token scopes (no private Go dependencies in `go.mod`, no `docs/sources/` to publish to the `website` repo, no `release-please`, no `version-bump-changelog`), so no additional workflow inputs or extra configuration are needed.
- **v8.0.0** — Playwright `e2e-version` v2.0.0: the nightly Grafana image switches from `grafana-dev` to `grafana-enterprise:nightly`. No workflow-file changes are required, but Playwright tests on this PR may now exercise the new image.
- **v8.0.1** — Internal fixes only (alpine `jq` install in publish-docs, `pnpm/action-setup` bump). No impact.