### PR TITLE
Add Kusto endpoint for AzureUSGovernment

### DIFF
--- a/pkg/azuredx/client/scopes.go
+++ b/pkg/azuredx/client/scopes.go
@@ -11,8 +11,9 @@ import (
 
 var (
 	adxScopes = map[string]string{
-		azsettings.AzurePublic: "https://kusto.kusto.windows.net/.default",
-		azsettings.AzureChina:  "https://kusto.kusto.chinacloudapi.cn/.default",
+		azsettings.AzurePublic:       "https://kusto.kusto.windows.net/.default",
+		azsettings.AzureChina:        "https://kusto.kusto.chinacloudapi.cn/.default",
+		azsettings.AzureUSGovernment: "https://kusto.kusto.usgovcloudapi.net/.default",
 	}
 )
 
@@ -20,7 +21,7 @@ func getAdxScopes(azureCloud string, clusterUrl string) ([]string, error) {
 	// Get scopes for the given cloud
 	scopeTmpl, ok := "", false
 	if scopeTmpl, ok = adxScopes[azureCloud]; !ok {
-		// AzurePublic and AzureChina use special scopes, other clouds will expect the clusterUrl in the scope
+		// AzurePublic, AzureUSGovernment and AzureChina use special scopes, other clouds will expect the clusterUrl in the scope
 		// so fallback to this pattern for all others
 		scopeTmpl = "{clusterUrl}/.default"
 	}

--- a/pkg/azuredx/client/scopes_test.go
+++ b/pkg/azuredx/client/scopes_test.go
@@ -26,13 +26,13 @@ func TestGetAzureScopes_KnownClouds(t *testing.T) {
 			description:   "test US Government cloud - Texas",
 			cloud:         azsettings.AzureUSGovernment,
 			clusterUrl:    "https://abc.usgovtexas.kusto.usgovvirginia.net",
-			expectedScope: "https://abc.usgovtexas.kusto.usgovvirginia.net/.default",
+			expectedScope: "https://kusto.kusto.usgovcloudapi.net/.default",
 		},
 		{
 			description:   "test US Government cloud - Virginia",
 			cloud:         azsettings.AzureUSGovernment,
 			clusterUrl:    "https://abc.usgovtexas.kusto.usgovvirginia.net/",
-			expectedScope: "https://abc.usgovtexas.kusto.usgovvirginia.net/.default",
+			expectedScope: "https://kusto.kusto.usgovcloudapi.net/.default",
 		},
 		{
 			description:   "test China cloud",


### PR DESCRIPTION
<!-- To surface this PR in the changelog add the label: changelog -->
<!-- If this PR is going in the changelog please make sure the title of the PR explains the feature in a user-centric way: -->
<!-- Bad: fix state bug in hooks -->
<!-- Good: Fix crash when switching from Query Builder -->

When accessing Kusto databases in Azure US Government (Fairfax), the current scope is /.default. Add the Kusto endpoint for USGov to change this to kusto.kusto.usgovcloudapi.net/.default.