### PR TITLE
fix(variables): forward scoped variables to query variable execution

### DIFF
--- a/src/variables.test.ts
+++ b/src/variables.test.ts
@@ -167,11 +167,14 @@ describe('variables', () => {
     it('will migrate text query', async () => {
       const buildQuerySpy = jest.spyOn(datasource, 'buildQuery');
       const variableSupport = new VariableSupport(datasource);
-      const req = mockRequest({ targets: ['test' as unknown as KustoQuery] });
+      const scopedVars = { namespace: { text: 'prod', value: 'prod' } };
+      const req = mockRequest({ scopedVars, targets: ['test' as unknown as KustoQuery] });
       const res = await lastValueFrom(variableSupport.query(req));
 
       expect(datasource.getDefaultOrFirstDatabase).toBeCalled();
-      expect(buildQuerySpy).toBeCalledWith('test', { scopedVars: {} }, 'test_db', 'clusterUrl');
+      expect(buildQuerySpy).toHaveBeenLastCalledWith('test', { scopedVars }, 'test_db', 'clusterUrl');
+      const buildQueryOptions = buildQuerySpy.mock.calls[buildQuerySpy.mock.calls.length - 1][1];
+      expect(buildQueryOptions.scopedVars).toBe(scopedVars);
       expect(datasource.query).toBeCalled();
       expect(res.data).toEqual(mockResponse);
     });
@@ -233,6 +236,33 @@ describe('variables', () => {
       });
       const res = await lastValueFrom(variableSupport.query(req));
       expect(res.data).toEqual([toDataFrame([{ Name: 'test_column' }, { Name: 'time' }])]);
+    });
+
+    it('will use scoped variables when building a Kusto variable query', async () => {
+      const buildQuerySpy = jest.spyOn(datasource, 'buildQuery');
+      const variableSupport = new VariableSupport(datasource);
+      const scopedVars = { namespace: { text: 'prod', value: 'prod' } };
+      const query = "test_table | where namespace == '$namespace'";
+      const req = mockRequest({
+        scopedVars,
+        targets: [
+          {
+            ...defaultQuery,
+            database: 'test_db',
+            resultFormat: 'table',
+            refId: '',
+            query,
+            clusterUri: 'clusterUrl',
+          },
+        ],
+      });
+
+      const res = await lastValueFrom(variableSupport.query(req));
+
+      expect(buildQuerySpy).toHaveBeenLastCalledWith(query, { scopedVars }, 'test_db', 'clusterUrl');
+      const buildQueryOptions = buildQuerySpy.mock.calls[buildQuerySpy.mock.calls.length - 1][1];
+      expect(buildQueryOptions.scopedVars).toBe(scopedVars);
+      expect(res.data).toEqual(mockResponse);
     });
   });
 });

--- a/src/variables.ts
+++ b/src/variables.ts
@@ -27,7 +27,12 @@ export class VariableSupport extends CustomVariableSupport<AdxDataSource, KustoQ
         const databasesQuery = (queryObj as string).match(/^databases\(\)/i);
         const defaultDatabase = await this.datasource.getDefaultOrFirstDatabase();
         const defaultCluster = await this.datasource.getDefaultOrFirstCluster();
-        const baseQuery = this.datasource.buildQuery(queryObj, {}, defaultDatabase, defaultCluster);
+        const baseQuery = this.datasource.buildQuery(
+          queryObj,
+          { scopedVars: request.scopedVars },
+          defaultDatabase,
+          defaultCluster
+        );
         if (databasesQuery) {
           queryObj = { ...baseQuery, queryType: AdxQueryType.Databases };
         } else {
@@ -76,7 +81,12 @@ export class VariableSupport extends CustomVariableSupport<AdxDataSource, KustoQ
               data: columns.length ? [toDataFrame(columnNames)] : [],
             };
           default:
-            const query = this.datasource.buildQuery(queryObj.query, {}, queryObj.database, queryObj.clusterUri);
+            const query = this.datasource.buildQuery(
+              queryObj.query,
+              { scopedVars: request.scopedVars },
+              queryObj.database,
+              queryObj.clusterUri
+            );
             if (query.query === '') {
               return { data: [] };
             }


### PR DESCRIPTION
## Summary

Grafana passes section-level variables to data source query-variable execution through
`DataQueryRequest.scopedVars`. The ADX variable support discarded those values when it called
`buildQuery` for both current Kusto query targets and legacy string targets, passing an empty options
object instead.

`buildQuery` uses `options.scopedVars` when calling `templateSrv.replace`, so dashboard-level
variables could still resolve from the global template service while section-level variables
referenced by another variable in the same section remained unresolved.

The variable query paths now forward `request.scopedVars` to `buildQuery`, allowing the existing ADX
interpolation logic to resolve section-level variables.

## Environment

- **Grafana version:** Grafana 13 with section variables enabled
- **Plugin version:** 7.2.9 and current `main`

## How to reproduce

1. Run Grafana with section variables enabled.
2. Configure an Azure Data Explorer data source and create a dashboard section.
3. Add a query variable named `namespace` to the section.
4. Add a second ADX Kusto query variable in the same section whose query references it, for example:

   ```kusto
   Services
   | where Namespace == '$namespace'
   | distinct ServiceName
   ```

5. Open the second variable's query preview or refresh the dashboard.

Before this fix, `$namespace` remains unresolved because the section's scoped variables never reach
ADX template interpolation. With the fix, the selected namespace is interpolated correctly.

## Related issues and changes

- Related Grafana issue: https://github.com/grafana/grafana/issues/122553
- Analogous ClickHouse fix: https://github.com/grafana/clickhouse-datasource/pull/1840
- Follow-up ClickHouse regression fix: https://github.com/grafana/clickhouse-datasource/pull/2057

---

## Test plan

- [x] Tests for this change have been added/updated.
- [x] `npx --no-install jest src/variables.test.ts --runInBand`
- [x] `npm run typecheck`

## Other Notes

The implementation changes only the two `buildQuery` call sites in `VariableSupport.query`.

The regression coverage verifies both supported target shapes:

- Legacy string variable queries.
- Current Kusto query object targets.

Both tests use non-empty scoped variables and assert that the original `scopedVars` object is
forwarded to `buildQuery`. This is important because `buildQuery` adds an empty `scopedVars` property
when one is absent, which allowed the previous empty-variable assertions to pass without proving
that request-scoped values were preserved.
