### PR TITLE
ci: drop CD environment matrix so catalog publish can finish

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -24,10 +24,6 @@ permissions: {}
 
 jobs:
   cd:
-    strategy:
-      fail-fast: false
-      matrix:
-        environment: [dev, ops, prod]
     name: CD
     uses: grafana/plugin-ci-workflows/.github/workflows/cd.yml@ci-cd-workflows/v10.1.0
     permissions:
@@ -37,7 +33,8 @@ jobs:
       pull-requests: read
     with:
       branch: ${{ github.event.inputs.branch }}
-      environment: ${{ matrix.environment }}
+      # prod expands to catalog waves [dev, ops, prod] inside cd.yml
+      environment: prod
       docs-only: ${{ fromJSON(github.event.inputs.docs-only) }}
       scopes: ${{ github.event.inputs.environment == 'cloud (recommended)' && 'grafana_cloud' || github.event.inputs.environment == 'on-prem (for emergencies fix to On Prem customers)' && 'universal' }}
       run-playwright: false


### PR DESCRIPTION
## Summary
- Plugins - CD was calling `plugin-ci-workflows` `cd.yml` three times in parallel (`dev` / `ops` / `prod`). Those reusable-workflow runs share concurrency group `cd-<run_id>` with `cancel-in-progress: true`, so two legs are cancelled and the parent run ends cancelled.
- GitHub release is gated on the **prod** leg, so tags/releases never get created (see cancelled run https://github.com/grafana/azure-data-explorer-datasource/actions/runs/34368795781).
- Match sentry/athena: one `environment: prod` call. `cd.yml` already expands that to catalog waves `[dev, ops, prod]`. Cloud vs on-prem still only changes `scopes`.
  - [sentry-datasource `publish.yml`](https://github.com/grafana/sentry-datasource/blob/main/.github/workflows/publish.yml)
  - [athena-datasource `publish.yml`](https://github.com/grafana/athena-datasource/blob/main/.github/workflows/publish.yml)

## Test plan
- [ ] After merge, dispatch **Plugins - CD** from `main` with **cloud (recommended)**
- [ ] Confirm a single CD job runs (no sibling `cd-<run_id>` cancellations)
- [ ] Confirm the run concludes **success** (or a real publish error, not cancelled)
- [ ] Confirm a GitHub release/tag is created when publishing a versioned `main`