### PR TITLE
Release 7.2.10

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # CHANGELOG
 
+## [7.2.10]
+
+- Resolve cluster OAuth scope per request from the cluster URL ([#1815](https://github.com/grafana/azure-data-explorer-datasource/pull/1815))
+- Dependency updates
+
 ## [7.2.9]
 
 - Support auto-retrieval of ADX audience ([#1793](https://github.com/grafana/azure-data-explorer-datasource/pull/1793))

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "grafana-azure-data-explorer-datasource",
-  "version": "7.2.9",
+  "version": "7.2.10",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "grafana-azure-data-explorer-datasource",
-      "version": "7.2.9",
+      "version": "7.2.10",
       "license": "Apache",
       "dependencies": {
         "@emotion/css": "11.13.5",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "grafana-azure-data-explorer-datasource",
-  "version": "7.2.9",
+  "version": "7.2.10",
   "description": "Grafana data source for Azure Data Explorer",
   "scripts": {
     "build": "webpack -c ./.config/webpack/webpack.config.ts --env production",


### PR DESCRIPTION
## Summary
- Bump version to **7.2.10** and update CHANGELOG.
- Includes per-request cluster scope resolution ([#1815](https://github.com/grafana/azure-data-explorer-datasource/pull/1815)) and dependency/CVE updates ([#1806](https://github.com/grafana/azure-data-explorer-datasource/pull/1806), [#1822](https://github.com/grafana/azure-data-explorer-datasource/pull/1822)).

## Test plan
- [x] `npm run build`
- [x] `npm run test:ci` (35 suites / 268 tests)
- [x] `mage -v`
- [ ] CI on this PR
- [ ] After merge, run the [plugin CD release process](https://enghub.grafana-ops.net/docs/default/component/grafana-plugins-platform/plugins-ci-github-actions/010-plugins-ci-github-actions/#cd_1)