### PR TITLE
docs: add signed commits requirement to CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,3 +1,10 @@
+# Contributing
+
+## Signed commits are required
+
+> [!IMPORTANT]
+> All commits must be [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) (GPG, SSH, or S/MIME) to be merged into this repository. Pull requests with unsigned commits will need to be re-committed with signatures before they can be merged.
+
 # Building and releasing
 
 ## How to build the Azure Data Explorer (ADX) data source plugin locally


### PR DESCRIPTION
## Summary

- Adds a highly visible callout at the top of `CONTRIBUTING.md` stating that signed commits (GPG, SSH, or S/MIME) are required to merge into this repository, per the recent policy change
- Uses GitHub's `[!IMPORTANT]` alert syntax so it renders as a highlighted callout, and links to GitHub's signed-commits docs.

## Checks

- `prettier --check CONTRIBUTING.md` passes.
